### PR TITLE
feat: add `lnpm check` guard and `add --link` protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ lnpm push
 | `lnpm push` | Push changes to all linked projects |
 | `lnpm status` | Show current project's links |
 | `lnpm list` | List this project's linked packages (`--store` lists the store, `--projects` lists consumers) |
+| `lnpm check` | Fail if package.json still has lnpm references (pre-publish guard) |
 | `lnpm doctor` | Diagnose issues |
 | `lnpm gc` | Garbage collect unused packages (`--dry-run`, `--older-than 30d`, `--fix-links`) |
 | `lnpm retreat` | Remove all lnpm changes |
@@ -98,6 +99,7 @@ lnpm publish
 # Add to a project (supports multiple packages)
 lnpm add my-package
 lnpm add pkg-a pkg-b pkg-c
+lnpm add my-package --link   # Use link: protocol instead of file:
 
 # Push updates after making changes
 lnpm push
@@ -130,8 +132,16 @@ lnpm push
 # Remove all lnpm links and restore original dependencies
 lnpm retreat --force
 npm install  # Restore original packages
+
+# Guard: fails (non-zero) if any lnpm reference is still in package.json
+lnpm check
+
 npm publish
 ```
+
+`lnpm check` scans `package.json` for leftover `file:.lnpm/` or `link:.lnpm/`
+references and exits non-zero if any remain — drop it in a `prepublishOnly`
+script or CI step to avoid accidentally publishing local links to npm.
 
 ### Shell Completions
 

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -20,7 +20,7 @@ import (
 
 // RunAdd adds a single package (for backward compatibility)
 func RunAdd(packageSpec string, dev bool, pure bool, runInstall bool) error {
-	return runAddSingle(packageSpec, dev, pure, runInstall)
+	return runAddSingle(packageSpec, dev, pure, runInstall, false)
 }
 
 // addResult holds the result of parallel package resolution and linking
@@ -33,9 +33,9 @@ type addResult struct {
 }
 
 // RunAddMultiple adds multiple packages with parallel linking
-func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool) error {
+func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool, useLink bool) error {
 	if len(packageSpecs) == 1 {
-		return runAddSingle(packageSpecs[0], dev, pure, runInstall)
+		return runAddSingle(packageSpecs[0], dev, pure, runInstall, useLink)
 	}
 
 	cwd, err := os.Getwd()
@@ -154,7 +154,7 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool)
 	// Update package.json for all successful packages
 	if !pure {
 		for i := range successful {
-			origVersion, err := updatePackageJSON(pkgJSONPath, successful[i].pkg.Name, dev)
+			origVersion, err := updatePackageJSON(pkgJSONPath, successful[i].pkg.Name, dev, useLink)
 			if err != nil {
 				fmt.Printf("  %s Failed to update package.json for %s: %v\n", iconWarn(), successful[i].pkg.Name, err)
 				continue
@@ -240,7 +240,7 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool)
 }
 
 // runAddSingle adds a single package (internal implementation)
-func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool) error {
+func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useLink bool) error {
 	// Parse package spec (name[@version])
 	name, version := parsePackageSpec(packageSpec)
 
@@ -324,7 +324,7 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool) erro
 	// Update package.json (unless --pure)
 	var originalVersion string
 	if !pure {
-		originalVersion, err = updatePackageJSON(pkgJSONPath, pkg.Name, dev)
+		originalVersion, err = updatePackageJSON(pkgJSONPath, pkg.Name, dev, useLink)
 		if err != nil {
 			return fmt.Errorf("failed to update package.json: %w", err)
 		}
@@ -411,8 +411,10 @@ func parsePackageSpec(spec string) (name, version string) {
 	return spec, ""
 }
 
-// updatePackageJSON updates package.json with the lnpm dependency
-func updatePackageJSON(path string, packageName string, dev bool) (originalVersion string, err error) {
+// updatePackageJSON updates package.json with the lnpm dependency. When link is
+// true the dependency uses the "link:" protocol (symlink-style resolution,
+// which helps pnpm/yarn dedupe peer deps) instead of the default "file:".
+func updatePackageJSON(path string, packageName string, dev bool, useLink bool) (originalVersion string, err error) {
 	// Read existing package.json
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -469,8 +471,12 @@ func updatePackageJSON(path string, packageName string, dev bool) (originalVersi
 		}
 	}
 
-	// Set the lnpm file: reference
-	deps[packageName] = fmt.Sprintf("file:.lnpm/%s", packageName)
+	// Set the lnpm reference (file: by default, link: when requested)
+	protocol := "file"
+	if useLink {
+		protocol = "link"
+	}
+	deps[packageName] = fmt.Sprintf("%s:.lnpm/%s", protocol, packageName)
 
 	// Write back
 	output, err := json.MarshalIndent(pkgJSON, "", "  ")

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// RunCheck scans the current project's package.json for leftover lnpm
+// references (file:.lnpm/ or link:.lnpm/) and returns a non-nil error if any
+// are found. It is meant as a pre-publish guard: run `lnpm retreat` to clear
+// the references before publishing to npm.
+func RunCheck() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	pkgJSONPath := filepath.Join(cwd, "package.json")
+	data, err := os.ReadFile(pkgJSONPath)
+	if err != nil {
+		return fmt.Errorf("no package.json found in current directory")
+	}
+
+	var pkgJSON map[string]interface{}
+	if err := json.Unmarshal(data, &pkgJSON); err != nil {
+		return fmt.Errorf("failed to parse package.json: %w", err)
+	}
+
+	// Collect "<field>: <pkg> => <ref>" for every lnpm reference found across
+	// the standard dependency maps.
+	var found []string
+	for _, field := range []string{"dependencies", "devDependencies", "optionalDependencies", "peerDependencies"} {
+		deps, ok := pkgJSON[field].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for name, v := range deps {
+			ref, ok := v.(string)
+			if ok && isLnpmReference(ref) {
+				found = append(found, fmt.Sprintf("  %s.%s -> %s", field, name, ref))
+			}
+		}
+	}
+
+	if len(found) == 0 {
+		fmt.Printf("%s No lnpm references in package.json\n", iconOK())
+		return nil
+	}
+
+	sort.Strings(found)
+	fmt.Printf("%s Found %d lnpm reference(s) in package.json:\n", iconFail(), len(found))
+	for _, line := range found {
+		fmt.Println(line)
+	}
+	fmt.Printf("\n  %s Run 'lnpm retreat --force' to restore original dependencies before publishing\n", iconTip())
+	return fmt.Errorf("%d lnpm reference(s) found in package.json", len(found))
+}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -51,13 +51,15 @@ Examples:
   lnpm add my-package@1.0.0      # Add specific version
   lnpm add my-package --dev      # Add as devDependency
   lnpm add my-package --install  # Add and run npm install
-  lnpm add my-package --pure     # Don't modify package.json`,
+  lnpm add my-package --pure     # Don't modify package.json
+  lnpm add my-package --link     # Use link: protocol instead of file:`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dev, _ := cmd.Flags().GetBool("dev")
 		pure, _ := cmd.Flags().GetBool("pure")
 		install, _ := cmd.Flags().GetBool("install")
-		return RunAddMultiple(args, dev, pure, install)
+		link, _ := cmd.Flags().GetBool("link")
+		return RunAddMultiple(args, dev, pure, install, link)
 	},
 }
 
@@ -206,9 +208,29 @@ Examples:
 	},
 }
 
+// checkCmd scans package.json for leftover lnpm references
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Check package.json for leftover lnpm references",
+	Long: `Scan the current project's package.json for lnpm references
+(file:.lnpm/ or link:.lnpm/) left behind by 'lnpm add'.
+
+Exits non-zero if any are found, so it can be used as a pre-publish guard
+in scripts or CI before running 'npm publish'.
+
+Examples:
+  lnpm check   # Fails if any lnpm reference remains in package.json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return RunCheck()
+	},
+}
+
 func init() {
 	// Register retreat command
 	rootCmd.AddCommand(retreatCmd)
+
+	// Register check command
+	rootCmd.AddCommand(checkCmd)
 
 	// publish flags
 	publishCmd.Flags().Bool("push", false, "Push to all linked projects after publish")
@@ -224,6 +246,7 @@ func init() {
 	addCmd.Flags().Bool("dev", false, "Add as devDependency")
 	addCmd.Flags().Bool("pure", false, "Don't modify package.json")
 	addCmd.Flags().Bool("install", false, "Run npm install after adding (default: no)")
+	addCmd.Flags().Bool("link", false, "Use link: protocol in package.json instead of file:")
 
 	// remove flags
 	removeCmd.Flags().Bool("all", false, "Remove all linked packages")

--- a/tests/add_test.go
+++ b/tests/add_test.go
@@ -218,7 +218,7 @@ func TestAddMultiplePackages(t *testing.T) {
 	}
 
 	projectDir := env.newProject("test-project")
-	if err := cli.RunAddMultiple(packages, false, false, false); err != nil {
+	if err := cli.RunAddMultiple(packages, false, false, false, false); err != nil {
 		t.Fatalf("Failed to add multiple packages: %v", err)
 	}
 
@@ -237,7 +237,7 @@ func TestAddMultipleWithPartialFailure(t *testing.T) {
 	env.simplePkg("exists-pkg")
 	projectDir := env.newProject("test-project")
 
-	err := cli.RunAddMultiple([]string{"exists-pkg", "nonexistent-pkg"}, false, false, false)
+	err := cli.RunAddMultiple([]string{"exists-pkg", "nonexistent-pkg"}, false, false, false, false)
 	if err == nil {
 		t.Fatal("Expected an error when one of the packages fails to add")
 	}

--- a/tests/check_test.go
+++ b/tests/check_test.go
@@ -1,0 +1,106 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+)
+
+// TestCheckCleanProject verifies check passes (nil error) when no lnpm
+// references are present in package.json.
+func TestCheckCleanProject(t *testing.T) {
+	env := setupTest(t)
+
+	projectDir := env.CreateTestPackage("clean-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":    "clean-project",
+		"version": "1.0.0",
+		"dependencies": map[string]interface{}{
+			"left-pad": "^1.0.0",
+		},
+		"devDependencies": map[string]interface{}{
+			"typescript": "^5.0.0",
+		},
+	})
+	env.chdir(projectDir)
+
+	if err := cli.RunCheck(); err != nil {
+		t.Fatalf("expected check to pass on clean project, got: %v", err)
+	}
+}
+
+// TestCheckDetectsFileRef verifies check fails when a file:.lnpm/ reference is
+// present in dependencies.
+func TestCheckDetectsFileRef(t *testing.T) {
+	env := setupTest(t)
+
+	projectDir := env.CreateTestPackage("dirty-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":    "dirty-project",
+		"version": "1.0.0",
+		"dependencies": map[string]interface{}{
+			"my-lib": "file:.lnpm/my-lib",
+		},
+	})
+	env.chdir(projectDir)
+
+	if err := cli.RunCheck(); err == nil {
+		t.Fatal("expected check to fail when a file:.lnpm/ reference is present, got nil")
+	}
+}
+
+// TestCheckDetectsLinkRef verifies check fails when a link:.lnpm/ reference is
+// present in devDependencies.
+func TestCheckDetectsLinkRef(t *testing.T) {
+	env := setupTest(t)
+
+	projectDir := env.CreateTestPackage("dirty-dev-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":    "dirty-dev-project",
+		"version": "1.0.0",
+		"devDependencies": map[string]interface{}{
+			"my-lib": "link:.lnpm/my-lib",
+		},
+	})
+	env.chdir(projectDir)
+
+	if err := cli.RunCheck(); err == nil {
+		t.Fatal("expected check to fail when a link:.lnpm/ reference is present, got nil")
+	}
+}
+
+// TestCheckNoPackageJSON verifies check errors when there is no package.json.
+func TestCheckNoPackageJSON(t *testing.T) {
+	env := setupTest(t)
+
+	dir := filepath.Join(env.TempDir, "no-pkg")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	env.chdir(dir)
+
+	if err := cli.RunCheck(); err == nil {
+		t.Fatal("expected check to error when no package.json exists, got nil")
+	}
+}
+
+// TestCheckCatchesRealAddLink verifies that check detects a reference produced
+// by `add --link`, closing the loop between the two features.
+func TestCheckCatchesRealAddLink(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("link-lib")
+	projectDir := env.newProject("consumer")
+
+	// add --link writes a link:.lnpm/ reference.
+	if err := cli.RunAddMultiple([]string{"link-lib"}, false, false, false, true); err != nil {
+		t.Fatalf("add --link failed: %v", err)
+	}
+
+	env.chdir(projectDir)
+	if err := cli.RunCheck(); err == nil {
+		t.Fatal("expected check to fail after add --link, got nil")
+	}
+}

--- a/tests/link_protocol_test.go
+++ b/tests/link_protocol_test.go
@@ -1,0 +1,41 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+)
+
+// TestAddLinkProtocol verifies that `add --link` writes a link:.lnpm/ reference
+// into package.json instead of the default file:.lnpm/ reference.
+func TestAddLinkProtocol(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("proto-lib")
+	projectDir := env.newProject("proto-project")
+
+	// link=true (last arg) selects the link: protocol.
+	if err := cli.RunAddMultiple([]string{"proto-lib"}, false, false, false, true); err != nil {
+		t.Fatalf("add --link failed: %v", err)
+	}
+
+	env.AssertPackageJSON(projectDir, "proto-lib", "link:.lnpm/proto-lib")
+	// Linking side effects must still happen.
+	env.AssertSymlinkExists(projectDir, "proto-lib")
+	env.AssertFilesLinked(projectDir, "proto-lib")
+}
+
+// TestAddDefaultProtocolUnchanged verifies that without --link the default
+// file:.lnpm/ reference is still written.
+func TestAddDefaultProtocolUnchanged(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("default-lib")
+	projectDir := env.newProject("default-project")
+
+	if err := cli.RunAddMultiple([]string{"default-lib"}, false, false, false, false); err != nil {
+		t.Fatalf("add failed: %v", err)
+	}
+
+	env.AssertPackageJSON(projectDir, "default-lib", "file:.lnpm/default-lib")
+}


### PR DESCRIPTION
## Summary

Two quick-win features closing gaps vs yalc, both leveraging code already on `main`.

### `lnpm check` — pre-publish guard
New command that scans the current project's `package.json` (`dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`) for leftover lnpm references (`file:.lnpm/` or `link:.lnpm/`) and exits non-zero if any are found.

Stops the #1 footgun this tool creates: accidentally publishing local links to npm. Drop it in a `prepublishOnly` script or CI step. `retreat` is the fix, `check` is the seatbelt.

### `lnpm add --link` — `link:` protocol
New flag that writes a `link:.lnpm/<pkg>` reference instead of the default `file:.lnpm/<pkg>`. The `link:` protocol uses symlink-style resolution, which helps pnpm/yarn dedupe peer dependencies (addresses the duplicate-React class of issues already noted in the README troubleshooting section).

Threaded via `useLink` through `RunAddMultiple → runAddSingle → updatePackageJSON`. The `RunAdd` back-compat wrapper is unchanged (defaults `link=false`), so existing callers don't churn.

## Test plan
- 7 new tests (5 `check`, 2 `--link`), written test-first
- Full suite `go test ./...` passes, no regressions
- Cross-compiles linux/darwin/windows
- Manual CLI smoke: `add --link` writes `link:`, `check` exits 1 and lists offenders, post-`retreat` `check` exits 0

## Files
- new: `internal/cli/check.go`, `tests/check_test.go`, `tests/link_protocol_test.go`
- edit: `internal/cli/add.go`, `internal/cli/commands.go`, `tests/add_test.go`, `README.md`