### PR TITLE
Fix versioned package spec being treated as a content hash in multi-package add

### DIFF
--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -72,14 +72,10 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 
 			name, version := parsePackageSpec(pkgSpec)
 
-			var pkg *db.Package
-			var lookupErr error
-			if version != "" {
-				pkg, lookupErr = database.GetPackageByHash(name, version)
-			} else {
-				pkg, lookupErr = database.GetPackageByName(name)
-			}
-
+			// The store keeps the latest published version per package
+			// (latest-wins), so resolve by name and then check the requested
+			// version against what's stored, same as the single-package path.
+			pkg, lookupErr := database.GetPackageByName(name)
 			if lookupErr != nil {
 				result.err = fmt.Errorf("failed to look up package: %w", lookupErr)
 				results <- result
@@ -87,6 +83,11 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 			}
 			if pkg == nil {
 				result.err = fmt.Errorf("package %s not found in store", name)
+				results <- result
+				return
+			}
+			if version != "" && pkg.Version != version {
+				result.err = fmt.Errorf("version %s of %s not found in store (latest published is %s). Re-publish %s to update.", version, name, pkg.Version, name)
 				results <- result
 				return
 			}

--- a/tests/add_test.go
+++ b/tests/add_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -315,10 +314,11 @@ func TestAddMultipleByVersion(t *testing.T) {
 		t.Fatalf("add pkg-a@1.2.3 pkg-b should succeed, got: %v", err)
 	}
 
-	env.AssertFilesLinked(projectDir, "pkg-a")
-	env.AssertFilesLinked(projectDir, "pkg-b")
-	env.AssertPackageJSON(projectDir, "pkg-a", "file:.lnpm/pkg-a")
-	env.AssertPackageJSON(projectDir, "pkg-b", "file:.lnpm/pkg-b")
+	for _, name := range []string{"pkg-a", "pkg-b"} {
+		env.AssertSymlinkExists(projectDir, name)
+		env.AssertPackageJSON(projectDir, name, "file:.lnpm/"+name)
+		env.AssertDatabaseLink(name, projectDir)
+	}
 }
 
 // TestAddMultipleByVersionMismatch verifies a non-matching version fails only
@@ -352,36 +352,11 @@ func TestAddMultipleByVersionMismatch(t *testing.T) {
 	}
 
 	// pkg-b still linked, pkg-a not.
-	env.AssertFilesLinked(projectDir, "pkg-b")
+	env.AssertSymlinkExists(projectDir, "pkg-b")
 	env.AssertPackageJSON(projectDir, "pkg-b", "file:.lnpm/pkg-b")
+	env.AssertDatabaseLink("pkg-b", projectDir)
+
 	env.AssertSymlinkMissing(projectDir, "pkg-a")
 	env.AssertPackageJSONMissing(projectDir, "pkg-a")
-}
-
-// captureStdout runs fn with os.Stdout redirected to a pipe and returns what it
-// printed. The multi-package add reports per-package failures on stdout rather
-// than in its returned error, so comparing wording requires reading it.
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("Failed to create pipe: %v", err)
-	}
-	orig := os.Stdout
-	os.Stdout = w
-
-	done := make(chan string, 1)
-	go func() {
-		data, _ := io.ReadAll(r)
-		done <- string(data)
-	}()
-
-	fn()
-
-	os.Stdout = orig
-	_ = w.Close()
-	out := <-done
-	_ = r.Close()
-	return out
+	env.AssertDatabaseNoLink("pkg-a", projectDir)
 }

--- a/tests/add_test.go
+++ b/tests/add_test.go
@@ -1,8 +1,10 @@
 package tests
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
@@ -294,4 +296,92 @@ func TestAddByVersion(t *testing.T) {
 	if err := cli.RunAdd("ver-pkg@9.9.9", false, false, false); err == nil {
 		t.Fatal("add ver-pkg@9.9.9 should fail (only 1.0.0 is published)")
 	}
+}
+
+// TestAddMultipleByVersion verifies a versioned spec resolves in the
+// multi-package path exactly as it does in the single-package one: the version
+// is matched against the stored version, not against the content hash (#154).
+func TestAddMultipleByVersion(t *testing.T) {
+	env := setupTest(t)
+
+	env.publishPkg("pkg-a", "1.2.3", map[string]string{
+		"index.js": "module.exports=1",
+	})
+	env.simplePkg("pkg-b")
+
+	projectDir := env.newProject("consumer")
+
+	if err := cli.RunAddMultiple([]string{"pkg-a@1.2.3", "pkg-b"}, false, false, false, false); err != nil {
+		t.Fatalf("add pkg-a@1.2.3 pkg-b should succeed, got: %v", err)
+	}
+
+	env.AssertFilesLinked(projectDir, "pkg-a")
+	env.AssertFilesLinked(projectDir, "pkg-b")
+	env.AssertPackageJSON(projectDir, "pkg-a", "file:.lnpm/pkg-a")
+	env.AssertPackageJSON(projectDir, "pkg-b", "file:.lnpm/pkg-b")
+}
+
+// TestAddMultipleByVersionMismatch verifies a non-matching version fails only
+// for that package, with the same message the single-package path produces, so
+// the two paths cannot drift (#154).
+func TestAddMultipleByVersionMismatch(t *testing.T) {
+	env := setupTest(t)
+
+	env.publishPkg("pkg-a", "1.2.3", map[string]string{
+		"index.js": "module.exports=1",
+	})
+	env.simplePkg("pkg-b")
+
+	projectDir := env.newProject("consumer")
+
+	// The single-package path is authoritative for the wording.
+	singleErr := cli.RunAdd("pkg-a@9.9.9", false, false, false)
+	if singleErr == nil {
+		t.Fatal("add pkg-a@9.9.9 should fail (only 1.2.3 is published)")
+	}
+
+	output := captureStdout(t, func() {
+		if err := cli.RunAddMultiple([]string{"pkg-a@9.9.9", "pkg-b"}, false, false, false, false); err == nil {
+			t.Error("add pkg-a@9.9.9 pkg-b should fail for pkg-a")
+		}
+	})
+
+	if !strings.Contains(output, singleErr.Error()) {
+		t.Errorf("multi-package error should match the single-package one.\nwant substring: %s\ngot output:\n%s",
+			singleErr.Error(), output)
+	}
+
+	// pkg-b still linked, pkg-a not.
+	env.AssertFilesLinked(projectDir, "pkg-b")
+	env.AssertPackageJSON(projectDir, "pkg-b", "file:.lnpm/pkg-b")
+	env.AssertSymlinkMissing(projectDir, "pkg-a")
+	env.AssertPackageJSONMissing(projectDir, "pkg-a")
+}
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what it
+// printed. The multi-package add reports per-package failures on stdout rather
+// than in its returned error, so comparing wording requires reading it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(r)
+		done <- string(data)
+	}()
+
+	fn()
+
+	os.Stdout = orig
+	_ = w.Close()
+	out := <-done
+	_ = r.Close()
+	return out
 }

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -391,6 +391,42 @@ func RunConcurrently(t *testing.T, funcs ...func() error) {
 	}
 }
 
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what it
+// printed. The multi-package add reports per-package failures on stdout rather
+// than in its returned error, so comparing wording requires reading it.
+//
+// The reader goroutine starts before fn does, so fn can write more than the
+// pipe buffer without deadlocking, and the teardown is deferred so os.Stdout is
+// restored however fn exits: a t.Fatal inside fn would otherwise leave the rest
+// of the package writing into a dead pipe.
+func captureStdout(t *testing.T, fn func()) (out string) {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+
+	done := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(r)
+		done <- string(data)
+	}()
+
+	orig := os.Stdout
+	os.Stdout = w
+
+	defer func() {
+		os.Stdout = orig
+		_ = w.Close() // unblocks the reader goroutine
+		out = <-done
+		_ = r.Close()
+	}()
+
+	fn()
+	return
+}
+
 // Helper functions
 
 func getMapValue(m map[string]interface{}, key string) map[string]interface{} {


### PR DESCRIPTION
Closes #154.

## The defect

`RunAddMultiple` resolved a `name@version` spec with `database.GetPackageByHash(name, version)`.
That function's second parameter is the **content hash** — a digest of the package's file
contents — not the semver string. A version like `1.2.3` never equals a content-hash
digest, so the lookup always returned nil and the command reported
`package <name> not found in store`, even when that exact version was published and
stored.

The effect: any pinned version made multi-package `add` unusable.
`lnpm add pkg-a@1.2.3 pkg-b` failed for `pkg-a` while the single-package
`lnpm add pkg-a@1.2.3` succeeded on the same store.

This also contradicted `ARCHITECTURE.md`, which documents that a specific version "must
match the latest published version" — a name lookup followed by a version comparison,
which is exactly what the single-package path already did.

## The change

Resolve by name, then compare the requested version against the stored one — the same
shape as the single-package path — using the identical error message:

```
version 9.9.9 of pkg-a not found in store (latest published is 1.2.3). Re-publish pkg-a to update.
```

`TestAddMultipleByVersionMismatch` takes the single-package path's returned error as
authoritative and asserts it appears verbatim in the multi-package output, so acceptance
criterion 3 ("identical to the single-package path") is pinned by a test rather than by
convention and the two cannot silently drift.

No shared helper was extracted: `runAddSingle` is out of scope for this issue, and the
file already duplicates its sibling error text across the two paths
(`"package %s not found in store"` at both sites). The string-equality test is what
guards against drift.

`GetPackageByHash` is untouched and still correctly used by `internal/cli/publish.go`
with a real content hash.

## Verification

Both new tests were confirmed failing against the unfixed code:

```
--- FAIL: TestAddMultipleByVersion
    add_test.go:315: add pkg-a@1.2.3 pkg-b should succeed, got: 1 of 2 package(s) failed to add
--- FAIL: TestAddMultipleByVersionMismatch
    want substring: version 9.9.9 of pkg-a not found in store (latest published is 1.2.3). Re-publish pkg-a to update.
    got output: - pkg-a@9.9.9: package pkg-a not found in store
```

`go build`, `go vet`, `gofmt` clean; full `go test ./...` green.

Edge cases probed beyond the acceptance criteria, all correct: scoped packages
(`@scope/pkg`, `@scope/pkg@1.2.3`, `@scope/pkg@9.9.9` — `parsePackageSpec` splits on the
*last* `@` only when it differs from the first, and multi and single agree); an empty
version (`pkg-a@`) treated as unversioned by both paths; and the concurrency path — each
goroutine sends exactly once on a channel buffered to `len(packageSpecs)` and the new
early `return` follows its send, verified with 5 specs of which 3 fail
(`3 of 5 package(s) failed to add`, all three errors reported).

## Test-helper fix found in review

`captureStdout` — needed because `RunAddMultiple` prints per-package errors to stdout and
returns only an aggregate — restored `os.Stdout` with straight-line code. A `t.Fatal`
inside the captured function would have leaked the redirect to the **rest of the test
package**, and the failure is silent: a later test's write into the abandoned pipe still
returns `n=20, err=<nil>`, so its output simply disappears with nothing to trace. Now
restored via `defer`, with the reader goroutine started before the redirect so a write
larger than the pipe buffer cannot deadlock. Demonstrated with a temporary A/B before and
after.

The helper also moved to `tests/helpers_test.go`, where this package keeps its generic
utilities, and the two new tests now assert the same
`AssertSymlinkExists`/`AssertPackageJSON`/`AssertDatabaseLink` trio as
`TestAddMultiplePackages`, with the exact negative counterparts for the failing package,
so the positive and negative halves inspect the same artifacts.