### PR TITLE
fix: detect bun.lock text lockfile and honor list package argument

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -131,6 +131,10 @@ func RunList(showStore bool, packageName string, showProjects bool) error {
 		return nil
 	}
 
+	if packageName != "" && !showProjects {
+		return fmt.Errorf("use --projects to list which projects use %q", packageName)
+	}
+
 	if packageName != "" && showProjects {
 		// List projects using a specific package
 		pkg, err := database.GetPackageByName(packageName)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,7 +186,8 @@ func DetectPackageManager(projectPath string) PackageManager {
 		file    string
 		manager PackageManager
 	}{
-		{"bun.lockb", Bun},
+		{"bun.lockb", Bun}, // Bun < 1.2 binary lockfile
+		{"bun.lock", Bun},  // Bun 1.2+ text lockfile
 		{"pnpm-lock.yaml", PNPM},
 		{"yarn.lock", Yarn},
 		{"package-lock.json", NPM},


### PR DESCRIPTION
## What this fixes
Closes #166
Closes #167

## Changes

### 1. Detect Bun 1.2+ text lockfile (config.go)
Bun 1.2 switched its default lockfile from the binary bun.lockb to a plain-text bun.lock. DetectPackageManager only checked for bun.lockb, so any Bun 1.2+ project with only bun.lock fell through and was misidentified as NPM.
Fix: added bun.lock as a second Bun entry in the lockFiles slice, checked right after bun.lockb.

### 2. Honor packageName argument in lnpm list (status.go)
lnpm list <package> silently ignored the package name when --projects was not passed and listed all packages instead. No error, no warning -- just wrong output.
Fix: added an early return with a clear error message directing the user to pass --projects when a package name is given without it.

## How to test
- Create a project with only bun.lock (no bun.lockb). Run lnpm add -- package manager should be detected as Bun.
- Run lnpm list react without --projects. Expect: error message suggesting --projects flag.