### PR TITLE
Add a macOS CI job to test the darwin binaries we ship

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,10 +100,37 @@ jobs:
       - name: Run workspace + e2e tests
         run: go test -v -race ./tests/...
 
+  test-macos:
+    name: Test (macOS)
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run unit tests
+        run: go test -v -race ./internal/...
+
+      - name: Run workspace + e2e tests
+        run: go test -v -race ./tests/...
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [test, test-windows, lint]
+    needs: [test, test-windows, test-macos, lint]
 
     steps:
       - name: Checkout

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -221,6 +221,8 @@ env.AssertLockfile(projectPath, func(lock *lockfile.LockFile) {
 **Jobs:**
 - `test`: Unit tests (`./internal/...`) and workspace tests (`./tests/...`)
 - `lint`: golangci-lint with `only-new-issues: true`
+- `test-windows`: Same test suites on `windows-latest`, without coverage
+- `test-macos`: Same test suites on `macos-latest`, without coverage
 - `build`: Multi-platform compilation
 
 **Race Detection:**
@@ -228,7 +230,7 @@ env.AssertLockfile(projectPath, func(lock *lockfile.LockFile) {
 - Location: `.github/workflows/ci.yaml`
 
 **Platform Testing:**
-- Primary: `ubuntu-latest`
+- Runners: `ubuntu-latest` (primary, with coverage), `windows-latest`, `macos-latest`
 - Go version: `1.26` (defined in `go.mod`, which workflows read via `go-version-file`)
 
 ---


### PR DESCRIPTION
Closes #174.

We ship darwin binaries via GoReleaser (`.goreleaser.yaml` builds `darwin` for both amd64 and arm64) but CI only ever ran the suite on `ubuntu-latest` and `windows-latest`. A macOS-specific bug — a path, hard-link, or case-sensitivity difference — would pass all of CI and still ship. Given that lnpm's core mechanism is hard-linking files into local projects, that is exactly the class of bug worth covering.

## What this does

- Adds a `test-macos` job on `macos-latest` that mirrors `test-windows` step for step: checkout, Go, Node 20, `go mod download`, then `go test -v -race ./internal/...` and `go test -v -race ./tests/...`. Node is required because the e2e suite shells out to real npm.
- Gates `build` on it (`needs: [test, test-windows, test-macos, lint]`), so a macOS failure blocks the build.
- Updates the CI Configuration block in `.planning/codebase/TESTING.md`, whose job list and platform statement this change would otherwise have made false.

It mirrors the **Windows** job rather than the Linux one on purpose: Linux additionally collects and uploads coverage, which a second platform should not duplicate.

## Why `go-version-file: go.mod` is load-bearing here

An earlier attempt on this branch hardcoded `go-version: "1.22"` and the job aborted while *loading* the first test binary, before any test ran:

```
dyld[7476]: missing LC_UUID load command in .../cli.test
signal: abort trap
```

Go 1.22.12 on darwin-arm64 links a Mach-O with no `LC_UUID` load command, which Apple's `dyld` refuses to load. That was a toolchain incompatibility, not a test failure. #173 has since moved the repo to `go 1.26`, so reading the version from `go.mod` — as every other `setup-go` step in this workflow now does — is what makes this job actually test the toolchain we ship.

## Verification

`go build`, `go vet`, and `go test ./...` are green locally. The race detector cannot run on the maintainer's machine (no gcc), so **this job is the only place darwin `-race` behavior is ever observed** — the green macOS run on this PR is itself the acceptance evidence.

Expect macOS to be the slow job in the run.