### PR TITLE
fix(config): support editor commands with args

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -3,12 +3,12 @@ package cli
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
 
 	"github.com/pedrosousa13/lnpm/internal/config"
+	"github.com/pedrosousa13/lnpm/internal/shellcmd"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -170,7 +170,7 @@ func editConfig() error {
 
 	fmt.Printf("Opening %s with %s\n", configPath, editor)
 
-	cmd := exec.Command(editor, configPath)
+	cmd := shellcmd.Command(editor + " " + shellcmd.QuoteArg(configPath))
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestEditConfigSupportsEditorWithArguments(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command quoting differs on Windows")
+	}
+
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, "config dir's", "config.yaml")
+	argsPath := filepath.Join(tmp, "editor-args.txt")
+	editorPath := filepath.Join(tmp, "fake-editor")
+
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$LNPM_TEST_EDITOR_ARGS\"\n"
+	if err := os.WriteFile(editorPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake editor: %v", err)
+	}
+
+	t.Setenv("EDITOR", editorPath+" --wait")
+	t.Setenv("VISUAL", "")
+	t.Setenv("LNPM_CONFIG", configPath)
+	t.Setenv("LNPM_TEST_EDITOR_ARGS", argsPath)
+
+	if err := editConfig(); err != nil {
+		t.Fatalf("editConfig() error = %v", err)
+	}
+
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read editor args: %v", err)
+	}
+
+	args := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(args) != 2 {
+		t.Fatalf("editor args = %#v, want --wait and config path", args)
+	}
+	if args[0] != "--wait" {
+		t.Fatalf("first editor arg = %q, want --wait", args[0])
+	}
+	if args[1] != configPath {
+		t.Fatalf("config path arg = %q, want %q", args[1], configPath)
+	}
+}

--- a/internal/shellcmd/shellcmd.go
+++ b/internal/shellcmd/shellcmd.go
@@ -3,6 +3,7 @@ package shellcmd
 import (
 	"os/exec"
 	"runtime"
+	"strings"
 )
 
 // Command returns an *exec.Cmd that runs cmdStr in the platform shell.
@@ -11,4 +12,12 @@ func Command(cmdStr string) *exec.Cmd {
 		return exec.Command("cmd", "/C", cmdStr)
 	}
 	return exec.Command("sh", "-c", cmdStr)
+}
+
+// QuoteArg quotes a single argument for the platform shell used by Command.
+func QuoteArg(arg string) string {
+	if runtime.GOOS == "windows" {
+		return `"` + strings.ReplaceAll(arg, `"`, `\"`) + `"`
+	}
+	return "'" + strings.ReplaceAll(arg, "'", "'\\''") + "'"
 }


### PR DESCRIPTION
## Summary

- Run `config --edit` editor values through the existing shell command helper.
- Quote the config path before appending it to the editor command.
- Add a regression test for an editor command with an argument and a config path containing spaces.

## Why

Fixes #168. `exec.Command(editor, configPath)` treats values like `code -w` as a single executable name, so `lnpm config --edit` fails for common `$EDITOR` settings.

## Validation

- `go test ./internal/cli -run TestEditConfigSupportsEditorWithArguments -count=1` — passed
- `go test ./internal/cli ./internal/shellcmd ./internal/config -count=1` — passed
- `go test -race ./internal/cli ./internal/shellcmd ./internal/config -count=1` — passed
- `go vet ./internal/cli ./internal/shellcmd ./internal/config` — passed
- `go test ./cmd/lnpm -count=1` — passed
- `go test ./internal/...` — existing permission tests fail in this root container outside the touched packages
