### PR TITLE
Fix nil-pointer crash in retreat when lnpm.lock is corrupt

### DIFF
--- a/internal/cli/retreat.go
+++ b/internal/cli/retreat.go
@@ -22,7 +22,14 @@ func RunRetreat(force bool, runInstall bool) error {
 
 	// Check for lnpm.lock
 	lock, err := lockfile.Load(cwd)
-	if err != nil || len(lock.List()) == 0 {
+	// A missing lock file loads as an empty one, so an error here means the file
+	// exists but cannot be parsed, and lock is nil. Abort instead of cleaning up:
+	// without the lock we cannot restore the original package.json dependencies,
+	// so removing .lnpm/ and lnpm.lock would leave the project half-retreated.
+	if err != nil {
+		return fmt.Errorf("lnpm.lock is corrupt: %w. Delete lnpm.lock and re-run 'lnpm retreat' to clean up the rest", err)
+	}
+	if len(lock.List()) == 0 {
 		// Check for .lnpm directory
 		lnpmDir := filepath.Join(cwd, ".lnpm")
 		if _, err := os.Stat(lnpmDir); os.IsNotExist(err) {

--- a/internal/cli/retreat.go
+++ b/internal/cli/retreat.go
@@ -23,11 +23,12 @@ func RunRetreat(force bool, runInstall bool) error {
 	// Check for lnpm.lock
 	lock, err := lockfile.Load(cwd)
 	// A missing lock file loads as an empty one, so an error here means the file
-	// exists but cannot be parsed, and lock is nil. Abort instead of cleaning up:
-	// without the lock we cannot restore the original package.json dependencies,
-	// so removing .lnpm/ and lnpm.lock would leave the project half-retreated.
+	// exists but could not be read or parsed, and lock is nil. Abort instead of
+	// cleaning up: without the lock we cannot restore the original package.json
+	// dependencies, so removing .lnpm/ and lnpm.lock would leave the project
+	// half-retreated.
 	if err != nil {
-		return fmt.Errorf("lnpm.lock is corrupt: %w. Delete lnpm.lock and re-run 'lnpm retreat' to clean up the rest", err)
+		return fmt.Errorf("could not read lnpm.lock: %w\n\nHint: Fix or remove lnpm.lock, then re-run 'lnpm retreat' to clean up the rest", err)
 	}
 	if len(lock.List()) == 0 {
 		// Check for .lnpm directory

--- a/tests/retreat_test.go
+++ b/tests/retreat_test.go
@@ -179,8 +179,8 @@ func TestRetreatCorruptLockfile(t *testing.T) {
 			if err == nil {
 				t.Fatal("Expected an error for a corrupt lock file, got nil")
 			}
-			if !strings.Contains(err.Error(), "corrupt") {
-				t.Errorf("Expected error to mention corruption, got: %v", err)
+			if !strings.Contains(err.Error(), "lnpm.lock") {
+				t.Errorf("Expected error to mention the lock file, got: %v", err)
 			}
 
 			// Nothing may be touched when the lock file cannot be read.

--- a/tests/retreat_test.go
+++ b/tests/retreat_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
@@ -152,6 +153,42 @@ func TestRetreatPartiallyLinked(t *testing.T) {
 	}
 	env.AssertLockfileExists(projectDir, false)
 	env.AssertDirectoryExists(filepath.Join(projectDir, ".lnpm"), false)
+}
+
+// TestRetreatCorruptLockfile tests that retreat aborts with a clear error when
+// lnpm.lock exists but cannot be parsed, in both the preview and --force paths,
+// instead of crashing on the nil lock file that lockfile.Load returns.
+func TestRetreatCorruptLockfile(t *testing.T) {
+	cases := []struct {
+		name  string
+		force bool
+	}{
+		{"preview", false},
+		{"force", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupTest(t)
+
+			_, projectDir := env.publishAndAdd("corrupt-lock-pkg")
+			env.chdir(projectDir)
+			env.writeFile(filepath.Join(projectDir, "lnpm.lock"), "version: 1\npackages: {not valid yaml")
+
+			err := cli.RunRetreat(tc.force, false)
+			if err == nil {
+				t.Fatal("Expected an error for a corrupt lock file, got nil")
+			}
+			if !strings.Contains(err.Error(), "corrupt") {
+				t.Errorf("Expected error to mention corruption, got: %v", err)
+			}
+
+			// Nothing may be touched when the lock file cannot be read.
+			env.AssertSymlinkExists(projectDir, "corrupt-lock-pkg")
+			env.AssertLockfileExists(projectDir, true)
+			env.AssertDirectoryExists(filepath.Join(projectDir, ".lnpm"), true)
+		})
+	}
 }
 
 // TestRetreatCleansGitignore tests that the .lnpm/ entry is removed from


### PR DESCRIPTION
Closes #153.

## The defect

`lockfile.Load` returns an empty lock file when `lnpm.lock` is absent, but `(nil, error)`
when the file exists and cannot be read or parsed. `RunRetreat` guarded the result with
`if err != nil || len(lock.List()) == 0`. The `||` short-circuit made that line itself
safe, but the body only returned early when `.lnpm/` did **not** exist — so a corrupt lock
plus an existing `.lnpm/` fell straight through to `lock.List()` on a nil pointer.

Both panic sites named in the issue were reproduced before fixing:

```
panic: runtime error: invalid memory address or nil pointer dereference
lockfile.(*LockFile).List(...)  pkg/lockfile/lockfile.go:101
cli.RunRetreat(0x0, 0x0)        internal/cli/retreat.go:41   <- preview path

panic: runtime error: invalid memory address or nil pointer dereference
lockfile.(*LockFile).List(...)  pkg/lockfile/lockfile.go:101
cli.RunRetreat(0x1, 0x0)        internal/cli/retreat.go:76   <- --force path
```

A panic is a poor answer at the exact moment a user reaches for `retreat`.

## The change

Option 1 from the issue — abort on a load error before touching anything. The guard sits
above the force/preview branch, so one check covers both paths; neither `lock.List()` site
is reachable with a nil `lock`.

Option 2 (substitute an empty lock) was rejected: `retreat` restores `package.json`'s
original dependencies *from the lock*, so running it with an empty one would delete
`.lnpm/` and `lnpm.lock` while leaving the linked dependencies in place — a silent
half-cleanup, worse than not starting. Aborting also matches `RunRemove`, which already
returns `failed to load lock file: %w`.

The error is actionable, since the issue's own severity note is that this is when a user
most needs `retreat` to help:

```
Error: could not read lnpm.lock: failed to parse lock file: yaml: line 1: did not find expected ',' or '}'

Hint: Fix or remove lnpm.lock, then re-run 'lnpm retreat' to clean up the rest
```

It deliberately does **not** say "corrupt". `lockfile.Load` also errors on a non-ENOENT
*read* failure — EACCES, or `lnpm.lock` being a directory — where the file is not corrupt
and "delete it" would be misleading advice. "Fix or remove" covers both causes. The
`\n\nHint:` shape follows `internal/hooks/hooks.go`, so the wrapped YAML text no longer
collides with the advice mid-sentence.

## One behavior change beyond the panic fix

Corrupt lock **and no** `.lnpm/` directory: previously this fell into the guard body and
printed `No lnpm links found in this project`, returning nil. It now returns the read
error. That is what the issue specifies — *"return ... before touching anything"* — and
AC3 scopes "unchanged" to valid and missing lock files, both verified unchanged. It is
arguably the better behavior: the user learns their lock file is broken instead of being
told there is nothing to do. The same path previously panicked for an unreadable lock and
now errors cleanly.

## Verification

`go build`, `go vet`, `gofmt` clean; full `go test ./...` green.

`TestRetreatCorruptLockfile` is table-driven over both paths and asserts more than the
issue asked: that the error names the lock file, and that the symlink, `lnpm.lock` and
`.lnpm/` are **all still present** afterwards — pinning the "abort, don't half-retreat"
invariant rather than just the absence of a panic. Both cases were confirmed to panic
against the unfixed code.

Existing coverage for a valid lock (`TestRetreatVariants`,
`TestRetreatRestoresOriginalVersion`, `TestRetreatPreservesOtherDependencies`,
`TestRetreatPartiallyLinked`, `TestRetreatNoForceFlag`, `TestRetreatCleansGitignore`) and
a missing lock (`TestRetreatNoLinks`) is unchanged and still passes, so it was not
duplicated.