### PR TITLE
Verify release checksums in the install scripts before running the binary

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -72,17 +72,17 @@ try {
     $Actual = (Get-FileHash -Algorithm SHA256 -Path $ZipPath).Hash
     # goreleaser writes "<hex>  <filename>", one entry per line.
     $Expected = $null
-    foreach ($line in Get-Content $ChecksumsPath) {
-        $fields = $line -split '\s+' | Where-Object { $_ -ne "" }
-        if ($fields.Count -eq 2 -and $fields[1] -eq $Filename) {
-            $Expected = $fields[0]
+    foreach ($Line in Get-Content $ChecksumsPath) {
+        $Fields = $Line -split '\s+' | Where-Object { $_ -ne "" }
+        if ($Fields.Count -eq 2 -and $Fields[1] -eq $Filename) {
+            $Expected = $Fields[0]
             break
         }
     }
     if (-not $Expected) {
         Write-Err "No checksum listed for $Filename in checksums.txt"
     }
-    if (-not ($Expected -ieq $Actual)) {
+    if ($Expected -ine $Actual) {
         Write-Err "Checksum mismatch for $Filename - the download is corrupted or was altered"
     }
     Write-Ok "Checksum verified"

--- a/install.ps1
+++ b/install.ps1
@@ -61,6 +61,32 @@ try {
     Write-Info "Downloading from $Url..."
     Invoke-WebRequest -Uri $Url -OutFile $ZipPath -UseBasicParsing
 
+    # Verify before extracting. checksums.txt comes from the same release as the
+    # archive, so this catches a corrupted download or an archive altered in
+    # transit - not a release where an attacker replaced both files.
+    Write-Info "Verifying checksum..."
+    $ChecksumsUrl = "https://github.com/$Repo/releases/download/v$Version/checksums.txt"
+    $ChecksumsPath = Join-Path $TmpDir "checksums.txt"
+    Invoke-WebRequest -Uri $ChecksumsUrl -OutFile $ChecksumsPath -UseBasicParsing
+
+    $Actual = (Get-FileHash -Algorithm SHA256 -Path $ZipPath).Hash
+    # goreleaser writes "<hex>  <filename>", one entry per line.
+    $Expected = $null
+    foreach ($line in Get-Content $ChecksumsPath) {
+        $fields = $line -split '\s+' | Where-Object { $_ -ne "" }
+        if ($fields.Count -eq 2 -and $fields[1] -eq $Filename) {
+            $Expected = $fields[0]
+            break
+        }
+    }
+    if (-not $Expected) {
+        Write-Err "No checksum listed for $Filename in checksums.txt"
+    }
+    if (-not ($Expected -ieq $Actual)) {
+        Write-Err "Checksum mismatch for $Filename - the download is corrupted or was altered"
+    }
+    Write-Ok "Checksum verified"
+
     Write-Info "Extracting..."
     Expand-Archive -Path $ZipPath -DestinationPath $TmpDir -Force
 

--- a/install.sh
+++ b/install.sh
@@ -45,27 +45,34 @@ error() {
 # checksums.txt comes from the same release as the archive, so this catches a
 # corrupted download or an archive altered in transit - not a release where an
 # attacker replaced both files.
+# sh has no 'local', so the variables below are prefixed to keep them scoped to
+# this helper by convention.
 verify_checksum() {
-    dir="$1"
-    file="$2"
+    VC_DIR="$1"
+    VC_FILE="$2"
 
     if command -v sha256sum >/dev/null 2>&1; then
-        sha_cmd="sha256sum"
+        VC_SHA_CMD="sha256sum"
     elif command -v shasum >/dev/null 2>&1; then
-        sha_cmd="shasum -a 256"
+        VC_SHA_CMD="shasum -a 256"
     else
         error "sha256sum or shasum is required to verify the download"
     fi
 
-    # goreleaser writes "<hex>  <filename>", one entry per line.
-    entry=$(awk -v f="$file" '$2 == f { print; exit }' "$dir/checksums.txt")
-    if [ -z "$entry" ]; then
-        error "No checksum listed for $file in checksums.txt"
+    if [ ! -r "$VC_DIR/checksums.txt" ]; then
+        error "checksums.txt is missing or unreadable"
     fi
 
-    # sha_cmd is unquoted on purpose: it may carry arguments.
-    if ! printf '%s\n' "$entry" | (cd "$dir" && $sha_cmd -c -) >/dev/null 2>&1; then
-        error "Checksum mismatch for $file - the download is corrupted or was altered"
+    # goreleaser writes "<hex>  <filename>", one entry per line. The CR is
+    # stripped so a CRLF checksums.txt both matches here and hashes below.
+    VC_ENTRY=$(awk -v f="$VC_FILE" '{ sub(/\r$/, "") } $2 == f { print; exit }' "$VC_DIR/checksums.txt")
+    if [ -z "$VC_ENTRY" ]; then
+        error "No checksum listed for $VC_FILE in checksums.txt"
+    fi
+
+    # VC_SHA_CMD is unquoted on purpose: it may carry arguments.
+    if ! printf '%s\n' "$VC_ENTRY" | (cd "$VC_DIR" && $VC_SHA_CMD -c -) >/dev/null 2>&1; then
+        error "Checksum mismatch for $VC_FILE - the download is corrupted or was altered"
     fi
 }
 
@@ -141,8 +148,7 @@ install() {
         wget -q "$CHECKSUMS_URL" -O "$TMP_DIR/checksums.txt" || error "Failed to download checksums.txt"
     fi
 
-    # Verify before extracting - a corrupted or altered archive must never
-    # reach the user's PATH.
+    # Verify before extracting
     info "Verifying checksum..."
     verify_checksum "$TMP_DIR" "$FILENAME"
     success "Checksum verified"

--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,34 @@ error() {
     exit 1
 }
 
+# Verify the archive's SHA-256 against the release checksums.txt.
+# checksums.txt comes from the same release as the archive, so this catches a
+# corrupted download or an archive altered in transit - not a release where an
+# attacker replaced both files.
+verify_checksum() {
+    dir="$1"
+    file="$2"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha_cmd="sha256sum"
+    elif command -v shasum >/dev/null 2>&1; then
+        sha_cmd="shasum -a 256"
+    else
+        error "sha256sum or shasum is required to verify the download"
+    fi
+
+    # goreleaser writes "<hex>  <filename>", one entry per line.
+    entry=$(awk -v f="$file" '$2 == f { print; exit }' "$dir/checksums.txt")
+    if [ -z "$entry" ]; then
+        error "No checksum listed for $file in checksums.txt"
+    fi
+
+    # sha_cmd is unquoted on purpose: it may carry arguments.
+    if ! printf '%s\n' "$entry" | (cd "$dir" && $sha_cmd -c -) >/dev/null 2>&1; then
+        error "Checksum mismatch for $file - the download is corrupted or was altered"
+    fi
+}
+
 # Detect OS
 detect_os() {
     case "$(uname -s)" in
@@ -96,6 +124,7 @@ install() {
     fi
 
     URL="https://github.com/${REPO}/releases/download/v${VERSION}/${FILENAME}"
+    CHECKSUMS_URL="https://github.com/${REPO}/releases/download/v${VERSION}/checksums.txt"
 
     # Create temp directory
     TMP_DIR=$(mktemp -d)
@@ -106,9 +135,17 @@ install() {
     # Download
     if command -v curl >/dev/null 2>&1; then
         curl -fsSL "$URL" -o "$TMP_DIR/$FILENAME" || error "Download failed"
+        curl -fsSL "$CHECKSUMS_URL" -o "$TMP_DIR/checksums.txt" || error "Failed to download checksums.txt"
     else
         wget -q "$URL" -O "$TMP_DIR/$FILENAME" || error "Download failed"
+        wget -q "$CHECKSUMS_URL" -O "$TMP_DIR/checksums.txt" || error "Failed to download checksums.txt"
     fi
+
+    # Verify before extracting - a corrupted or altered archive must never
+    # reach the user's PATH.
+    info "Verifying checksum..."
+    verify_checksum "$TMP_DIR" "$FILENAME"
+    success "Checksum verified"
 
     # Extract
     info "Extracting..."


### PR DESCRIPTION
Closes #146.

## The defect

Users install by piping a script into their shell — `curl -fsSL .../install.sh | sh`,
or `irm .../install.ps1 | iex`. Both scripts downloaded the release archive, extracted
it, and copied the binary onto the user's `PATH` with **no integrity check at all**.
A corrupted download (truncated transfer, a partially-uploaded release asset) or one
altered in transit (a TLS-intercepting proxy, a MITM on a compromised network) was
extracted and installed, and the script reported "Installation complete!".

Every release already publishes `checksums.txt`, and the Go self-updater already
verifies against it. Only the install scripts did not.

## The change

Both installers now verify the archive's SHA-256 against the release's `checksums.txt`
**before** extracting, aborting non-zero on a mismatch or a missing entry.

- `install.sh` gets a `verify_checksum` helper that probes `sha256sum`, then
  `shasum -a 256` — covering Linux and macOS — via the same `command -v` pattern the
  script already uses for curl/wget, and errors if neither is available rather than
  installing unverified.
- `install.ps1` verifies with `Get-FileHash -Algorithm SHA256` and compares
  case-insensitively, since goreleaser writes lowercase hex and `Get-FileHash` returns
  uppercase.
- Both print `Checksum verified` on success and reuse the existing `error()` /
  `Write-Err` helpers, so the existing `trap` / `finally` temp-directory cleanup still
  fires on every path.

### Scope, stated honestly

`checksums.txt` is fetched from the same GitHub release as the archive. Verifying
against it catches download corruption and in-transit tampering **of the archive
alone** — not a fully compromised release channel where an attacker replaces both
files. This matches what the self-updater already enforces and does not claim to
defend against a compromised publisher. Signing release artifacts is #195.

## Two defects found in review and fixed here

1. **A CRLF `checksums.txt` would have bricked `install.sh`.** The issue says to mirror
   the Go updater, and Go's `strings.Fields` treats `\r` as whitespace, so `findChecksum`
   matches. `awk '$2 == f'` saw `lnpm_..._amd64.tar.gz\r` and did not, so a legitimate
   release would have aborted as though the entry were absent. It failed closed, so it
   was safe rather than dangerous — but it was a real divergence, and `install.ps1` did
   *not* share it (`Get-Content` strips CRLF), so the two installers disagreed. The CR
   is now stripped before both the match and the hash check.
2. **A missing `checksums.txt` bypassed `error()`.** Because a bare assignment takes its
   command substitution's status, `set -e` aborted at `VC_ENTRY=$(awk ...)` with a raw
   `awk: fatal: cannot open file` and **exit 2** — no `[ERROR]` prefix, wrong exit code,
   unlike every other failure in the script. Now guarded explicitly.

## Verification

The scripts are not Go, so there is no `go test` coverage. `verify_checksum` was driven
directly against local fixtures in `/tmp` — a real `.tar.gz` plus a goreleaser-format
`checksums.txt` — with nothing downloaded and nothing written to any `PATH` directory:

| Case | Result |
|---|---|
| LF `checksums.txt`, matching | `[OK] Checksum verified`, exit 0 |
| **CRLF `checksums.txt`, matching** | exit 0 (failed before fix 1) |
| corrupted archive (byte flipped) | `[ERROR] Checksum mismatch...`, exit 1, extraction never reached |
| no entry for the filename | `[ERROR] No checksum listed...`, exit 1 |
| **missing `checksums.txt`** | `[ERROR] checksums.txt is missing or unreadable`, exit 1 (was raw `awk: fatal`, exit 2) |
| neither `sha256sum` nor `shasum` on `PATH` | `[ERROR] sha256sum or shasum is required...`, exit 1 |
| suffix-collision entry listed first with an all-zeros hash | still matches exactly, exit 0 |

The matching, CRLF and corrupted cases were re-run under a `PATH` containing only
`shasum`, `awk` and `cat`, so the macOS branch is genuinely exercised, not just reasoned
about. `sh -n`, `dash -n` and `bash -n` all pass. Temp-dir cleanup was confirmed to fire
on the abort path.

**Not verified by execution:** `install.ps1` was reviewed statically only — there is no
`pwsh` on the machine this was developed on, so its changes rest on inspection rather
than a run, and are worth a manual check on Windows. `shellcheck` is likewise not
installed, so the POSIX portability the issue asks it to confirm was reasoned manually
(no `[[`, `local`, arrays, `==` inside `[`, `$'...'`, or `pipefail`) and backed by the
three syntax checks above. The real end-to-end download path was deliberately not run,
since it installs a binary onto the machine's `PATH`.