### PR TITLE
fix: stop hardlinking source files into the store

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,14 +64,24 @@ project/
 
 ## Intelligent Linking Strategy
 
-### Priority System: Reflink → Hard Link → Parallel Copy
+### Priority System
 
-lnpm uses a sophisticated multi-tier approach for maximum performance:
+lnpm uses a sophisticated multi-tier approach for maximum performance. The tiers
+differ between the two hops:
+
+- **Source → store** (`publish`, `push`): reflink → parallel copy. The store
+  **never** hard links a source file. A hard link would give the source file and
+  the store entry one shared inode, so an in-place rewrite of the source (tsc,
+  webpack, an editor saving over its own output) would mutate content already
+  filed under its content hash. The store must own a private copy of its bytes.
+- **Store → project** (`add`, `push`): reflink → hard link → parallel copy. The
+  store entry is already a private copy, so sharing its inode with consumers is
+  safe as long as consumers treat linked packages as read-only.
 
 | Method | Speed | Platform Support | Use Case | Disk Usage |
 |--------|-------|------------------|----------|------------|
-| **Reflink (CoW)** | Instant (~1ms) | macOS APFS, Linux Btrfs/XFS/OCFS2 | Primary method | Zero (copy-on-write) |
-| **Hard Link** | Instant (~1ms) | Same filesystem (all platforms) | Fallback #1 | Zero (shared inodes) |
+| **Reflink (CoW)** | Instant (~1ms) | macOS APFS, Linux Btrfs/XFS/OCFS2 | Primary method, both hops | Zero (copy-on-write) |
+| **Hard Link** | Instant (~1ms) | Same filesystem (all platforms) | Fallback #1, store → project only | Zero (shared inodes) |
 | **Parallel Copy** | Fast (~100ms for 10k files) | All platforms, cross-filesystem | Fallback #2 | Full copy |
 
 ### Reflink (Copy-on-Write Cloning)
@@ -87,7 +97,7 @@ lnpm uses a sophisticated multi-tier approach for maximum performance:
 #### Platform Implementation
 - **macOS APFS**: Uses `clonefile()` syscall (SYS_CLONEFILE #462)
 - **Linux Btrfs/XFS**: Uses `FICLONE` ioctl (#0x40049409)
-- **Other filesystems**: Gracefully falls back to hard links
+- **Other filesystems**: Gracefully falls back to hard links (store → project) or to a parallel copy (source → store)
 
 #### Why Reflink is Better Than Hard Links
 ```
@@ -102,11 +112,10 @@ Reflink:       source.js ──► [inode 12345: blocks 1-100]
 ### How It Works
 
 #### During `lnpm publish`:
-1. Detect if source and store are on same filesystem
-2. Try reflink first (works even across directories on same FS)
-3. If reflink unsupported, try hard link (requires same filesystem)
-4. If hard link fails, use parallel copy with 8 worker goroutines
-5. Display progress and warnings for user visibility
+1. Try reflink first (works even across directories on same FS)
+2. If reflink is unsupported, use parallel copy with 8 worker goroutines
+3. Hard linking from the source is never attempted — see the priority system above
+4. Display progress for user visibility
 
 #### During `lnpm add`:
 1. Check user config for `link_mode` preference
@@ -118,10 +127,10 @@ Reflink:       source.js ──► [inode 12345: blocks 1-100]
 ```
 Source Package          Store                    Project
 ──────────────          ─────                    ───────
-src/index.ts    ──►   (reflink/hardlink)
+src/index.ts    ──►    (reflink/copy)
 dist/index.js   ──►     ~/.lnpm/store/      ══► .lnpm/pkg/     ──► node_modules/pkg
 package.json    ──►       pkg/abc123/      (reflink/hardlink)     (symlink)
-                       (CoW or shared)      (CoW or shared)
+                       (private copy)       (CoW or shared)
 ```
 
 ### Performance Characteristics
@@ -138,23 +147,20 @@ package.json    ──►       pkg/abc123/      (reflink/hardlink)     (symlink
 
 lnpm intelligently handles edge cases:
 
-1. **Same filesystem**: Try reflink → hard link → parallel copy
-2. **Different filesystem**: Try reflink → parallel copy (skip hard link)
-3. **User config `link_mode: copy`**: Skip linking, use parallel copy
-4. **User config `link_mode: hardlink`**: Try reflink → hard link → parallel copy
+1. **Source → store**: Try reflink → parallel copy (hard link never attempted)
+2. **Store → project, same filesystem**: Try reflink → hard link → parallel copy
+3. **Store → project, different filesystem**: Try reflink → parallel copy (skip hard link)
+4. **User config `link_mode: copy`**: Skip linking, use parallel copy
+5. **User config `link_mode: hardlink`**: Store → project tries reflink → hard link → parallel copy
 
 **User Feedback:**
 ```bash
-# Same filesystem, linking works
-✓ Linked 10,000 files instantly
-
-# Linking not supported
-⚠ Linking not supported, copying files instead
+# Large packages report progress while the store is populated
+  Processing... 10000/10000 files
   Copying... 10000/10000 files
 
-# Cross-filesystem scenario
-ℹ Store and source on different filesystems - files were copied
-💡 Tip: Move your store to the same filesystem for instant linking
+# Store → project hard linking not available
+  ⚠ Hard linking failed, falling back to copying files
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Features
 
 - **Blazing fast** — Reflink/CoW + hard links for instant operations on large packages
-- **Smart linking** — Automatically uses the fastest method: reflink → hardlink → parallel copy
+- **Smart linking** — Automatically uses the fastest method: reflink → hardlink → parallel copy (store → project); reflink → parallel copy into the store
 - **Monorepo support** — Publish all workspace packages at once
 - **Cross-platform** — Works on Linux, macOS, and Windows
 - **All package managers** — npm, yarn, pnpm, and bun
@@ -321,7 +321,7 @@ Debug output goes to stderr with timestamps, useful for diagnosing slow operatio
 
 ## How It Works
 
-1. **Publish** — Uses `npm pack` rules to determine files, strips lifecycle scripts (`prepare`/`prepublish`), then links or copies to `~/.lnpm/store/{name}/{hash}/`
+1. **Publish** — Uses `npm pack` rules to determine files, strips lifecycle scripts (`prepare`/`prepublish`), then reflinks or copies to `~/.lnpm/store/{name}/{hash}/`
 2. **Add** — Creates reflinks or hard links from store to `project/.lnpm/{package}/`, updates package.json to `file:.lnpm/{package}`
 3. **Symlink** — Links `node_modules/{package}` → `.lnpm/{package}`
 4. **Push** — Updates store and re-links changed files
@@ -332,7 +332,7 @@ Debug output goes to stderr with timestamps, useful for diagnosing slow operatio
 ```
 Source Package          Store                    Project
 ──────────────          ─────                    ───────
-src/index.ts    ──►   (reflink/hardlink)
+src/index.ts    ──►    (reflink/copy)
 dist/index.js   ──►     ~/.lnpm/store/      ══► .lnpm/pkg/     ──► node_modules/pkg
 package.json    ──►       pkg/abc123/      (reflink/hardlink)     (symlink)
 ```
@@ -365,12 +365,19 @@ lnpm automatically manages `.gitignore` entries to prevent committing linked pac
 
 lnpm uses an intelligent priority system for maximum performance:
 
-**Priority Order:** Reflink → Hard Link → Parallel Copy
+**Priority Order:**
+- Source → store: Reflink → Parallel Copy
+- Store → project: Reflink → Hard Link → Parallel Copy
+
+The store never hard links your source files. A hard link would make the source
+file and the store entry share one inode, so rewriting the source in place (tsc,
+webpack, an editor saving over its own output) would silently mutate content
+already filed under its content hash. The store keeps a private copy instead.
 
 | Method | Speed | Platform Support | Disk Usage |
 |--------|-------|------------------|------------|
 | **Reflink (CoW)** | Instant | macOS APFS, Linux Btrfs/XFS | Zero (copy-on-write) |
-| **Hard Link** | Instant | Same filesystem | Zero (shared inodes) |
+| **Hard Link** | Instant | Same filesystem, store → project only | Zero (shared inodes) |
 | **Parallel Copy** | Fast | Always works | Full copy (8 workers) |
 
 **Benefits:**
@@ -385,7 +392,7 @@ lnpm automatically detects the best method and falls back gracefully with helpfu
 
 | Feature | lnpm | yalc |
 |---------|------|------|
-| Link method | Reflink → Hard link → Parallel copy | Sequential copy only |
+| Link method | Reflink → Hard link → Parallel copy (reflink or copy into the store) | Sequential copy only |
 | Large packages (10k+ files) | Instant (~5ms) on APFS/Btrfs | Slow (~5s+) |
 | State tracking | bbolt database | Hash files |
 | Monorepo | Native support | Manual |

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -36,11 +36,12 @@ func New(projectPath string) *Linker {
 // Link links a package from the store to the project
 // It creates hard links in .lnpm/{package}/ and a symlink in node_modules/{package}
 //
-// These store→project hard links share an inode with the store entry, so
-// propagation is one-way by design: the store pushes content out to consumers.
-// A consumer that edits a linked file in place would write back into the store
-// entry and corrupt it for every other consumer. Linked packages are therefore
-// read-only from the consumer's side; `push` is the supported way to update them.
+// Files are materialised by reflink, hard link or copy, whichever the platform
+// allows. Where a hard link is used the linked file shares an inode with the
+// store entry, so a consumer that edits it in place writes back into the store
+// and corrupts that entry for every other consumer. Propagation is therefore
+// one-way by design: linked packages are read-only from the consumer's side,
+// and `push` is the supported way to update them.
 func (l *Linker) Link(packageName string, storePath string, files []*pack.FileInfo) (LinkType, error) {
 	debug.Logf("link: linking %s from %s (%d files)", packageName, storePath, len(files))
 

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -35,6 +35,12 @@ func New(projectPath string) *Linker {
 
 // Link links a package from the store to the project
 // It creates hard links in .lnpm/{package}/ and a symlink in node_modules/{package}
+//
+// These store→project hard links share an inode with the store entry, so
+// propagation is one-way by design: the store pushes content out to consumers.
+// A consumer that edits a linked file in place would write back into the store
+// entry and corrupt it for every other consumer. Linked packages are therefore
+// read-only from the consumer's side; `push` is the supported way to update them.
 func (l *Linker) Link(packageName string, storePath string, files []*pack.FileInfo) (LinkType, error) {
 	debug.Logf("link: linking %s from %s (%d files)", packageName, storePath, len(files))
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -66,7 +66,10 @@ func (s *Store) Exists(name, hash string) bool {
 	return err == nil
 }
 
-// Store copies or hard links files to the store
+// Store populates the store with the package's files, using reflink (CoW clone)
+// where the filesystem supports it and a plain copy otherwise. It never hard
+// links a source file into the store: the store entry must be a private copy so
+// later writes to the source cannot mutate content already addressed by hash.
 func (s *Store) Store(name, hash string, files []*pack.FileInfo, sourceDir string) (string, error) {
 	// Guard against path traversal: name is joined into the store path.
 	if err := pack.ValidatePackageName(name); err != nil {
@@ -101,22 +104,20 @@ func (s *Store) Store(name, hash string, files []*pack.FileInfo, sourceDir strin
 		}
 	}()
 
-	// Determine if we can use hard links (same filesystem)
-	useHardLink := s.canUseHardLink(sourceDir)
-	sameFS := useHardLink
-	if useHardLink {
-		debug.Log("store: same filesystem detected, will try reflink or hard link")
-	} else {
-		debug.Log("store: different filesystem, will try reflink or copy")
-	}
+	// The store must own its bytes: never hard link the source file into the
+	// store. A shared inode means an in-place rewrite of the developer's source
+	// (tsc, webpack, an editor saving in place) silently mutates the store entry,
+	// so the content stored under hash H no longer hashes to H. Reflink is a CoW
+	// clone and stays isolated; otherwise we copy.
+	debug.Log("store: populating store with reflink or copy")
 
-	// Process files in parallel: try reflink/hardlink first, collect failures for copy
+	// Process files in parallel: try reflink first, collect failures for copy
 	total := len(files)
-	var reflinkCount, hardLinkCount, copyCount int32
+	var reflinkCount, copyCount int32
 	var filesToCopyMu sync.Mutex
 	var filesToCopy []*pack.FileInfo
 
-	// Parallel pass: try fast methods (reflink/hardlink)
+	// Parallel pass: try the fast method (reflink)
 	numWorkers := min(runtime.NumCPU(), 8)
 	if len(files) < numWorkers {
 		numWorkers = len(files)
@@ -152,15 +153,7 @@ func (s *Store) Store(name, hash string, files []*pack.FileInfo, sourceDir strin
 					atomic.AddInt32(&reflinkCount, 1)
 				}
 
-				// 2. Try hard link if on same filesystem and reflink didn't work
-				if !linked && useHardLink {
-					if err := os.Link(f.Path, destFile); err == nil {
-						linked = true
-						atomic.AddInt32(&hardLinkCount, 1)
-					}
-				}
-
-				// 3. Queue for parallel copy if linking didn't work
+				// 2. Queue for parallel copy if reflink didn't work
 				if !linked {
 					filesToCopyMu.Lock()
 					filesToCopy = append(filesToCopy, f)
@@ -191,12 +184,7 @@ func (s *Store) Store(name, hash string, files []*pack.FileInfo, sourceDir strin
 	default:
 	}
 
-	// Show warning if needed
-	if len(filesToCopy) > 0 && sameFS {
-		fmt.Printf("  ⚠ Linking not supported, copying files instead\n")
-	}
-
-	// Parallel copy for files that couldn't be linked
+	// Parallel copy for files that couldn't be reflinked
 	if len(filesToCopy) > 0 {
 		debug.Logf("store: copying %d files in parallel", len(filesToCopy))
 
@@ -256,12 +244,7 @@ func (s *Store) Store(name, hash string, files []*pack.FileInfo, sourceDir strin
 		fmt.Printf("\r                                        \r") // Clear progress line
 	}
 
-	if reflinkCount > 0 || hardLinkCount > 0 {
-		debug.Logf("store: reflinked %d, hard linked %d, copied %d files", reflinkCount, hardLinkCount, copyCount)
-	} else if copyCount > 0 && !sameFS {
-		fmt.Printf("  ℹ Store and source on different filesystems - files were copied\n")
-		fmt.Printf("  💡 Tip: Move your store to the same filesystem for instant linking\n")
-	}
+	debug.Logf("store: reflinked %d, copied %d files", reflinkCount, copyCount)
 
 	// Strip lifecycle scripts from package.json to prevent npm from running them
 	// when installed as file: dependency (matches yalc behavior)
@@ -313,35 +296,6 @@ func (s *Store) GetFiles(name, hash string) ([]*pack.FileInfo, error) {
 	})
 
 	return files, err
-}
-
-// canUseHardLink checks if the source directory and store are on the same filesystem
-func (s *Store) canUseHardLink(sourceDir string) bool {
-	// Windows: always try hard links, let it fail if needed
-	if runtime.GOOS == "windows" {
-		return true
-	}
-
-	// Unix: check device IDs
-	storeInfo, err := os.Stat(s.basePath)
-	if err != nil {
-		return false
-	}
-
-	sourceInfo, err := os.Stat(sourceDir)
-	if err != nil {
-		return false
-	}
-
-	storeDev := fsutil.DeviceID(storeInfo)
-	sourceDev := fsutil.DeviceID(sourceInfo)
-
-	if storeDev != 0 && sourceDev != 0 {
-		return storeDev == sourceDev
-	}
-
-	// Default to trying hard link
-	return true
 }
 
 // copyFile copies a file preserving permissions

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -104,13 +104,6 @@ func (s *Store) Store(name, hash string, files []*pack.FileInfo, sourceDir strin
 		}
 	}()
 
-	// The store must own its bytes: never hard link the source file into the
-	// store. A shared inode means an in-place rewrite of the developer's source
-	// (tsc, webpack, an editor saving in place) silently mutates the store entry,
-	// so the content stored under hash H no longer hashes to H. Reflink is a CoW
-	// clone and stays isolated; otherwise we copy.
-	debug.Log("store: populating store with reflink or copy")
-
 	// Process files in parallel: try reflink first, collect failures for copy
 	total := len(files)
 	var reflinkCount, copyCount int32
@@ -313,6 +306,13 @@ func copyFile(src, dst string, mode os.FileMode) error {
 	defer func() { _ = dstFile.Close() }()
 
 	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return err
+	}
+
+	// OpenFile's mode argument is masked by the process umask, so the stored
+	// file would not carry the exact permission bits the content hash was
+	// computed from (pack folds Mode.Perm() into the hash). Set them explicitly.
+	if err := dstFile.Chmod(mode); err != nil {
 		return err
 	}
 

--- a/internal/store/store_isolation_test.go
+++ b/internal/store/store_isolation_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"syscall"
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/pack"
@@ -12,11 +11,9 @@ import (
 
 // TestStore_DoesNotShareInodeWithSource verifies the store owns its own bytes:
 // a stored file must never be a hard link to the developer's source file.
+// os.SameFile is the portable identity check (inode on unix, volume + file
+// index on Windows), so this assertion holds on every platform.
 func TestStore_DoesNotShareInodeWithSource(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping on Windows - inode semantics differ")
-	}
-
 	tmpDir := t.TempDir()
 	t.Setenv("LNPM_STORE", tmpDir)
 
@@ -59,17 +56,8 @@ func TestStore_DoesNotShareInodeWithSource(t *testing.T) {
 		t.Fatalf("Failed to stat stored file: %v", err)
 	}
 
-	sourceStat, ok := sourceInfo.Sys().(*syscall.Stat_t)
-	if !ok {
-		t.Skip("Skipping - stat_t unavailable on this platform")
-	}
-	storedStat, ok := storedInfo.Sys().(*syscall.Stat_t)
-	if !ok {
-		t.Skip("Skipping - stat_t unavailable on this platform")
-	}
-
-	if sourceStat.Ino == storedStat.Ino {
-		t.Errorf("Stored file shares inode %d with source file - external writes to the source would corrupt the store", sourceStat.Ino)
+	if os.SameFile(sourceInfo, storedInfo) {
+		t.Error("Stored file is the same file as the source - external writes to the source would corrupt the store")
 	}
 }
 
@@ -78,7 +66,7 @@ func TestStore_DoesNotShareInodeWithSource(t *testing.T) {
 // bytes untouched.
 func TestStore_SourceMutationDoesNotAffectStore(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("Skipping on Windows - permission handling differs")
+		t.Skip("Skipping on Windows - rewriting a file in place is blocked while other handles hold it open")
 	}
 
 	tmpDir := t.TempDir()

--- a/internal/store/store_isolation_test.go
+++ b/internal/store/store_isolation_test.go
@@ -1,0 +1,140 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/pack"
+)
+
+// TestStore_DoesNotShareInodeWithSource verifies the store owns its own bytes:
+// a stored file must never be a hard link to the developer's source file.
+func TestStore_DoesNotShareInodeWithSource(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - inode semantics differ")
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("LNPM_STORE", tmpDir)
+
+	store, err := New()
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+
+	sourceDir := filepath.Join(tmpDir, "source")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatalf("Failed to create source dir: %v", err)
+	}
+
+	sourceFile := filepath.Join(sourceDir, "index.js")
+	if err := os.WriteFile(sourceFile, []byte("original content"), 0644); err != nil {
+		t.Fatalf("Failed to create source file: %v", err)
+	}
+
+	files := []*pack.FileInfo{
+		{
+			RelPath:     "index.js",
+			Path:        sourceFile,
+			Size:        int64(len("original content")),
+			Mode:        0644,
+			ContentHash: "inode123",
+		},
+	}
+
+	destPath, err := store.Store("test-pkg", "inode-hash", files, sourceDir)
+	if err != nil {
+		t.Fatalf("Failed to store: %v", err)
+	}
+
+	sourceInfo, err := os.Stat(sourceFile)
+	if err != nil {
+		t.Fatalf("Failed to stat source file: %v", err)
+	}
+	storedInfo, err := os.Stat(filepath.Join(destPath, "index.js"))
+	if err != nil {
+		t.Fatalf("Failed to stat stored file: %v", err)
+	}
+
+	sourceStat, ok := sourceInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Skip("Skipping - stat_t unavailable on this platform")
+	}
+	storedStat, ok := storedInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Skip("Skipping - stat_t unavailable on this platform")
+	}
+
+	if sourceStat.Ino == storedStat.Ino {
+		t.Errorf("Stored file shares inode %d with source file - external writes to the source would corrupt the store", sourceStat.Ino)
+	}
+}
+
+// TestStore_SourceMutationDoesNotAffectStore verifies that rewriting the source
+// file in place (as tsc, webpack or an editor would) leaves the store entry's
+// bytes untouched.
+func TestStore_SourceMutationDoesNotAffectStore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - permission handling differs")
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("LNPM_STORE", tmpDir)
+
+	store, err := New()
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+
+	sourceDir := filepath.Join(tmpDir, "source")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatalf("Failed to create source dir: %v", err)
+	}
+
+	sourceFile := filepath.Join(sourceDir, "index.js")
+	original := []byte("original content")
+	if err := os.WriteFile(sourceFile, original, 0644); err != nil {
+		t.Fatalf("Failed to create source file: %v", err)
+	}
+
+	files := []*pack.FileInfo{
+		{
+			RelPath:     "index.js",
+			Path:        sourceFile,
+			Size:        int64(len(original)),
+			Mode:        0644,
+			ContentHash: "mutate123",
+		},
+	}
+
+	destPath, err := store.Store("test-pkg", "mutate-hash", files, sourceDir)
+	if err != nil {
+		t.Fatalf("Failed to store: %v", err)
+	}
+
+	// Rewrite the source in place, without unlinking it, exactly as a build
+	// tool writing over its own output would.
+	f, err := os.OpenFile(sourceFile, os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open source for rewrite: %v", err)
+	}
+	if _, err := f.Write([]byte("MUTATED CONTENT")); err != nil {
+		_ = f.Close()
+		t.Fatalf("Failed to rewrite source: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Failed to close source: %v", err)
+	}
+
+	stored, err := os.ReadFile(filepath.Join(destPath, "index.js"))
+	if err != nil {
+		t.Fatalf("Failed to read stored file: %v", err)
+	}
+
+	if string(stored) != string(original) {
+		t.Errorf("Store entry changed when source was rewritten: got %q, want %q", string(stored), string(original))
+	}
+}

--- a/internal/store/store_permissions_test.go
+++ b/internal/store/store_permissions_test.go
@@ -139,6 +139,79 @@ func TestStore_PreservesExecutablePermissions(t *testing.T) {
 	}
 }
 
+// TestStore_PreservesModeUmaskWouldStrip tests that the stored file carries the
+// exact permission bits of the source, even bits the process umask would mask
+// out of an open(2) mode argument. pack folds Mode.Perm() into the content hash,
+// so a store entry with different bits no longer hashes to the hash it is filed
+// under.
+func TestStore_PreservesModeUmaskWouldStrip(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - permission handling differs")
+	}
+
+	// The regression is only observable when the process umask masks the bits
+	// under test, so prove that first rather than passing vacuously.
+	probe := filepath.Join(t.TempDir(), "probe")
+	probeFile, err := os.OpenFile(probe, os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		t.Fatalf("Failed to create probe file: %v", err)
+	}
+	_ = probeFile.Close()
+	probeInfo, err := os.Stat(probe)
+	if err != nil {
+		t.Fatalf("Failed to stat probe file: %v", err)
+	}
+	if probeInfo.Mode().Perm() == 0666 {
+		t.Skip("Skipping - process umask masks nothing, so a umask regression cannot be detected here")
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("LNPM_STORE", tmpDir)
+
+	store, err := New()
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+
+	sourceDir := filepath.Join(tmpDir, "source")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatalf("Failed to create source dir: %v", err)
+	}
+
+	sourceFile := filepath.Join(sourceDir, "group-writable.js")
+	if err := os.WriteFile(sourceFile, []byte("test content"), 0644); err != nil {
+		t.Fatalf("Failed to create source file: %v", err)
+	}
+	// WriteFile's mode is umask-masked too, so set the bits explicitly.
+	if err := os.Chmod(sourceFile, 0666); err != nil {
+		t.Fatalf("Failed to chmod source file: %v", err)
+	}
+
+	files := []*pack.FileInfo{
+		{
+			RelPath:     "group-writable.js",
+			Path:        sourceFile,
+			Size:        12,
+			Mode:        0666,
+			ContentHash: "umask123",
+		},
+	}
+
+	destPath, err := store.Store("test-pkg", "umask-hash", files, sourceDir)
+	if err != nil {
+		t.Fatalf("Failed to store: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(destPath, "group-writable.js"))
+	if err != nil {
+		t.Fatalf("Failed to stat stored file: %v", err)
+	}
+
+	if got := info.Mode().Perm(); got != 0666 {
+		t.Errorf("Stored mode %o, want %o - the umask masked the mode the hash was computed from", got, 0666)
+	}
+}
+
 // TestStore_DestinationDirCreation tests store directory creation
 func TestStore_DestinationDirCreation(t *testing.T) {
 	tmpDir := t.TempDir()


### PR DESCRIPTION
Closes #136.

## The bug

Store population tried reflink, then a **hardlink from the developer's source file**, then a copy. The hardlink branch made the source file, the store entry, and every consumer's linked copy share one inode. Any tool that rewrites the source in place — `tsc`, a bundler, an editor that doesn't save-via-rename — silently mutated the store entry, so content filed under hash `H` no longer hashed to `H`. Because `Exists()` only stats the directory, a later republish of the original content short-circuited and returned the corrupted entry permanently.

## The fix

Populate the store with **reflink-or-copy only**, so the store owns its bytes. `canUseHardLink` and the `os.Link(f.Path, …)` branch are removed.

Store→project hardlinks stay: once the store entry is a private copy, nothing writes to it from the source side. That propagation is now documented as one-way — linked packages are read-only from the consumer, and `push` is the supported way to update them.

## Also in this PR

- **Stored permission bits.** With copy now the common path, `copyFile` was letting the umask mask `OpenFile`'s mode argument, so stored files no longer carried the bits the content hash was computed from (`pack` folds `Mode.Perm()` into the hash). Set explicitly after the copy. Narrow fix to the store copy path only — the reflink and link paths remain #139's scope.
- **`TestStore_SymlinkHandling` red → green.** It was failing wherever the hardlink branch was reachable: `os.Link` on a symlink stored the symlink itself rather than its target. Removing that branch fixes it.
- **Docs.** `ARCHITECTURE.md` and `README.md` still documented the removed source→store hardlink tier and quoted user-facing messages the code no longer prints.

## Verification

- Three new tests, all confirmed to fail against the pre-fix code and to run rather than skip on this platform: no shared file identity with the source, an in-place source rewrite leaves stored bytes untouched, and a mode the umask would strip is stored exactly.
- `go vet` clean on linux, darwin and windows. The test file uses `os.SameFile` rather than `syscall.Stat_t`, which does not compile on Windows.
- Full suite green under `umask 022`.

Not verified locally: the `-race` leg, as this machine has no gcc. The change adds no concurrency.