### PR TITLE
feat(add): support multiple packages in single command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,6 @@
 
 * align add and push with yalc ([#28](https://github.com/pedrosousa13/lnpm/issues/28)) ([1abccde](https://github.com/pedrosousa13/lnpm/commit/1abccde8f8ead26a13de6711cd91bdd5aeecc779))
 
-## [Unreleased]
-
-### Changed
-
-- **Don't run npm install by default** - Matches yalc behavior. Use `--install` flag to run npm install after adding/retreating. This prevents symlink overwrites and duplicate React issues.
-
-### Fixed
-
-- **Husky/git hooks failing** - Strip `prepare` and `prepublish` scripts from stored package.json (matches yalc behavior)
-- **npm ERESOLVE peer dependency errors** - Use `--legacy-peer-deps` when `--install` flag is used
-- **Retreat restoring wrong version** - No longer saves `file:.lnpm/` as original version; properly removes package from package.json when no original version exists
-- **Re-add losing original version** - Preserve existing original version from lnpm.lock when re-adding a package
 ## [1.8.1](https://github.com/pedrosousa13/lnpm/compare/v1.8.0...v1.8.1) (2026-01-19)
 
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ lnpm watch
 | Command | Description |
 |---------|-------------|
 | `lnpm publish` | Publish package to local store |
-| `lnpm add <pkg>` | Add package from store to project |
+| `lnpm add <pkg...>` | Add package(s) from store to project |
 | `lnpm remove <pkg>` | Remove linked package |
 | `lnpm push` | Push changes to all linked projects |
 | `lnpm watch` | Auto-sync on file changes |
@@ -89,8 +89,9 @@ lnpm watch
 # Publish a package
 lnpm publish
 
-# Add to a project
+# Add to a project (supports multiple packages)
 lnpm add my-package
+lnpm add pkg-a pkg-b pkg-c
 
 # Push updates after making changes
 lnpm push

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pedrosousa13/lnpm/internal/config"
@@ -17,8 +18,224 @@ import (
 	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
 
-// RunAdd executes the add command
+// RunAdd adds a single package (for backward compatibility)
 func RunAdd(packageSpec string, dev bool, pure bool, runInstall bool) error {
+	return runAddSingle(packageSpec, dev, pure, runInstall)
+}
+
+// addResult holds the result of parallel package resolution and linking
+type addResult struct {
+	spec         string
+	pkg          *db.Package
+	linkType     link.LinkType
+	origVersion  string
+	err          error
+}
+
+// RunAddMultiple adds multiple packages with parallel linking
+func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool) error {
+	if len(packageSpecs) == 1 {
+		return runAddSingle(packageSpecs[0], dev, pure, runInstall)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	pkgJSONPath := filepath.Join(cwd, "package.json")
+	if _, err := os.Stat(pkgJSONPath); err != nil {
+		return fmt.Errorf("no package.json found in current directory")
+	}
+
+	database, err := db.GetDB()
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+
+	s, err := store.New()
+	if err != nil {
+		return fmt.Errorf("failed to access store: %w", err)
+	}
+
+	linker := link.New(cwd)
+
+	// Phase 1: Resolve and link packages in parallel
+	var wg sync.WaitGroup
+	results := make(chan addResult, len(packageSpecs))
+
+	for _, spec := range packageSpecs {
+		wg.Add(1)
+		go func(pkgSpec string) {
+			defer wg.Done()
+			result := addResult{spec: pkgSpec}
+
+			name, version := parsePackageSpec(pkgSpec)
+
+			var pkg *db.Package
+			var lookupErr error
+			if version != "" {
+				pkg, lookupErr = database.GetPackageByHash(name, version)
+			} else {
+				pkg, lookupErr = database.GetPackageByName(name)
+			}
+
+			if lookupErr != nil {
+				result.err = fmt.Errorf("failed to look up package: %w", lookupErr)
+				results <- result
+				return
+			}
+			if pkg == nil {
+				result.err = fmt.Errorf("package %s not found in store", name)
+				results <- result
+				return
+			}
+
+			result.pkg = pkg
+
+			files, err := s.GetFiles(pkg.Name, pkg.ContentHash)
+			if err != nil {
+				result.err = fmt.Errorf("failed to get package files: %w", err)
+				results <- result
+				return
+			}
+
+			linkType, err := linker.Link(pkg.Name, pkg.StorePath, files)
+			if err != nil {
+				result.err = fmt.Errorf("failed to link package: %w", err)
+				results <- result
+				return
+			}
+
+			result.linkType = linkType
+			results <- result
+		}(spec)
+	}
+
+	wg.Wait()
+	close(results)
+
+	// Collect results
+	var successful []addResult
+	var errors []error
+	for r := range results {
+		if r.err != nil {
+			errors = append(errors, fmt.Errorf("%s: %w", r.spec, r.err))
+		} else {
+			successful = append(successful, r)
+		}
+	}
+
+	if len(successful) == 0 {
+		fmt.Println("\n⚠ All packages failed to add:")
+		for _, err := range errors {
+			fmt.Printf("  • %v\n", err)
+		}
+		return fmt.Errorf("all packages failed to add")
+	}
+
+	// Phase 2: Sequential file updates (gitignore, package.json, lockfile, database)
+	cfg := config.Get()
+	if cfg.ShouldManageGitignore() {
+		if added, err := gitignore.EnsureInGitignore(cwd, ".lnpm/"); err != nil {
+			fmt.Printf("  ⚠ Could not update .gitignore: %v\n", err)
+		} else if added {
+			fmt.Println("  ✓ Added .lnpm/ to .gitignore")
+		}
+	}
+
+	pm := config.DetectPackageManager(cwd)
+
+	lock, err := lockfile.Load(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to load lock file: %w", err)
+	}
+
+	// Update package.json for all successful packages
+	if !pure {
+		for i := range successful {
+			origVersion, err := updatePackageJSON(pkgJSONPath, successful[i].pkg.Name, dev)
+			if err != nil {
+				fmt.Printf("  ⚠ Failed to update package.json for %s: %v\n", successful[i].pkg.Name, err)
+				continue
+			}
+			successful[i].origVersion = origVersion
+		}
+	}
+
+	// Update lockfile and database for all successful packages
+	proj := &db.Project{
+		Path:           cwd,
+		Name:           getProjectName(cwd),
+		PackageManager: string(pm),
+	}
+	if err := database.InsertProject(proj); err != nil {
+		return fmt.Errorf("failed to register project: %w", err)
+	}
+
+	existingProj, err := database.GetProjectByPath(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to get project: %w", err)
+	}
+
+	for _, r := range successful {
+		// Check for existing original version in lockfile
+		existingOrigVersion := ""
+		if existing, ok := lock.Get(r.pkg.Name); ok && existing.OriginalVersion != "" {
+			existingOrigVersion = existing.OriginalVersion
+		}
+
+		origVersion := r.origVersion
+		if origVersion == "" && existingOrigVersion != "" {
+			origVersion = existingOrigVersion
+		}
+
+		lock.Add(r.pkg.Name, lockfile.Package{
+			Version:         r.pkg.Version,
+			Hash:            r.pkg.ContentHash,
+			Source:          r.pkg.SourcePath,
+			Linked:          time.Now(),
+			OriginalVersion: origVersion,
+		})
+
+		dbLink := &db.Link{
+			PackageID: r.pkg.ID,
+			ProjectID: existingProj.ID,
+			LinkType:  string(r.linkType),
+		}
+		if err := database.InsertLink(dbLink); err != nil {
+			fmt.Printf("  ⚠ Failed to record link for %s: %v\n", r.pkg.Name, err)
+		}
+
+		fmt.Printf("✓ Added %s@%s (%s)\n", r.pkg.Name, r.pkg.Version, r.linkType)
+	}
+
+	if err := lock.Save(cwd); err != nil {
+		return fmt.Errorf("failed to save lock file: %w", err)
+	}
+
+	if len(errors) > 0 {
+		fmt.Println("\n⚠ Some packages failed:")
+		for _, err := range errors {
+			fmt.Printf("  • %v\n", err)
+		}
+	}
+
+	// Run npm install once at the end if requested
+	if runInstall && !pure && len(successful) > 0 {
+		fmt.Println("\nRunning npm install...")
+		if err := hooks.RunPostAdd(cwd, true); err != nil {
+			fmt.Printf("  ⚠ npm install failed: %v\n", err)
+		}
+	} else if !pure && len(successful) > 0 {
+		fmt.Println("\n  💡 Run 'npm install' if you need to resolve peer dependencies")
+	}
+
+	return nil
+}
+
+// runAddSingle adds a single package (internal implementation)
+func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool) error {
 	// Parse package spec (name[@version])
 	name, version := parsePackageSpec(packageSpec)
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -36,12 +36,12 @@ Examples:
 
 // addCmd adds a package from the store to the current project
 var addCmd = &cobra.Command{
-	Use:   "add <package>",
-	Short: "Add a package from store to current project",
-	Long: `Add a package from the local store to the current project.
+	Use:   "add <package> [packages...]",
+	Short: "Add packages from store to current project",
+	Long: `Add packages from the local store to the current project.
 
 This command:
-  1. Finds the package in the store
+  1. Finds the packages in the store
   2. Creates hard links in .lnpm/{package}/
   3. Creates a symlink in node_modules/{package}
   4. Updates package.json with file: dependency
@@ -49,17 +49,17 @@ This command:
 
 Examples:
   lnpm add my-package            # Add latest version
+  lnpm add pkg1 pkg2 pkg3        # Add multiple packages
   lnpm add my-package@1.0.0      # Add specific version
   lnpm add my-package --dev      # Add as devDependency
   lnpm add my-package --install  # Add and run npm install
   lnpm add my-package --pure     # Don't modify package.json`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		pkg := args[0]
 		dev, _ := cmd.Flags().GetBool("dev")
 		pure, _ := cmd.Flags().GetBool("pure")
 		install, _ := cmd.Flags().GetBool("install")
-		return RunAdd(pkg, dev, pure, install)
+		return RunAddMultiple(args, dev, pure, install)
 	},
 }
 

--- a/tests/add_test.go
+++ b/tests/add_test.go
@@ -397,6 +397,77 @@ func TestAddWithNPMWorkspace(t *testing.T) {
 	env.AssertPackageJSON(packageADir, "workspace-pkg", "file:.lnpm/workspace-pkg")
 }
 
+// TestAddMultiplePackages tests adding multiple packages in one command
+func TestAddMultiplePackages(t *testing.T) {
+	env := setupTest(t)
+
+	// Create and publish multiple packages
+	packages := []string{"multi-pkg-a", "multi-pkg-b", "multi-pkg-c"}
+	for _, name := range packages {
+		pkgDir := env.CreateTestPackage(name, "1.0.0", map[string]string{
+			"index.js": "module.exports = '" + name + "';",
+		})
+		if err := os.Chdir(pkgDir); err != nil {
+			t.Fatalf("Failed to chdir: %v", err)
+		}
+		if err := cli.RunPublish(false, "", false, false, false); err != nil {
+			t.Fatalf("Failed to publish %s: %v", name, err)
+		}
+	}
+
+	// Create a project
+	projectDir := env.CreateTestPackage("test-project", "1.0.0", nil)
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("Failed to chdir: %v", err)
+	}
+
+	// Add all packages at once
+	if err := cli.RunAddMultiple(packages, false, false, false); err != nil {
+		t.Fatalf("Failed to add multiple packages: %v", err)
+	}
+
+	// Verify all packages were added
+	for _, name := range packages {
+		env.AssertSymlinkExists(projectDir, name)
+		env.AssertPackageJSON(projectDir, name, "file:.lnpm/"+name)
+		env.AssertDatabaseLink(name, projectDir)
+	}
+}
+
+// TestAddMultipleWithPartialFailure tests adding multiple packages where some fail
+func TestAddMultipleWithPartialFailure(t *testing.T) {
+	env := setupTest(t)
+
+	// Create and publish only one package
+	pkgDir := env.CreateTestPackage("exists-pkg", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'exists';",
+	})
+	if err := os.Chdir(pkgDir); err != nil {
+		t.Fatalf("Failed to chdir: %v", err)
+	}
+	if err := cli.RunPublish(false, "", false, false, false); err != nil {
+		t.Fatalf("Failed to publish: %v", err)
+	}
+
+	// Create a project
+	projectDir := env.CreateTestPackage("test-project", "1.0.0", nil)
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("Failed to chdir: %v", err)
+	}
+
+	// Add mix of existing and non-existing packages
+	err := cli.RunAddMultiple([]string{"exists-pkg", "nonexistent-pkg"}, false, false, false)
+
+	// Should not return error (partial success)
+	if err != nil {
+		t.Fatalf("Expected partial success, got error: %v", err)
+	}
+
+	// Verify the existing package was added
+	env.AssertSymlinkExists(projectDir, "exists-pkg")
+	env.AssertPackageJSON(projectDir, "exists-pkg", "file:.lnpm/exists-pkg")
+}
+
 // TestAddLockfileContents tests that lockfile contains correct information
 func TestAddLockfileContents(t *testing.T) {
 	env := setupTest(t)


### PR DESCRIPTION
## Summary
- `lnpm add pkg1 pkg2 pkg3` now works
- Links packages in parallel for speed
- Serializes file updates (package.json, lockfile, db) to avoid race conditions
- Single npm install at end if `--install` flag used

## Test plan
- [x] `TestAddMultiplePackages` - add 3 packages at once
- [x] `TestAddMultipleWithPartialFailure` - partial success when some packages don't exist
- [x] All existing tests pass