### PR TITLE
Rewrite isExcluded to satisfy gitignore and npm ignore semantics

### DIFF
--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -307,49 +307,91 @@ func readIgnoreFile(path string) []string {
 	return patterns
 }
 
-// isExcluded checks if a path matches any exclude pattern
+// isExcluded checks if a path matches any exclude pattern.
+//
+// It follows gitignore semantics: every pattern is evaluated and the last one
+// that matches decides the outcome, so a later "!pattern" re-includes a path an
+// earlier pattern excluded. collectFiles appends defaultExcludes after the
+// user's patterns, which is what keeps a user negation from re-including a
+// default-excluded path such as .env or node_modules.
 func isExcluded(relPath string, patterns []string) bool {
 	baseName := filepath.Base(relPath)
+	excluded := false
 
 	for _, pattern := range patterns {
-		// Handle negation patterns
-		if strings.HasPrefix(pattern, "!") {
-			continue // Skip negation for now
+		// A leading "!" negates: a match un-excludes the path.
+		negated := strings.HasPrefix(pattern, "!")
+		if negated {
+			pattern = pattern[1:]
 		}
 
-		// Handle ** patterns (common in .gitignore)
-		if strings.HasSuffix(pattern, "/**") {
-			prefix := strings.TrimSuffix(pattern, "/**")
-			if relPath == prefix || strings.HasPrefix(relPath, prefix+"/") {
-				return true
+		// A leading "/" anchors the pattern to the package root, so it is
+		// matched against the full relative path only, never the basename.
+		anchored := strings.HasPrefix(pattern, "/")
+		if anchored {
+			pattern = pattern[1:]
+		}
+
+		// A trailing "/" marks a directory pattern: it matches the directory
+		// itself and everything under it.
+		//
+		// Limitation: git's trailing slash matches directories only, but
+		// isExcluded receives no directory signal, so a plain *file* named
+		// "dist" is also matched by "dist/". Threading an isDir flag through
+		// the signature is out of scope here.
+		if strings.HasSuffix(pattern, "/") {
+			dir := strings.TrimSuffix(pattern, "/")
+			if dir == "" {
+				continue
+			}
+			if relPath == dir || strings.HasPrefix(relPath, dir+"/") {
+				excluded = !negated
 			}
 			continue
 		}
 
-		// Exact match
-		if pattern == relPath {
+		if pattern == "" {
+			continue
+		}
+
+		if matchesIgnorePattern(relPath, baseName, pattern, anchored) {
+			excluded = !negated
+		}
+	}
+
+	return excluded
+}
+
+// matchesIgnorePattern reports whether relPath matches a single ignore pattern
+// that has already had its "!", leading "/" and trailing "/" stripped.
+func matchesIgnorePattern(relPath, baseName, pattern string, anchored bool) bool {
+	// "dir/**" matches the directory and everything under it.
+	if strings.HasSuffix(pattern, "/**") {
+		prefix := strings.TrimSuffix(pattern, "/**")
+		return relPath == prefix || strings.HasPrefix(relPath, prefix+"/")
+	}
+
+	// Exact match
+	if pattern == relPath {
+		return true
+	}
+
+	if !anchored && !strings.Contains(pattern, "/") {
+		// For unanchored patterns without path separators, also match against
+		// the basename. This follows gitignore behavior: "*.log" matches
+		// "foo/bar.log".
+		if matched, _ := filepath.Match(pattern, baseName); matched {
 			return true
 		}
-
-		// For patterns without path separators, also match against basename
-		// This follows gitignore behavior: "*.log" matches "foo/bar.log"
-		if !strings.Contains(pattern, "/") {
-			if matched, _ := filepath.Match(pattern, baseName); matched {
-				return true
-			}
-		} else {
-			// Full path glob match
-			if matched, _ := filepath.Match(pattern, relPath); matched {
-				return true
-			}
-		}
-
-		// Directory prefix match
-		if strings.HasPrefix(relPath, pattern+"/") {
+	} else {
+		// Full path glob match
+		if matched, _ := filepath.Match(pattern, relPath); matched {
 			return true
 		}
 	}
-	return false
+
+	// Directory prefix match: "node_modules" excludes "node_modules/foo".
+	return strings.HasPrefix(relPath, pattern+"/")
 }
 
 // isIncluded checks if a path matches any include pattern (files field)

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -178,6 +178,9 @@ func collectFiles(packageDir string, filesField []string) ([]*FileInfo, error) {
 		// Check if excluded
 		if isExcluded(relPath, ignorePatterns) {
 			if info.IsDir() {
+				// Pruning is the one place last-match-wins does not hold end
+				// to end: the walk never descends, so a later "!" pattern
+				// inside this directory is never consulted.
 				return filepath.SkipDir
 			}
 			return nil
@@ -333,7 +336,9 @@ func isExcluded(relPath string, patterns []string) bool {
 		}
 
 		// A trailing "/" marks a directory pattern: it matches the directory
-		// itself and everything under it.
+		// itself and everything under it. A negated one matches the directory
+		// only, never its contents, because git cannot re-include a file whose
+		// parent directory is excluded.
 		//
 		// Limitation: git's trailing slash matches directories only, but
 		// isExcluded receives no directory signal, so a plain *file* named
@@ -344,7 +349,7 @@ func isExcluded(relPath string, patterns []string) bool {
 			if dir == "" {
 				continue
 			}
-			if relPath == dir || strings.HasPrefix(relPath, dir+"/") {
+			if relPath == dir || (!negated && strings.HasPrefix(relPath, dir+"/")) {
 				excluded = !negated
 			}
 			continue
@@ -354,7 +359,7 @@ func isExcluded(relPath string, patterns []string) bool {
 			continue
 		}
 
-		if matchesIgnorePattern(relPath, baseName, pattern, anchored) {
+		if matchesIgnorePattern(relPath, baseName, pattern, anchored, negated) {
 			excluded = !negated
 		}
 	}
@@ -363,12 +368,19 @@ func isExcluded(relPath string, patterns []string) bool {
 }
 
 // matchesIgnorePattern reports whether relPath matches a single ignore pattern
-// that has already had its "!", leading "/" and trailing "/" stripped.
-func matchesIgnorePattern(relPath, baseName, pattern string, anchored bool) bool {
+// that has already had its "!" and leading "/" stripped. Directory patterns
+// (a trailing "/") never reach here: isExcluded handles them inline.
+//
+// negated says the "!" was there. It only ever narrows the match: a negated
+// pattern matches the paths it names directly, but not the paths merely
+// underneath a directory it names, because git cannot re-include a file whose
+// parent directory is excluded. A positive pattern keeps that reach, since git
+// ignores everything inside an ignored directory.
+func matchesIgnorePattern(relPath, baseName, pattern string, anchored, negated bool) bool {
 	// "dir/**" matches the directory and everything under it.
 	if strings.HasSuffix(pattern, "/**") {
 		prefix := strings.TrimSuffix(pattern, "/**")
-		return relPath == prefix || strings.HasPrefix(relPath, prefix+"/")
+		return relPath == prefix || (!negated && strings.HasPrefix(relPath, prefix+"/"))
 	}
 
 	// Exact match
@@ -391,7 +403,7 @@ func matchesIgnorePattern(relPath, baseName, pattern string, anchored bool) bool
 	}
 
 	// Directory prefix match: "node_modules" excludes "node_modules/foo".
-	return strings.HasPrefix(relPath, pattern+"/")
+	return !negated && strings.HasPrefix(relPath, pattern+"/")
 }
 
 // isIncluded checks if a path matches any include pattern (files field)

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -163,8 +163,6 @@ func TestIsExcludedGitignoreSemantics(t *testing.T) {
 // against the current matcher. The expected values describe correct gitignore
 // semantics, not current behavior.
 func TestIsExcludedGitignoreSemanticsPending(t *testing.T) {
-	t.Skip("pending isExcluded rewrite - see #150")
-
 	tests := []struct {
 		path     string
 		patterns []string
@@ -326,6 +324,247 @@ func TestPack(t *testing.T) {
 	for _, name := range excludedFiles {
 		if fileNames[name] {
 			t.Errorf("expected file %q to be excluded", name)
+		}
+	}
+}
+
+// TestPackNpmignoreGitignoreSemantics packs a real package whose .npmignore
+// uses the pattern forms #150 added: a root-anchored "/credentials.json", a
+// trailing-slash directory "dist/", and a negation "!dist/keep.js".
+func TestPackNpmignoreGitignoreSemantics(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pkgJSON := `{
+		"name": "ignore-semantics",
+		"version": "1.0.0"
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(pkgJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	npmignore := "/credentials.json\ndist/\n!dist/keep.js\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, ".npmignore"), []byte(npmignore), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "credentials.json"), []byte(`{"token":"x"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "index.js"), []byte("module.exports = {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	distDir := filepath.Join(tmpDir, "dist")
+	if err := os.MkdirAll(distDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(distDir, "keep.js"), []byte("keep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(distDir, "drop.js"), []byte("drop"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A nested credentials.json proves "/credentials.json" is anchored to the
+	// package root and does not exclude the same name further down the tree.
+	nestedDir := filepath.Join(tmpDir, "src")
+	if err := os.MkdirAll(nestedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDir, "credentials.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, files, err := Pack(tmpDir)
+	if err != nil {
+		t.Fatalf("Pack() error: %v", err)
+	}
+
+	packed := make(map[string]bool)
+	for _, f := range files {
+		packed[f.RelPath] = true
+	}
+
+	for _, name := range []string{"package.json", "index.js", "src/credentials.json"} {
+		if !packed[name] {
+			t.Errorf("expected file %q to be packed, got %v", name, files)
+		}
+	}
+	for _, name := range []string{"credentials.json", "dist/drop.js", ".npmignore"} {
+		if packed[name] {
+			t.Errorf("expected file %q to be excluded", name)
+		}
+	}
+
+	// "dist/" + "!dist/keep.js" is the one combination where git and npm
+	// disagree: git prunes the whole directory and never reconsiders keep.js,
+	// npm packs both files. lnpm lands on git's answer, but by a different
+	// route than isExcluded alone: isExcluded("dist/keep.js", ...) is false
+	// here, because the negation is the last matching pattern. The file is
+	// still not packed because collectFiles returns filepath.SkipDir for the
+	// excluded "dist" directory, so the walk never reaches keep.js to ask.
+	//
+	// Which answer is correct is an open product decision (see #150). This
+	// assertion records what lnpm does today rather than endorsing it.
+	if packed["dist/keep.js"] {
+		t.Errorf("dist/keep.js was packed: directory pruning no longer beats a negation, which changes documented behavior")
+	}
+}
+
+// TestPackNpmignoreNegationReincludesFile packs a real package whose .npmignore
+// re-includes one file out of an otherwise ignored directory.
+//
+// The pattern is "dist/*", not "dist/": a trailing slash prunes the directory
+// during the walk, so a later negation can never reach inside it. "dist/*"
+// matches the entries instead, and on that form git and npm agree — keep.js is
+// re-included, drop.js stays out.
+func TestPackNpmignoreNegationReincludesFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pkgJSON := `{
+		"name": "ignore-negation",
+		"version": "1.0.0"
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(pkgJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	npmignore := "/credentials.json\ndist/*\n!dist/keep.js\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, ".npmignore"), []byte(npmignore), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "credentials.json"), []byte(`{"token":"x"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "index.js"), []byte("module.exports = {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	distDir := filepath.Join(tmpDir, "dist")
+	if err := os.MkdirAll(distDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(distDir, "keep.js"), []byte("keep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(distDir, "drop.js"), []byte("drop"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A nested credentials.json proves "/credentials.json" is anchored to the
+	// package root and does not exclude the same name further down the tree.
+	nestedDir := filepath.Join(tmpDir, "src")
+	if err := os.MkdirAll(nestedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDir, "credentials.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, files, err := Pack(tmpDir)
+	if err != nil {
+		t.Fatalf("Pack() error: %v", err)
+	}
+
+	packed := make(map[string]bool)
+	for _, f := range files {
+		packed[f.RelPath] = true
+	}
+
+	for _, name := range []string{"package.json", "index.js", "src/credentials.json", "dist/keep.js"} {
+		if !packed[name] {
+			t.Errorf("expected file %q to be packed, got %v", name, files)
+		}
+	}
+	for _, name := range []string{"credentials.json", "dist/drop.js"} {
+		if packed[name] {
+			t.Errorf("expected file %q to be excluded", name)
+		}
+	}
+}
+
+// TestIsExcludedDefaultExcludesCannotBeNegated proves a user "!" pattern cannot
+// re-include a default-excluded path. collectFiles appends defaultExcludes
+// after the user's patterns, and the last matching pattern wins, so a default
+// exclude always has the final say.
+func TestIsExcludedDefaultExcludesCannotBeNegated(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		userPats []string
+	}{
+		{"negated .env", ".env", []string{"!.env"}},
+		{"negated node_modules file", "node_modules/foo", []string{"!node_modules/foo"}},
+		{"negated node_modules dir", "node_modules", []string{"!node_modules"}},
+		{"negated .npmrc", ".npmrc", []string{"!.npmrc"}},
+		{"negated .git file", ".git/config", []string{"!.git/config"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patterns := append(append([]string{}, tt.userPats...), defaultExcludes...)
+			if !isExcluded(tt.path, patterns) {
+				t.Errorf("isExcluded(%q, user %v + defaults) = false, want true: a user negation must not re-include a default exclude", tt.path, tt.userPats)
+			}
+		})
+	}
+}
+
+// TestPackDefaultExcludesWinInWhitelistMode proves default excludes still win
+// when package.json has a "files" whitelist and .npmignore tries to negate
+// them: excludes are evaluated before the whitelist, and defaultExcludes are
+// appended last so they have the final say.
+func TestPackDefaultExcludesWinInWhitelistMode(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pkgJSON := `{
+		"name": "whitelist-defaults",
+		"version": "1.0.0",
+		"files": ["dist", ".env", "node_modules"]
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(pkgJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".npmignore"), []byte("!.env\n!node_modules\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".env"), []byte("SECRET=1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	nodeModules := filepath.Join(tmpDir, "node_modules", "dep")
+	if err := os.MkdirAll(nodeModules, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nodeModules, "index.js"), []byte("dep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	distDir := filepath.Join(tmpDir, "dist")
+	if err := os.MkdirAll(distDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(distDir, "index.js"), []byte("ok"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, files, err := Pack(tmpDir)
+	if err != nil {
+		t.Fatalf("Pack() error: %v", err)
+	}
+
+	packed := make(map[string]bool)
+	for _, f := range files {
+		packed[f.RelPath] = true
+	}
+
+	if !packed["dist/index.js"] {
+		t.Errorf("expected whitelisted file %q to be packed, got %v", "dist/index.js", files)
+	}
+	for _, name := range []string{".env", "node_modules/dep/index.js"} {
+		if packed[name] {
+			t.Errorf("default-excluded %q was packed: a user negation must not re-include it", name)
 		}
 	}
 }

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -202,6 +202,41 @@ func TestIsExcludedGitignoreSemanticsPending(t *testing.T) {
 	}
 }
 
+// TestIsExcludedNegationDoesNotReachDescendants pins git's rule that "it is not
+// possible to re-include a file if a parent directory of that file is
+// excluded": a "!" pattern re-includes only the paths it matches directly,
+// never the paths that merely sit underneath a directory it matched. A positive
+// pattern keeps the opposite behavior, because git ignores everything inside an
+// ignored directory.
+func TestIsExcludedNegationDoesNotReachDescendants(t *testing.T) {
+	tests := []struct {
+		path     string
+		patterns []string
+		want     bool
+	}{
+		// "!foo" names the directory, not its contents, so foo/bar stays out.
+		{"foo/bar", []string{"foo/bar", "!foo"}, true},
+		{"foo/sub/baz.js", []string{"foo/**", "!foo"}, true},
+		{"dist/a.js", []string{"dist/", "!dist/"}, true},
+
+		// A negation still matches its own path exactly.
+		{"foo", []string{"foo", "!foo"}, false},
+		{"dist", []string{"dist/", "!dist/"}, false},
+
+		// A positive parent pattern still excludes everything below it.
+		{"node_modules/foo/index.js", []string{"node_modules"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := isExcluded(tt.path, tt.patterns)
+			if got != tt.want {
+				t.Errorf("isExcluded(%q, %v) = %v, want %v", tt.path, tt.patterns, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsIncluded(t *testing.T) {
 	tests := []struct {
 		path     string
@@ -387,7 +422,7 @@ func TestPackNpmignoreGitignoreSemantics(t *testing.T) {
 
 	for _, name := range []string{"package.json", "index.js", "src/credentials.json"} {
 		if !packed[name] {
-			t.Errorf("expected file %q to be packed, got %v", name, files)
+			t.Errorf("expected file %q to be packed, packed set was %v", name, packed)
 		}
 	}
 	for _, name := range []string{"credentials.json", "dist/drop.js", ".npmignore"} {
@@ -474,7 +509,7 @@ func TestPackNpmignoreNegationReincludesFile(t *testing.T) {
 
 	for _, name := range []string{"package.json", "index.js", "src/credentials.json", "dist/keep.js"} {
 		if !packed[name] {
-			t.Errorf("expected file %q to be packed, got %v", name, files)
+			t.Errorf("expected file %q to be packed, packed set was %v", name, packed)
 		}
 	}
 	for _, name := range []string{"credentials.json", "dist/drop.js"} {
@@ -560,7 +595,7 @@ func TestPackDefaultExcludesWinInWhitelistMode(t *testing.T) {
 	}
 
 	if !packed["dist/index.js"] {
-		t.Errorf("expected whitelisted file %q to be packed, got %v", "dist/index.js", files)
+		t.Errorf("expected whitelisted file %q to be packed, packed set was %v", "dist/index.js", packed)
 	}
 	for _, name := range []string{".env", "node_modules/dep/index.js"} {
 		if packed[name] {

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -113,83 +113,39 @@ func TestIsExcluded(t *testing.T) {
 	}
 }
 
-// TestIsExcludedGitignoreSemantics covers the gitignore/npmignore pattern forms
-// whose expected value the current matcher happens to produce. It produces them
-// by accident, not by handling the pattern: "dist/" and "/dist" both contain a
-// "/", so they take the full-path glob branch and then the pattern+"/" prefix
-// check, and neither can ever match; the negation case comes out right only
-// because "dist/*" matches a sibling that should be excluded anyway, with the
-// "!" pattern skipped. They are recorded so the contract sits in one place and
-// so they turn red if a later change regresses them.
-//
-// Its counterpart, TestIsExcludedGitignoreSemanticsPending, holds the cases the
-// current matcher cannot satisfy. The two together are the contract for the
-// isExcluded rewrite in #150; they are split only so the suite stays green
-// today.
+// TestIsExcludedGitignoreSemantics pins the gitignore/npmignore semantics
+// isExcluded implements: a trailing slash excludes a directory and everything
+// under it, a leading slash anchors a pattern to the package root, and among
+// several matching patterns the last one wins, so a "!" pattern can re-include
+// a path an earlier pattern excluded.
 func TestIsExcludedGitignoreSemantics(t *testing.T) {
 	tests := []struct {
 		path     string
 		patterns []string
 		want     bool
 	}{
-		// Trailing slash: "dist/" excludes the dist directory and its contents,
-		// and nothing else.
+		// Trailing slash: "dist/" excludes the dist directory and everything
+		// under it, and nothing else.
+		// CAVEAT on {"dist", ...}: git's trailing slash matches directories
+		// only, and isExcluded gets no directory signal, so it also matches a
+		// same-named plain file. This case assumes "dist" is a directory.
+		{"dist/index.js", []string{"dist/"}, true},
+		{"dist", []string{"dist/"}, true},
 		{"src/index.ts", []string{"dist/"}, false},
 
 		// Leading slash anchors the pattern to the package root, so a nested
-		// "dist" further down the tree is not matched.
+		// path of the same name further down the tree is not matched.
+		{"credentials.json", []string{"/credentials.json"}, true},
+		{"dist/index.js", []string{"/dist"}, true},
 		{"src/dist/index.js", []string{"/dist"}, false},
 
 		// Negation: the last matching pattern wins, so "!dist/keep.js"
 		// re-includes a file that "dist/*" excluded, while its siblings stay
 		// excluded. The pattern is "dist/*" and not "dist/" because a trailing
 		// slash prunes the directory outright, and nothing beneath a pruned
-		// directory can be re-included.
-		{"dist/drop.js", []string{"dist/*", "!dist/keep.js"}, true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
-			got := isExcluded(tt.path, tt.patterns)
-			if got != tt.want {
-				t.Errorf("isExcluded(%q, %v) = %v, want %v", tt.path, tt.patterns, got, tt.want)
-			}
-		})
-	}
-}
-
-// TestIsExcludedGitignoreSemanticsPending records the gitignore/npmignore
-// pattern forms isExcluded silently ignores today: every case here fails
-// against the current matcher. The expected values describe correct gitignore
-// semantics, not current behavior.
-func TestIsExcludedGitignoreSemanticsPending(t *testing.T) {
-	tests := []struct {
-		path     string
-		patterns []string
-		want     bool
-	}{
-		// Trailing slash: "dist/" excludes the dist directory and everything
-		// under it. isExcluded never strips the trailing slash, so the pattern
-		// matches nothing.
-		// CAVEAT on {"dist", ...}: git's trailing slash matches directories
-		// only, and isExcluded gets no directory signal, so this case assumes
-		// "dist" is a directory.
-		{"dist/index.js", []string{"dist/"}, true},
-		{"dist", []string{"dist/"}, true},
-
-		// Leading slash anchors the pattern to the package root. isExcluded
-		// never strips it, so "/credentials.json" matches nothing and the file
-		// is copied into the shared store.
-		{"credentials.json", []string{"/credentials.json"}, true},
-		{"dist/index.js", []string{"/dist"}, true},
-
-		// Negation: the last matching pattern wins, so "!dist/keep.js"
-		// re-includes a file that "dist/*" excluded. isExcluded skips "!"
-		// patterns entirely, so keep.js stays excluded with its siblings. The
-		// pattern is "dist/*" and not "dist/" because a trailing slash prunes
-		// the directory outright, and nothing beneath a pruned directory can be
-		// re-included.
+		// directory can be re-included; on "dist/*" git and npm agree.
 		{"dist/keep.js", []string{"dist/*", "!dist/keep.js"}, false},
+		{"dist/drop.js", []string{"dist/*", "!dist/keep.js"}, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #150.

## The defect

`lnpm publish` decides which files to copy into the shared store at `~/.lnpm` — which is
then linked into every project on the machine that consumes the package — via
`isExcluded(relPath, patterns)`. It handled only exact matches, a `/**` suffix, basename
globs, full-path globs and a `prefix/` check. Three common forms silently matched nothing:

- **Root anchoring.** `/credentials.json` never had its leading `/` stripped, so it
  matched nothing and the file was published — a silent secret leak, with no signal to
  the developer that their ignore rule did nothing.
- **Trailing-slash directories.** `dist/` matched nothing: exact match and
  `filepath.Match` both failed, and the prefix branch compared against the literal
  `"dist//"`.
- **Negation.** `!keep.js` was skipped outright, so it could never re-include anything.

## The change

Approach B from the issue — extend the matcher by hand. **No new dependency**;
`go.mod`/`go.sum` are untouched. The issue prefers a library "unless adding a dependency
is undesirable", and it is here: `go.mod` carries only 6 direct dependencies and no
go-git, CI pins Go 1.22 (a dependency-version collision already bit this repo when x/mod
v0.40 turned out to require Go 1.25), and a wholesale library swap would put at risk both
the 13 existing `TestIsExcluded` cases and the default-excludes-always-win precedence
that the acceptance criteria require.

Every pattern is now evaluated and the **last match decides**, so a later `!pattern`
re-includes a path an earlier one excluded. A leading `/` anchors to the package root and
suppresses the basename branch. A trailing `/` matches the directory and its contents.

`collectFiles` already appends `defaultExcludes` after the user's patterns, which is what
stops a user negation re-including `.env` or `node_modules`. That was previously an
assumption; it now has tests — both a unit table and an end-to-end `Pack` run in
`files`-whitelist mode.

## A bug found in review and fixed here

The first cut let negation reach descendants. The directory-prefix fallback
(`strings.HasPrefix(relPath, pattern+"/")`) ran for negated patterns too, so a `!` on a
parent silently re-included its entire subtree:

```
isExcluded("foo/bar",          ["foo/bar", "!foo"])  = false   // want true
isExcluded("foo2/sub/baz.env", ["foo2/**", "!foo2"]) = false   // want true
```

Checked against real `git check-ignore`: git reports **both** paths ignored. Per git's
documented rule, "it is not possible to re-include a file if a parent directory of that
file is excluded" — a negation re-includes only paths it matches directly. Re-including
files the user never named is a silent-publish risk in the same family as the bug this
issue set out to fix.

All three descendant-reaching forms (the prefix fallback, the `/**` branch, and the
trailing-slash branch) are now positive-only. Exact matches are unaffected, so `!foo`
still un-excludes `foo` itself. Covered by
`TestIsExcludedNegationDoesNotReachDescendants`.

## Known limitations, both deliberate

1. **`dist/` also matches a same-named plain file.** In git a trailing slash matches
   directories only, but `isExcluded` receives no directory signal — its caller has
   `info.IsDir()` in hand and does not thread it through. The issue's step 4 prescribes
   the path-prefix form, so that is what is implemented, documented inline.
2. **Directory pruning defeats negation inside a pruned directory.** `collectFiles`
   returns `filepath.SkipDir` for an excluded directory, so with `dist/` +
   `!dist/keep.js` the walk never descends and `keep.js` stays out — git's answer, not
   npm's (npm packs both). This is the one place last-match-wins does not hold end to
   end, and it is now commented at that `return filepath.SkipDir`.

   The two integration tests make the divergence explicit rather than hiding it:
   `TestPackNpmignoreGitignoreSemantics` uses the issue's literal `dist/` patterns and
   asserts what lnpm actually does (`keep.js` **absent**);
   `TestPackNpmignoreNegationReincludesFile` uses `dist/*`, where git and npm agree, and
   gets `keep.js` **present** along with `drop.js` absent — the outcome the issue's
   Testing section describes. Whether lnpm should follow git or npm on the `dist/` form
   is an open product decision, recorded on the issue and not silently settled here.

## Verification

`go build`, `go vet`, `gofmt` clean; full `go test ./...` green. The 13 original
`TestIsExcluded` cases are unmodified and still pass — they are the regression guard for
the forms that already worked. No `t.Skip` remains: #149's pending suite is merged into
`TestIsExcludedGitignoreSemantics` with all 8 cases passing, since the split existed only
to keep the suite green while this fix was outstanding.

Symlink skipping and the `.git` safety filter are untouched, and a scratch probe
confirmed an `.npmignore` of `!.git`, `!.git/**`, `!.git/config` still cannot defeat
`filterGitFiles`.