### PR TITLE
chore: adopt Factory conventions

### DIFF
--- a/.factory/config.json
+++ b/.factory/config.json
@@ -1,0 +1,11 @@
+{
+  "stampVersion": "2.0.0",
+  "tracker": {
+    "kind": "github",
+    "repo": "pedrosousa13/lnpm"
+  },
+  "merge": {
+    "policy": "squash"
+  },
+  "attackSurface": true
+}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ lnpm.lock
 
 # Node
 node_modules/
+
+# Factory
+.scratch/
+.factory/run.lock
+.factory/journal.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in the repo itself — GitHub issues on pedrosousa13/lnpm, via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical label names, as repo labels on pedrosousa13/lnpm — plus `in-progress` and `P0`–`P3`, labels that stand in for a missing field. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,238 @@
+# Issue tracker: GitHub
+
+<!-- factory:tracker kind=github -->
+
+Issues and PRDs for this repo live as GitHub issues on **pedrosousa13/lnpm**.
+
+Use the `gh` CLI for all operations. Pass `-R pedrosousa13/lnpm` explicitly on every
+call rather than relying on the current directory's remote — a session that
+runs from a worktree, a subdirectory, or another clone stays correct.
+
+## Conventions
+
+- **Create an issue**: `gh issue create -R pedrosousa13/lnpm --title "..." --body
+  "..."`. Title in imperative mood; use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <n> -R pedrosousa13/lnpm --json
+  title,body,labels,milestone,state,stateReason,comments` — `comments` is a
+  `--json` field, so one call returns the body and the discussion together.
+- **List issues**: `gh issue list -R pedrosousa13/lnpm --state open --limit 500 --json
+  number,title,labels,milestone,createdAt`, plus `--label` / `--milestone`
+  filters as needed. `--limit` defaults to 30; pass it on every listing.
+- **Comment**: `gh issue comment <n> -R pedrosousa13/lnpm --body "..."`.
+- **Apply / remove labels**: `gh issue edit <n> -R pedrosousa13/lnpm --add-label
+  "..."` / `--remove-label "..."`.
+- **Close**: `gh issue close <n> -R pedrosousa13/lnpm --reason completed` (resolved)
+  or `--reason "not planned"` (wontfix).
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue on pedrosousa13/lnpm.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <n> -R pedrosousa13/lnpm --json
+title,body,labels,milestone,state,stateReason,comments`.
+
+## Factory loop operations
+
+GitHub's answer to each row of the tracker contract in `PROTOCOL.md`, the
+Factory plugin's own protocol document — a session with the Factory
+installed can find it, and one without it has no use for this section — one
+bullet per row. A `/factory` Loop Session needs every one of them.
+
+- **Reachability**: `gh auth status` resolves the `gh` CLI and confirms it
+  is authenticated; `gh repo view pedrosousa13/lnpm --json name` confirms the
+  **pedrosousa13/lnpm** repo exists and is visible to this account.
+- **Queue listing**: `gh issue list -R pedrosousa13/lnpm --state open --label
+  ready-for-agent --milestone <n-or-title> --limit 500 --json
+  number,title,labels,milestone,createdAt`. `--milestone` accepts either a
+  milestone number or its title; drop the flag entirely for an unscoped
+  run. `--limit` is not optional: `gh issue list` fetches 30 by default, so
+  a Queue longer than that loses everything past the cap with no error, and
+  because the order below is applied to whatever came back, the issue that
+  should have been picked can simply be absent. Unstarted means the issue
+  does **not** carry `in-progress` — GitHub has no started state, so the
+  label stands in for one (see "Where a label is weaker than a field"
+  below). Treat the result as a set of candidates to confirm, not as fact:
+  the listing lags label writes, and each candidate is re-checked
+  individually before it is picked.
+- **Queue order**: the `P0`–`P3` labels, highest first — **`P0` (Urgent) >
+  `P1` (High) > `P2` (Medium) > `P3` (Low) > no priority label** — ties
+  broken by the oldest `createdAt`. Both the labels and `createdAt` come
+  back on the same listing call, so ordering costs no extra call.
+- **State: started**: `gh issue edit <n> -R pedrosousa13/lnpm --add-label
+  in-progress --add-assignee @me` — one call, which is what makes pickup
+  atomic. GitHub issues have only `OPEN` and `CLOSED`, so `in-progress` is
+  the started state.
+- **State: completed / canceled**: `gh issue close <n> -R pedrosousa13/lnpm --reason
+  completed` for landed work, which reads back as `state=CLOSED`,
+  `stateReason=COMPLETED`. Wontfix is two calls, because `gh issue close`
+  has no label flag: `gh issue edit <n> -R pedrosousa13/lnpm --add-label wontfix`,
+  then `gh issue close <n> -R pedrosousa13/lnpm --reason "not planned"`, which reads
+  back as `state=CLOSED`, `stateReason=NOT_PLANNED`. The reason is what
+  distinguishes the two — a closed issue with no reason is
+  indistinguishable from either.
+- **Park**: `gh issue edit <n> -R pedrosousa13/lnpm --remove-label ready-for-agent
+  --remove-label in-progress --add-label needs-info`. The issue stays
+  **open**: Park returns work to an unstarted state, it does not close it.
+  Removing `in-progress` is the unstarted half of the Park and is not
+  optional — an issue left carrying it never re-enters the Queue even once
+  it is re-labeled `ready-for-agent`.
+- **Blocking**: GitHub's native **sub-issues**. Link one with `gh issue
+  edit <parent> -R pedrosousa13/lnpm --add-sub-issue <child>`; read them back with
+  `gh issue view <n> -R pedrosousa13/lnpm --json subIssues,subIssuesSummary`:
+
+  ```json
+  {"subIssues":{"nodes":[{"number":2,"state":"OPEN","title":"...",
+                          "url":"..."}],
+                "totalCount":1},
+   "subIssuesSummary":{"completed":0,"percentCompleted":0,"total":1}}
+  ```
+
+  **Direction matters.** A sub-issue is a *child* of its parent, and the
+  child **blocks** the parent: an issue is blocked while any of its
+  sub-issues is still `OPEN`. Equivalently, `subIssuesSummary.completed <
+  subIssuesSummary.total` means blocked. Issues filed from a plan also
+  carry a `Blocked by #N` line in the body, the form `/to-tickets` writes;
+  where that line is present, an open issue it names blocks this one too.
+  `gh issue list` returns neither, so each candidate needs its own `gh
+  issue view` — check them one at a time, in Queue order, and stop at the
+  first unblocked one.
+- **Milestone**: a GitHub **milestone** on the issue, not a label. Create
+  one with `gh api repos/pedrosousa13/lnpm/milestones -f title=... -f
+  description=...`; list a repo's milestones with `gh api --paginate
+  "repos/pedrosousa13/lnpm/milestones?state=all&per_page=100"`, which returns them
+  in GitHub's own order, stable between runs. Both halves of that query
+  are load-bearing: the endpoint returns only open milestones by default
+  and pages at 30, and the milestone menu is supposed to show *every*
+  milestone in the Project — a stable menu shape matters more than hiding
+  the closed or the empty ones. Set one with `gh issue create --milestone
+  <n-or-title>` at creation, or `gh issue edit <n> -R pedrosousa13/lnpm --milestone
+  <n-or-title>` afterwards. Read a milestone's completion with `gh api
+  repos/pedrosousa13/lnpm/milestones/<n>` and its `open_issues` / `closed_issues`
+  counts — GitHub reports no percentage, so compute one from the pair.
+- **Milestone issue counts**: `gh issue list -R pedrosousa13/lnpm --state all
+  --milestone <n> --limit 500 --json number,labels,state,stateReason`,
+  bucketed by state: **done** is `state=CLOSED` with
+  `stateReason=COMPLETED`; **canceled** is `state=CLOSED` with
+  `stateReason=NOT_PLANNED`; **started** is `state=OPEN` carrying
+  `in-progress`; among the rest (`state=OPEN`, no `in-progress`), a
+  `needs-info` label makes the issue **parked**, its absence makes it
+  **unstarted**. `--limit` is not optional here either: leave it off and
+  the default of 30 pins every larger milestone at exactly 30, and the
+  empty-Queue report states a wrong number without any sign that it did.
+  This is deliberately not a re-count of the Queue, which sees only
+  `ready-for-agent`.
+- **Open issues**: `gh issue list -R pedrosousa13/lnpm --state open --milestone
+  <n-or-title> --limit 500 --json
+  number,title,labels,milestone,createdAt,assignees,subIssuesSummary`.
+  Drop `--milestone` entirely for an unscoped call. Every open issue,
+  unfiltered by label, unlike Queue listing above. Full ticket facts per
+  issue: `state` derived as under **Milestone issue counts** above,
+  `blockedBy` from the same sub-issue and body check as **Blocking**
+  above, `claimedBy` from `assignees`.
+- **Read an issue**: `gh issue view <n> -R pedrosousa13/lnpm --json
+  title,body,labels,milestone,state,stateReason,comments` — one call.
+  `comments` is a valid `--json` field and returns each comment's author,
+  body and timestamp, so the body and the whole discussion come back
+  together. `gh issue view <n> -R pedrosousa13/lnpm --comments` renders the same
+  discussion for a human to read, but a session working from the issue
+  needs only the `--json` call.
+- **Comment**: `gh issue comment <n> -R pedrosousa13/lnpm --body "..."`. Body as
+  Markdown; use a heredoc so newlines stay literal.
+- **Branch name**: GitHub supplies none, so it is a convention this repo
+  derives: `<user>/issue-<number>-<slug>`, where `<user>` is the
+  maintainer's GitHub login and `<slug>` is the issue title lowercased,
+  non-alphanumerics collapsed to single hyphens, trimmed to a few words —
+  e.g. `pedrosousa13/issue-42-add-the-github-adapter`. Nothing stores it,
+  so every session that touches the issue must derive it the same way from
+  the same title, and a session resuming an issue looks for that branch
+  rather than inventing a new one.
+- **State verification**: `gh issue view <n> -R pedrosousa13/lnpm --json
+  state,stateReason,labels,milestone` returns the issue's current state.
+  Fetch it fresh when verifying a Pause note's claim — never compare
+  against a value read earlier in the session.
+
+## Wayfinding operations
+
+GitHub's answer to what the `/wayfinder` skill (`~/.claude/skills/wayfinder`)
+needs from a tracker. Wayfinder maps and their tickets are planning
+artifacts, not work items: they carry `wayfinder:*` labels in place of the
+triage axes, never `ready-for-agent` and never `in-progress`, so they can
+never enter a Loop Session's Queue ("Wayfinder maps" in `PROTOCOL.md`, the
+Factory plugin's own protocol document — not a file in this repo;
+"Wayfinder labels" in `docs/agents/triage-labels.md`).
+
+- **The map**: an ordinary issue on **pedrosousa13/lnpm** labeled `wayfinder:map`.
+  Find a Project's maps with `gh issue list -R pedrosousa13/lnpm --state open
+  --label wayfinder:map --limit 500 --json number,title`.
+- **Labels**: `wayfinder:map`, `wayfinder:research`, `wayfinder:prototype`,
+  `wayfinder:grilling`, `wayfinder:task` — repo labels on **pedrosousa13/lnpm**,
+  created lazily by the first charting session: `gh label list -R pedrosousa13/lnpm`
+  first, then `gh label create <label> -R pedrosousa13/lnpm` only for the names that
+  are missing. Never create a label you haven't first confirmed is missing.
+- **Child tickets**: GitHub's native sub-issues — `gh issue edit <map> -R
+  pedrosousa13/lnpm --add-sub-issue <ticket>`, the same relation the loop's
+  **Blocking** bullet reads. No conflict: under that bullet an open child
+  blocks its parent, and a map with open tickets *is* a map that isn't
+  finished — the map never carries `ready-for-agent`, so nothing ever
+  checks it as a Queue candidate anyway.
+- **Blocking between tickets**: a sub-issue has exactly one parent and the
+  map holds that slot, so ticket-to-ticket edges use the body convention
+  the loop already reads — a `Blocked by #N` line in the blocked ticket's
+  body, added in a second pass once every ticket has a number. A ticket is
+  blocked while any issue such a line names is still open.
+- **Frontier**: read the map's children from `gh issue view <map> -R
+  pedrosousa13/lnpm --json subIssues`, keep the `OPEN` ones, then confirm each
+  candidate with its own `gh issue view <n> -R pedrosousa13/lnpm --json
+  assignees,body,state` — unclaimed means no assignee; unblocked means no
+  `Blocked by #N` line naming a still-open issue. The per-candidate view is
+  the authority here for the same reason it is in Queue selection: the
+  listing lags.
+- **Claim**: `gh issue edit <n> -R pedrosousa13/lnpm --add-assignee @me` — the
+  assignee is the claim; an open, unassigned ticket is unclaimed.
+- **Resolve**: post the resolution with `gh issue comment`, then `gh issue
+  close <n> -R pedrosousa13/lnpm --reason completed`. A ticket ruled out of scope
+  closes with `--reason "not planned"` instead — resolved and ruled-out
+  stay distinguishable, the same way landed and wontfix do.
+
+## Reachability
+
+What the Factory's Preflight checks: `gh` resolves and is authenticated,
+and the **pedrosousa13/lnpm** repo exists and is visible — `gh auth status`, then
+`gh repo view pedrosousa13/lnpm --json name`.
+
+## If GitHub is unreachable
+
+Say so and stop. Don't silently fall back to another tracker or local files.
+
+## Where a label is weaker than a field
+
+Linear-shaped trackers carry state and priority as native fields; GitHub
+carries them as labels, which nothing validates. Three invariants can
+therefore break. Each has a resolution rule, so two sessions over identical
+state still behave the same.
+
+- **Two priority labels on one issue.** Nothing stops `P0` and `P2` both
+  being applied. Rule: **highest wins** — `P0` beats `P1` beats `P2` beats
+  `P3`. Ordering stays deterministic no matter how many priority labels an
+  issue carries, and no session has to stop and ask.
+- **`in-progress` is enforced by nothing.** A session that dies mid-issue
+  leaves the label behind; nothing removes it. Rule: `in-progress` on an
+  issue with no matching branch (see **Branch name** above) is a **stale
+  marker to verify, not a fact to trust** — the same posture `PROTOCOL.md`'s
+  Pause note section takes toward an interrupted state. Verify against the
+  branch and the Pause note; if neither backs it up, the issue was never
+  really started.
+- **`gh issue list` lags label writes.** Verified against a real repo:
+  freshly created issues were missing from a filtered listing for tens of
+  seconds, and an issue kept appearing in a `--label ready-for-agent`
+  listing for about a minute after that label was removed. `gh issue view`
+  on the same issue was correct immediately, every time. Rule: **the
+  listing is a hint; the per-candidate `gh issue view` is the authority.**
+  Queue selection already confirms each candidate individually for the
+  blocker check — that same confirmation must also re-check that the
+  candidate still carries `ready-for-agent`, still lacks `in-progress`, and
+  is still open, and skip it otherwise. Without that re-check, a Loop
+  Session that Parks an issue and immediately re-runs Queue selection
+  re-picks the issue it just Parked, Parks it again, and loops forever.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,145 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+**The label set is tracker-dependent.** The eight labels on this page's first
+two tables — five triage states plus three categories — are universal: every
+Project carries them whatever its tracker, created at stamp time. The
+wayfinder labels below apply on every tracker too, but are created lazily,
+not at stamp time. Everything after them exists only on trackers that need
+it, and is spelled out as such.
+
+These labels live wherever this repo's tracker scopes labels — a team, an
+organization, the repo itself. `docs/agents/issue-tracker.md` names the
+tracker, and so the scope.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+## Category labels
+
+Alongside its state label, every issue gets exactly one category label. These are scoped the same way as the state labels above:
+
+| Label         | Meaning                              |
+| ------------- | ------------------------------------ |
+| `Feature`     | New capability                       |
+| `Improvement` | Enhancement to existing behavior     |
+| `Bug`         | Something is wrong                   |
+
+Use these exact names — not `enhancement`, not lowercase `bug`.
+
+## Wayfinder labels
+
+The `/wayfinder` skill charts planning maps on this tracker: a map issue
+labeled `wayfinder:map`, and decision tickets labeled `wayfinder:research`,
+`wayfinder:prototype`, `wayfinder:grilling`, or `wayfinder:task`. These are
+scoped the same way as the state labels above, created lazily the first
+time a map is charted here.
+
+An issue carrying any `wayfinder:*` label is a **planning artifact, not a
+work item**: it sits outside the triage state machine, carries no state
+label, no category label, no milestone, and no priority label, and a triage
+sweep skips it entirely rather than bringing it up to the invariant. It
+never carries `ready-for-agent`, so it can never enter a Loop Session's
+Queue. How this tracker expresses the map, its tickets, blocking, and the
+frontier is in `docs/agents/issue-tracker.md`, under "Wayfinding
+operations".
+
+The reserved planning namespace is every label that starts with
+`wayfinder:` or `planning:`. Today that is `wayfinder:map`,
+`wayfinder:research`, `wayfinder:prototype`, `wayfinder:grilling`,
+`wayfinder:task`, and `planning:prd`. The match is on the prefix, so a new
+artifact kind inherits the exclusion by naming itself in the namespace.
+
+## Labels that stand in for a missing field
+
+The eight labels in the first two tables are universal. Two further groups exist **only** where
+the tracker has no native field for what they express — which is to say on
+GitHub, whose issues have no started state and no priority. Where the tracker
+does carry those as fields, these labels must not be created: the field is the
+source of truth, and a label beside it is a second, unenforced one.
+
+`docs/agents/issue-tracker.md` says which case this repo is in. If it names a
+tracker with native state and priority fields, ignore the rest of this
+section.
+
+**Started state.** One label, orthogonal to everything above — it is not a
+triage state, and an issue carrying it still carries exactly one of the five:
+
+| Label         | Meaning                                            |
+| ------------- | -------------------------------------------------- |
+| `in-progress` | A session has picked this issue up and is on it    |
+
+**Priority.** Exactly one per issue, and what makes the Queue's order
+deterministic. Highest first; an issue with none sorts last:
+
+| Label | Priority |
+| ----- | -------- |
+| `P0`  | Urgent   |
+| `P1`  | High     |
+| `P2`  | Medium   |
+| `P3`  | Low      |
+
+"Exactly one" is the invariant, not a guarantee — nothing enforces it when
+priority is a label. `docs/agents/issue-tracker.md` carries the resolution
+rule for an issue that ends up carrying two.
+
+## Milestones
+
+Alongside its category and state labels, every open issue also carries
+exactly one milestone — a third axis, and never a triage label: a tracker
+field, or whatever that tracker offers in its place.
+`docs/agents/issue-tracker.md` names the mechanism. Per-axis, exactly like
+the two above: assigning a milestone must not disturb the category label,
+the state label, or this Project's own domain labels.
+
+If this Project has no milestones defined yet, the invariant doesn't apply
+until they exist — milestone names are a maintainer decision, made once, not
+invented by an agent sweep.
+
+The maintainer may decline a milestone for a specific issue. That decision is
+recorded as a comment on the issue carrying this exact line:
+
+**Milestone: declined by the maintainer.**
+
+An issue carrying that line is left alone rather than re-proposed. Detection
+is that line and nothing else — a comment merely discussing milestones is not
+a decline. If the record is ambiguous or absent, treat the issue as **not**
+declined and propose a milestone again: re-asking costs one approval, while
+wrongly inferring a decline drops an issue out of the invariant silently and
+permanently.
+
+## Security sweeps
+
+If this Project passes the attack-surface test — its software accepts
+untrusted input, serves HTTP, authenticates anyone, stores user data, or
+calls third-party services — then every milestone containing issues that
+touch that surface also carries one **security-sweep issue**: a full OWASP
+Top 10 pass over the code as it stands, filed, triaged, and milestoned like
+any other issue (category `Improvement`), blocked by the milestone's
+attack-surface issues, its findings filed as new `needs-triage` issues
+rather than fixed in the sweep. Planning
+Sessions file it alongside the milestone's other issues; an adoption sweep
+proposes it where missing.
+
+A sweep skips every issue in the reserved planning namespace above: a
+wayfinder map or a PRD never touches the attack surface, so a sweep never
+treats one as though it did. Findings a sweep files are ordinary issues
+labeled `needs-triage`, never planning artifacts — a sweep never mints a
+`wayfinder:` or `planning:` label.
+
+The maintainer may rule the Project fails the test, or decline sweeps
+outright — recorded in this Project's `CONTEXT.md` with this exact marker
+line:
+
+**Security sweeps: declined by the maintainer.**
+
+Detection is the marker line only. An ambiguous or absent record means not
+declined, and the sweep is proposed again.


### PR DESCRIPTION
Brings the repo under Factory conventions so the automated loop can run here.

**Files**
- `AGENTS.md` — points agents at `docs/agents/`
- `docs/agents/issue-tracker.md` — the tracker adapter (GitHub, via `gh`)
- `docs/agents/triage-labels.md` — canonical label vocabulary
- `docs/agents/domain.md` — how agents should read domain docs
- `.factory/config.json` — tracker, merge policy, attack-surface decision
- `.gitignore` — adds `.scratch/`, `.factory/run.lock`, `.factory/journal.json`

All generated from the Factory stamp templates. No source code is touched, and
nothing outside the appended `.gitignore` block is modified.

**Tracker side (already applied, not part of this diff):** renamed the `bug` label
to `Bug` preserving all 34 assignments, added the canonical triage/category/priority
labels, created 9 milestones from the existing epics, and swept all open issues onto
exactly one category, state, milestone and priority.