### PR TITLE
Report a real version for go install builds so they can self-update

### DIFF
--- a/cmd/lnpm/main.go
+++ b/cmd/lnpm/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"runtime/debug"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
 )
@@ -13,8 +14,21 @@ var (
 	Date    = "unknown"
 )
 
+// resolveVersion returns the version to report. Release builds are stamped via
+// ldflags, but `go install ...@version` is not, so fall back to the module
+// version Go embeds in the binary's build metadata.
+func resolveVersion() string {
+	if Version != "dev" {
+		return Version
+	}
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version
+	}
+	return "dev"
+}
+
 func main() {
-	cli.SetVersion(Version)
+	cli.SetVersion(resolveVersion())
 	if err := cli.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/lnpm/main.go
+++ b/cmd/lnpm/main.go
@@ -5,6 +5,8 @@ import (
 	"runtime/debug"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/semver"
 )
 
 // Version, Commit, and Date are set at build time via ldflags (see .goreleaser.yaml)
@@ -18,13 +20,33 @@ var (
 // ldflags, but `go install ...@version` is not, so fall back to the module
 // version Go embeds in the binary's build metadata.
 func resolveVersion() string {
-	if Version != "dev" {
-		return Version
+	info, ok := debug.ReadBuildInfo()
+	return pickVersion(Version, info, ok)
+}
+
+// pickVersion decides which version to report given the ldflags stamp and the
+// binary's embedded build info.
+//
+// Only a real released module version is accepted from the build info. Go >=
+// 1.24 stamps a VCS-derived pseudo-version (optionally suffixed "+dirty") into
+// a plain `go build` from a checkout; reporting that would make a local build
+// look like a release to the updater, which would then overwrite it with a
+// release tarball. Anything unrecognised falls through to "dev".
+func pickVersion(stamped string, info *debug.BuildInfo, ok bool) string {
+	if stamped != "dev" && stamped != "" {
+		return stamped
 	}
-	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
-		return info.Main.Version
+	if !ok {
+		return "dev"
 	}
-	return "dev"
+	v := info.Main.Version
+	if v == "" || v == "(devel)" || !semver.IsValid(v) {
+		return "dev"
+	}
+	if module.IsPseudoVersion(v) || semver.Build(v) != "" {
+		return "dev"
+	}
+	return v
 }
 
 func main() {

--- a/cmd/lnpm/main_test.go
+++ b/cmd/lnpm/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+func TestResolveVersion_StampedByLdflags(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{"v-prefixed release tag", "v1.11.0"},
+		{"bare release tag", "1.11.0"},
+		{"pre-release tag", "v1.12.0-rc.1"},
+	}
+
+	original := Version
+	t.Cleanup(func() { Version = original })
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Version = tt.version
+			if got := resolveVersion(); got != tt.version {
+				t.Errorf("resolveVersion() = %q, want %q", got, tt.version)
+			}
+		})
+	}
+}

--- a/cmd/lnpm/main_test.go
+++ b/cmd/lnpm/main_test.go
@@ -1,25 +1,40 @@
 package main
 
-import "testing"
+import (
+	"runtime/debug"
+	"testing"
+)
 
-func TestResolveVersion_StampedByLdflags(t *testing.T) {
+func buildInfo(version string) *debug.BuildInfo {
+	return &debug.BuildInfo{Main: debug.Module{Version: version}}
+}
+
+func TestPickVersion(t *testing.T) {
 	tests := []struct {
 		name    string
-		version string
+		stamped string
+		info    *debug.BuildInfo
+		ok      bool
+		want    string
 	}{
-		{"v-prefixed release tag", "v1.11.0"},
-		{"bare release tag", "1.11.0"},
-		{"pre-release tag", "v1.12.0-rc.1"},
+		{"v-prefixed release tag", "v1.11.0", nil, false, "v1.11.0"},
+		{"bare release tag", "1.11.0", nil, false, "1.11.0"},
+		{"pre-release tag", "v1.12.0-rc.1", nil, false, "v1.12.0-rc.1"},
+		{"unstamped with released module version", "dev", buildInfo("v1.11.0"), true, "v1.11.0"},
+		{"empty stamp with released module version", "", buildInfo("v1.11.0"), true, "v1.11.0"},
+		{"no build info", "dev", nil, false, "dev"},
+		{"empty module version", "dev", buildInfo(""), true, "dev"},
+		{"devel module version", "dev", buildInfo("(devel)"), true, "dev"},
+		{"pseudo-version", "dev", buildInfo("v1.12.1-0.20260819061412-6d9902254937"), true, "dev"},
+		{"dirty pseudo-version", "dev", buildInfo("v1.12.1-0.20260819061412-6d9902254937+dirty"), true, "dev"},
+		{"dirty release tag", "dev", buildInfo("v1.11.0+dirty"), true, "dev"},
+		{"non-semver module version", "dev", buildInfo("garbage"), true, "dev"},
 	}
-
-	original := Version
-	t.Cleanup(func() { Version = original })
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			Version = tt.version
-			if got := resolveVersion(); got != tt.version {
-				t.Errorf("resolveVersion() = %q, want %q", got, tt.version)
+			if got := pickVersion(tt.stamped, tt.info, tt.ok); got != tt.want {
+				t.Errorf("pickVersion(%q, %+v, %v) = %q, want %q", tt.stamped, tt.info, tt.ok, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #143.

## The defect

The release build stamps a version via ldflags, but `go install
github.com/pedrosousa13/lnpm/cmd/lnpm@latest` passes no ldflags, so `Version` kept
its source default of `"dev"`. For a supported, documented install path that meant:

1. `lnpm --version` printed `lnpm version dev`.
2. `lnpm update` refused to run, advising the user to run `go install` — which is
   exactly how they installed it.
3. The background update check was skipped, so no update notices ever appeared.

`installLatestViaGo` already handled these users correctly; the `"dev"` guard just
rejected the build before that path was reachable.

## The change

Fall back to the module version Go embeds in the binary's build metadata when
ldflags left the default in place. The `"dev"` guards themselves are untouched.

## One deliberate deviation from the issue

The issue's step 3 asserts that *"a bare `go build` from a local checkout still has
no module version and correctly stays `dev`"*, and concludes the fix *"only rescues
the `@version` install path"*.

That premise is false on **Go >= 1.24**, which stamps a VCS-derived pseudo-version
(e.g. `v1.12.1-0.20260819061412-6d9902254937`, sometimes `+dirty`) into a plain
`go build`. Implemented exactly as written, the fallback accepts it — `semver.IsValid`
returns true for pseudo-versions and ignores `+dirty` build metadata — so a local
development build reports itself as a release.

That is latent today only because the pseudo-version sorts above the current tag.
Once **any newer tag ships**, `compareVersions` reports an update available, the
binary passes the `"dev"` guard, and — because a local build is not in `GOPATH/bin`,
so `wasInstalledViaGo()` returns false — it falls through to `installLatestViaBinary()`.
A developer's working build would silently overwrite itself with a release tarball,
with update nag notices in the meantime.

CI would not have caught this: `go.mod` says `go 1.22` and all three `actions/setup-go`
steps pin `1.22`, where `go build` still yields `(devel)` → `dev`.

So the build-info fallback now accepts only a real released module version, rejecting
pseudo-versions (`module.IsPseudoVersion`) and any version carrying build metadata
(`semver.Build`). Anything unrecognised falls through to `"dev"`. This restores the
issue's stated intent rather than exceeding it. No new dependency: `golang.org/x/mod`
is already a direct requirement, and `go.mod`/`go.sum` are untouched by this PR.

Also aligned one edge: `resolveVersion` gated on `Version != "dev"`, but the three
downstream guards all treat `""` as unstamped too, so an empty ldflags stamp now
falls through to the same fallback.

## Verification

The decision logic is extracted into a pure `pickVersion(stamped, info, ok)` so every
branch is directly testable; `cmd/lnpm` coverage goes 25% → 66.7% (the remainder is
`main()` and the wrapper, which have no branching left). `TestPickVersion` has 12 rows,
including the pseudo-version, `+dirty` and non-semver cases — all confirmed failing
before the guard and passing after.

Real binaries, verified locally on go1.24.2:

| build | `--version` |
|---|---|
| `go build` | `dev` (was a pseudo-version) |
| `go build -buildvcs=false` | `dev` |
| `go build -ldflags "-X main.Version=v9.9.9"` | `v9.9.9` |

`go build ./...`, `go vet ./...` and the full `go test ./...` suite are green.

**Not verified end-to-end:** acceptance criterion 1 names a real
`go install ...@latest`, which cannot be exercised until this lands and a release is
cut — installing `@latest` today fetches the published code, not this branch. The
issue's suggested local proxy (`go install ./cmd/lnpm`) is no longer equivalent on
Go >= 1.24: it is a VCS build, so it now correctly reports `dev`. The `@version`
path is covered instead by the `"dev"` + `v1.11.0` unit-test row, which is the exact
input `ReadBuildInfo` yields for a tagged install.