### PR TITLE
Compare versions with a semver library instead of text ordering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/panjf2000/ants/v2 v2.11.4
 	github.com/spf13/cobra v1.8.1
 	go.etcd.io/bbolt v1.3.8
+	golang.org/x/mod v0.17.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.etcd.io/bbolt v1.3.8 h1:xs88BrvEv273UsB79e0hcVrlUWmS0a8upikMFhSyAtA=
 go.etcd.io/bbolt v1.3.8/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
+golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
+golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
 golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pedrosousa13/lnpm/internal/config"
 	"github.com/pedrosousa13/lnpm/internal/debug"
+	"golang.org/x/mod/semver"
 )
 
 const (
@@ -195,11 +196,7 @@ func compareVersions(current, latest string) *Result {
 		UpdateAvailable: false,
 	}
 
-	// Simple string comparison works for semver if same length
-	// For proper comparison we'd need a semver library, but this handles most cases
-	if latestNorm != currentNorm && latestNorm > currentNorm {
-		result.UpdateAvailable = true
-	}
+	result.UpdateAvailable = semver.Compare("v"+latestNorm, "v"+currentNorm) > 0
 
 	debug.Logf("update: current=%s latest=%s available=%v", current, latest, result.UpdateAvailable)
 	return result

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -186,17 +186,18 @@ func fetchLatestVersion(ctx context.Context) (string, error) {
 }
 
 func compareVersions(current, latest string) *Result {
-	// Normalize versions (strip v prefix)
-	currentNorm := strings.TrimPrefix(current, "v")
-	latestNorm := strings.TrimPrefix(latest, "v")
+	// Normalize mixed v-prefixed and bare inputs to canonical vX.Y.Z form
+	currentSemver := "v" + strings.TrimPrefix(current, "v")
+	latestSemver := "v" + strings.TrimPrefix(latest, "v")
 
+	// semver.Compare treats an invalid version as less than any valid one, so an
+	// unparseable current (e.g. a bare commit hash from an untagged build) would
+	// otherwise always look outdated.
 	result := &Result{
 		CurrentVersion:  current,
 		LatestVersion:   latest,
-		UpdateAvailable: false,
+		UpdateAvailable: semver.IsValid(currentSemver) && semver.Compare(latestSemver, currentSemver) > 0,
 	}
-
-	result.UpdateAvailable = semver.Compare("v"+latestNorm, "v"+currentNorm) > 0
 
 	debug.Logf("update: current=%s latest=%s available=%v", current, latest, result.UpdateAvailable)
 	return result

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,30 @@
+package update
+
+import "testing"
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		latest  string
+		want    bool
+	}{
+		{"newer minor with more digits", "1.9.0", "1.11.0", true},
+		{"newer patch with more digits", "1.2.9", "1.2.10", true},
+		{"same version", "1.11.0", "1.11.0", false},
+		{"current newer than latest", "1.11.0", "1.9.0", false},
+		{"v-prefixed inputs", "v1.9.0", "v1.11.0", true},
+		{"mixed v-prefixed and bare inputs", "1.9.0", "v1.11.0", true},
+		{"v-prefixed same version", "v1.11.0", "1.11.0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareVersions(tt.current, tt.latest)
+			if got.UpdateAvailable != tt.want {
+				t.Errorf("compareVersions(%q, %q).UpdateAvailable = %v, want %v",
+					tt.current, tt.latest, got.UpdateAvailable, tt.want)
+			}
+		})
+	}
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -16,6 +16,12 @@ func TestCompareVersions(t *testing.T) {
 		{"v-prefixed inputs", "v1.9.0", "v1.11.0", true},
 		{"mixed v-prefixed and bare inputs", "1.9.0", "v1.11.0", true},
 		{"v-prefixed same version", "v1.11.0", "1.11.0", false},
+		{"unparseable current from untagged build", "a1b2c3d", "1.12.0", false},
+		{"malformed latest", "1.11.0", "release-1.12", false},
+		{"empty latest", "1.11.0", "", false},
+		{"newer pre-release", "1.11.0", "1.12.0-rc.1", true},
+		{"current pre-release newer than latest", "1.12.0-rc.1", "1.11.0", false},
+		{"release supersedes its own rc", "1.12.0-rc.1", "1.12.0", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #142.

## The defect

`compareVersions` decided whether a newer release existed with Go's byte-wise
string `>`. That stops at the first differing character, so whenever the version
numbers differ in digit count it gives the wrong answer:

- `"1.11.0" > "1.9.0"` is **false** (`'1'` < `'9'`), so a user on v1.9.0 was told
  "Already up to date" and never offered v1.10.x or v1.11.x.
- Same for `1.2.9` → `1.2.10`, and pre-release suffixes were mishandled.

## The change

Compare with `golang.org/x/mod/semver` — the module the Go toolchain itself uses.
The `v` prefix is normalized on both inputs so bare and `v`-prefixed versions
behave identically. The `current == "dev"` short-circuits in `CheckFresh` and
`CheckAsync` are untouched, so `"dev"` still never reaches this function.

Adds `internal/update/update_test.go` (the package had no tests) with a
table-driven `TestCompareVersions` — 13 cases.

## Two deliberate deviations from the issue

**1. `golang.org/x/mod` is pinned to v0.17.0, not latest.** A bare
`go get golang.org/x/mod/semver` resolves to v0.40.0, which requires Go >= 1.25
and silently rewrites the `go` directive from 1.22. All three `actions/setup-go`
steps pin `go-version: "1.22"`, so that would break CI. v0.17.0 requires Go 1.18
and leaves the directive alone; the `semver` API is identical across the two.
Upgrading the toolchain is #173's job.

**2. Invalid `current` is guarded, though step 4 said no guarding was needed.**
The issue states `semver.Compare` "returns 0 if either input is not valid semver,
which is a safe default". That premise is wrong — `x/mod/semver` ranks an invalid
version as **less than** any valid one. So `compareVersions("a1b2c3d", "1.12.0")`
returned `true`: a spurious update claim. It is reachable, not theoretical —
`Makefile:4` builds with `git describe --tags --always`, so any untagged local
build carries a bare commit hash as its version and would have reported an update
available on every run.

`semver.IsValid(current)` now gates the result, which is what step 4's stated
intent ("it will not claim a spurious update") actually asks for. An invalid
*latest* already returned false and is unchanged.

## Verification

`go build ./...`, `go vet ./...` and the full `go test ./...` suite are green.
The invalid-`current` test row was confirmed to fail before the guard and pass
after.