### PR TITLE
Codify gitignore and npmignore semantics for isExcluded

### DIFF
--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -115,12 +115,12 @@ func TestIsExcluded(t *testing.T) {
 
 // TestIsExcludedGitignoreSemantics covers the gitignore/npmignore pattern forms
 // whose expected value the current matcher happens to produce. It produces them
-// by matching nothing at all, not by handling the pattern: "dist/" and "/dist"
-// both contain a "/", so they take the full-path glob branch and then the
-// pattern+"/" prefix check, and neither can ever match. Every case here would
-// pass just as well against a matcher that always returned false. They are
-// recorded so the contract sits in one place and so they turn red if a later
-// change regresses them.
+// by accident, not by handling the pattern: "dist/" and "/dist" both contain a
+// "/", so they take the full-path glob branch and then the pattern+"/" prefix
+// check, and neither can ever match; the negation case comes out right only
+// because "dist/*" matches a sibling that should be excluded anyway, with the
+// "!" pattern skipped. They are recorded so the contract sits in one place and
+// so they turn red if a later change regresses them.
 //
 // Its counterpart, TestIsExcludedGitignoreSemanticsPending, holds the cases the
 // current matcher cannot satisfy. The two together are the contract for the
@@ -141,8 +141,11 @@ func TestIsExcludedGitignoreSemantics(t *testing.T) {
 		{"src/dist/index.js", []string{"/dist"}, false},
 
 		// Negation: the last matching pattern wins, so "!dist/keep.js"
-		// re-includes a file that "dist/" excluded.
-		{"dist/keep.js", []string{"dist/", "!dist/keep.js"}, false},
+		// re-includes a file that "dist/*" excluded, while its siblings stay
+		// excluded. The pattern is "dist/*" and not "dist/" because a trailing
+		// slash prunes the directory outright, and nothing beneath a pruned
+		// directory can be re-included.
+		{"dist/drop.js", []string{"dist/*", "!dist/keep.js"}, true},
 	}
 
 	for _, tt := range tests {
@@ -182,10 +185,13 @@ func TestIsExcludedGitignoreSemanticsPending(t *testing.T) {
 		{"credentials.json", []string{"/credentials.json"}, true},
 		{"dist/index.js", []string{"/dist"}, true},
 
-		// Negation: the last matching pattern wins. isExcluded skips "!"
-		// patterns entirely, so it cannot distinguish a re-included file from
-		// its excluded siblings.
-		{"dist/drop.js", []string{"dist/", "!dist/keep.js"}, true},
+		// Negation: the last matching pattern wins, so "!dist/keep.js"
+		// re-includes a file that "dist/*" excluded. isExcluded skips "!"
+		// patterns entirely, so keep.js stays excluded with its siblings. The
+		// pattern is "dist/*" and not "dist/" because a trailing slash prunes
+		// the directory outright, and nothing beneath a pruned directory can be
+		// re-included.
+		{"dist/keep.js", []string{"dist/*", "!dist/keep.js"}, false},
 	}
 
 	for _, tt := range tests {

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -113,6 +113,89 @@ func TestIsExcluded(t *testing.T) {
 	}
 }
 
+// TestIsExcludedGitignoreSemantics covers the gitignore/npmignore pattern forms
+// that isExcluded already handles correctly. Its counterpart,
+// TestIsExcludedGitignoreSemanticsPending, holds the cases the current matcher
+// cannot satisfy. The two together are the contract for the isExcluded rewrite
+// in #150; they are split only so the suite stays green today.
+func TestIsExcludedGitignoreSemantics(t *testing.T) {
+	tests := []struct {
+		path     string
+		patterns []string
+		want     bool
+	}{
+		// Trailing slash: "dist/" excludes the dist directory and its contents,
+		// and nothing else.
+		{"src/index.ts", []string{"dist/"}, false},
+
+		// Leading slash anchors the pattern to the package root, so a nested
+		// "dist" further down the tree is not matched.
+		{"src/dist/index.js", []string{"/dist"}, false},
+
+		// Negation: the last matching pattern wins, so "!dist/keep.js"
+		// re-includes a file that "dist/" excluded.
+		// NOTE: this passes today only because "dist/" itself matches nothing
+		// (see TestIsExcludedGitignoreSemanticsPending). Once #150 makes
+		// trailing-slash patterns work, negation must land with it or this
+		// case turns red.
+		{"dist/keep.js", []string{"dist/", "!dist/keep.js"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := isExcluded(tt.path, tt.patterns)
+			if got != tt.want {
+				t.Errorf("isExcluded(%q, %v) = %v, want %v", tt.path, tt.patterns, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsExcludedGitignoreSemanticsPending records the gitignore/npmignore
+// pattern forms isExcluded silently ignores today: every case here fails
+// against the current matcher. The expected values describe correct gitignore
+// semantics, not current behaviour.
+func TestIsExcludedGitignoreSemanticsPending(t *testing.T) {
+	t.Skip("pending isExcluded rewrite — see #150")
+
+	tests := []struct {
+		path     string
+		patterns []string
+		want     bool
+	}{
+		// Trailing slash: "dist/" excludes the dist directory and everything
+		// under it. isExcluded never strips the trailing slash, so the pattern
+		// matches nothing.
+		// CAVEAT on {"dist", ...}: in git a trailing slash matches directories
+		// only, and isExcluded is given no signal about whether relPath is a
+		// directory (pack.go passes only the path). This case therefore assumes
+		// "dist" is a directory; a plain *file* named "dist" would not be
+		// matched by git. #150 has to decide how to carry that signal.
+		{"dist/index.js", []string{"dist/"}, true},
+		{"dist", []string{"dist/"}, true},
+
+		// Leading slash anchors the pattern to the package root. isExcluded
+		// never strips it, so "/credentials.json" matches nothing and the file
+		// is copied into the shared store.
+		{"credentials.json", []string{"/credentials.json"}, true},
+		{"dist/index.js", []string{"/dist"}, true},
+
+		// Negation: the last matching pattern wins. isExcluded skips "!"
+		// patterns entirely, so it cannot distinguish a re-included file from
+		// its excluded siblings.
+		{"dist/drop.js", []string{"dist/", "!dist/keep.js"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := isExcluded(tt.path, tt.patterns)
+			if got != tt.want {
+				t.Errorf("isExcluded(%q, %v) = %v, want %v", tt.path, tt.patterns, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsIncluded(t *testing.T) {
 	tests := []struct {
 		path     string

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -114,10 +114,18 @@ func TestIsExcluded(t *testing.T) {
 }
 
 // TestIsExcludedGitignoreSemantics covers the gitignore/npmignore pattern forms
-// that isExcluded already handles correctly. Its counterpart,
-// TestIsExcludedGitignoreSemanticsPending, holds the cases the current matcher
-// cannot satisfy. The two together are the contract for the isExcluded rewrite
-// in #150; they are split only so the suite stays green today.
+// whose expected value the current matcher happens to produce. It produces them
+// by matching nothing at all, not by handling the pattern: "dist/" and "/dist"
+// both contain a "/", so they take the full-path glob branch and then the
+// pattern+"/" prefix check, and neither can ever match. Every case here would
+// pass just as well against a matcher that always returned false. They are
+// recorded so the contract sits in one place and so they turn red if a later
+// change regresses them.
+//
+// Its counterpart, TestIsExcludedGitignoreSemanticsPending, holds the cases the
+// current matcher cannot satisfy. The two together are the contract for the
+// isExcluded rewrite in #150; they are split only so the suite stays green
+// today.
 func TestIsExcludedGitignoreSemantics(t *testing.T) {
 	tests := []struct {
 		path     string
@@ -134,10 +142,6 @@ func TestIsExcludedGitignoreSemantics(t *testing.T) {
 
 		// Negation: the last matching pattern wins, so "!dist/keep.js"
 		// re-includes a file that "dist/" excluded.
-		// NOTE: this passes today only because "dist/" itself matches nothing
-		// (see TestIsExcludedGitignoreSemanticsPending). Once #150 makes
-		// trailing-slash patterns work, negation must land with it or this
-		// case turns red.
 		{"dist/keep.js", []string{"dist/", "!dist/keep.js"}, false},
 	}
 
@@ -154,9 +158,9 @@ func TestIsExcludedGitignoreSemantics(t *testing.T) {
 // TestIsExcludedGitignoreSemanticsPending records the gitignore/npmignore
 // pattern forms isExcluded silently ignores today: every case here fails
 // against the current matcher. The expected values describe correct gitignore
-// semantics, not current behaviour.
+// semantics, not current behavior.
 func TestIsExcludedGitignoreSemanticsPending(t *testing.T) {
-	t.Skip("pending isExcluded rewrite — see #150")
+	t.Skip("pending isExcluded rewrite - see #150")
 
 	tests := []struct {
 		path     string
@@ -166,11 +170,9 @@ func TestIsExcludedGitignoreSemanticsPending(t *testing.T) {
 		// Trailing slash: "dist/" excludes the dist directory and everything
 		// under it. isExcluded never strips the trailing slash, so the pattern
 		// matches nothing.
-		// CAVEAT on {"dist", ...}: in git a trailing slash matches directories
-		// only, and isExcluded is given no signal about whether relPath is a
-		// directory (pack.go passes only the path). This case therefore assumes
-		// "dist" is a directory; a plain *file* named "dist" would not be
-		// matched by git. #150 has to decide how to carry that signal.
+		// CAVEAT on {"dist", ...}: git's trailing slash matches directories
+		// only, and isExcluded gets no directory signal, so this case assumes
+		// "dist" is a directory.
 		{"dist/index.js", []string{"dist/"}, true},
 		{"dist", []string{"dist/"}, true},
 


### PR DESCRIPTION
Closes #149. Test-only — `isExcluded` is unchanged; the fix is #150.

## Why

`lnpm publish` decides which files to copy into the shared store at `~/.lnpm` — which
is then linked into every project on the machine that consumes the package — by calling
`isExcluded(relPath, patterns)`. It implements only a subset of `.gitignore` /
`.npmignore` syntax, so several common patterns silently match nothing.

The motivating case: a developer puts `credentials.json` at the package root and adds
`/credentials.json` to `.npmignore`. The matcher never strips the leading `/`, so the
pattern matches nothing, the file is copied into the shared store and linked into every
consuming project, and the developer gets no signal their ignore rule did nothing.

This PR pins down the intended semantics as a table-driven suite. Cases the current
matcher cannot satisfy are behind `t.Skip`, so the suite is green today and becomes the
acceptance target for #150.

## The split

- `TestIsExcludedGitignoreSemantics` — cases whose expected value the current matcher
  already produces. The doc comment is explicit that most of them produce it by matching
  *nothing at all* rather than by handling the pattern, so they guard against regression
  rather than proving correctness.
- `TestIsExcludedGitignoreSemanticsPending` — the five cases the current matcher fails,
  skipped pending #150.

Which case sits in which was determined by running every case unskipped against the
current `isExcluded`, not by assumption.

## Correction to the issue's negation cases

The issue specified:

```go
{"dist/keep.js", []string{"dist/", "!dist/keep.js"}, false},
{"dist/drop.js", []string{"dist/", "!dist/keep.js"}, true},
```

Those expected values are not achievable with those patterns. Verified by running the
real tools rather than reasoning about them:

| patterns | `git check-ignore` | `npm pack --dry-run` (npm 11.16.0) |
|---|---|---|
| `dist/` + `!dist/keep.js` | **both** ignored | **both** packed |
| `dist/*` + `!dist/keep.js` | keep.js re-included, drop.js ignored | keep.js packed, drop.js excluded |

A trailing-slash pattern prunes the whole directory, so git never descends into it and
nothing beneath it can be re-included. `dist/*` matches the *entries*, so a later `!`
can re-include one. With `dist/*`, git and npm **agree**, and together they produce
exactly the expected values the issue wanted.

So the issue's expected values were right and its patterns were wrong. Both negation
cases now use `dist/*`, with paths and expected values unchanged.

No `dist/` + `!...` assertion was added in either direction: git ignores both files and
npm packs both, so that combination is a genuine open product decision for #150, not
something this suite should assert. It is recorded on #150.

## Known caveat for #150

`{"dist", []string{"dist/"}, true}` is only conditionally correct. In git a trailing
slash matches **directories only**, so a plain *file* named `dist` would not be excluded.
`isExcluded` receives no directory signal — its caller in `pack.go` has `info.IsDir()` in
hand and uses it two lines later, but does not thread it through. #150 will have to
either extend the signature or accept that trailing-slash patterns also match same-named
files. The case is documented inline and left at the issue's expected value.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l` clean; full `go test ./...` green.
`TestIsExcluded` is byte-for-byte unchanged — the diff is additions only (91 insertions,
0 deletions). The pending test reports SKIP, never FAIL.