### PR TITLE
Abort destructive operations in non-interactive mode instead of auto-confirming

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ lnpm push
 | `lnpm list` | List this project's linked packages (`--store` lists the store, `--projects` lists consumers) |
 | `lnpm check` | Fail if package.json still has lnpm references (pre-publish guard) |
 | `lnpm doctor` | Diagnose issues |
-| `lnpm gc` | Garbage collect unused packages (`--dry-run`, `--older-than 30d`, `--fix-links`) |
+| `lnpm gc` | Garbage collect unused packages (`--dry-run`, `--older-than 30d`, `--fix-links`, `--yes`) |
 | `lnpm retreat` | Remove all lnpm changes |
 | `lnpm config` | View/edit configuration |
 | `lnpm update` | Update lnpm to the latest version |

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -77,10 +77,12 @@ This command:
 
 Examples:
   lnpm remove my-package   # Remove specific package
-  lnpm remove --all        # Remove all linked packages`,
+  lnpm remove --all        # Remove all linked packages
+  lnpm remove --all --yes  # Remove all without a confirmation prompt`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		all, _ := cmd.Flags().GetBool("all")
+		yes, _ := cmd.Flags().GetBool("yes")
 		var packageName string
 		if len(args) > 0 {
 			packageName = args[0]
@@ -88,7 +90,7 @@ Examples:
 		if !all && packageName == "" {
 			return fmt.Errorf("please specify a package name or use --all")
 		}
-		return RunRemove(packageName, all)
+		return RunRemove(packageName, all, yes)
 	},
 }
 
@@ -158,13 +160,15 @@ Examples:
   lnpm gc              # Remove packages with no links
   lnpm gc --dry-run    # Show what would be removed
   lnpm gc --older-than 30d   # Remove packages older than 30 days
-  lnpm gc --fix-links  # Clean up orphaned link records`,
+  lnpm gc --fix-links  # Clean up orphaned link records
+  lnpm gc --yes        # Remove without a confirmation prompt (for scripts)`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		olderThan, _ := cmd.Flags().GetString("older-than")
 		fixLinks, _ := cmd.Flags().GetBool("fix-links")
+		yes, _ := cmd.Flags().GetBool("yes")
 
-		return RunGC(dryRun, olderThan, fixLinks)
+		return RunGC(dryRun, olderThan, fixLinks, yes)
 	},
 }
 
@@ -250,6 +254,7 @@ func init() {
 
 	// remove flags
 	removeCmd.Flags().Bool("all", false, "Remove all linked packages")
+	removeCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
 
 	// push flags
 	pushCmd.Flags().Bool("skip-hooks", false, "Skip prepare scripts before push")
@@ -262,4 +267,5 @@ func init() {
 	gcCmd.Flags().Bool("dry-run", false, "Show what would be removed")
 	gcCmd.Flags().String("older-than", "", "Remove packages older than duration (e.g., 30d)")
 	gcCmd.Flags().Bool("fix-links", false, "Clean up orphaned link records")
+	gcCmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
 }

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -12,7 +12,7 @@ import (
 )
 
 // RunGC executes the garbage collection command
-func RunGC(dryRun bool, olderThan string, fixLinks bool) error {
+func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 	database, err := db.GetDB()
 	if err != nil {
 		return fmt.Errorf("failed to open database: %w", err)
@@ -121,7 +121,7 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool) error {
 		fmt.Println()
 
 		if !dryRun {
-			if !confirm("Permanently delete these package(s) from the store?") {
+			if !confirm("Permanently delete these package(s) from the store?", yes) {
 				fmt.Println("Aborted.")
 				return nil
 			}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"strings"
 )
@@ -65,14 +66,44 @@ func hrule(width int) string {
 	return strings.Repeat(ch, width)
 }
 
+// confirmDecision is the outcome of the confirmation policy: either the answer
+// is already known, or the user still has to be asked.
+type confirmDecision int
+
+const (
+	decisionAsk confirmDecision = iota
+	decisionProceed
+	decisionAbort
+)
+
+// shouldProceed applies the confirmation policy without touching stdin/stdout.
+// An explicit --yes always proceeds without asking. Otherwise an interactive
+// session is asked, and a non-interactive one aborts with the returned message
+// rather than silently destroying data.
+func shouldProceed(interactive, yes bool) (confirmDecision, string) {
+	if yes {
+		return decisionProceed, ""
+	}
+	if !interactive {
+		return decisionAbort, "Refusing to proceed without confirmation; re-run with --yes"
+	}
+	return decisionAsk, ""
+}
+
 // confirm prompts the user for a yes/no answer, defaulting to No. It reads a
 // single line from stdin. The prompt is only shown when the session is fully
-// interactive (both stdin and stdout are terminals). For scripts, pipes,
-// redirected output, or tests it does not prompt and returns proceed=true so
-// non-interactive callers are not blocked waiting for input.
-func confirm(prompt string) bool {
-	if !isTTY(os.Stdin) || !isTTY(os.Stdout) {
+// interactive (both stdin and stdout are terminals) and yes is not set. When
+// yes is set the caller has already confirmed, so it proceeds without asking.
+// For scripts, pipes, redirected output, or tests it does not prompt and
+// reports false so destructive work never happens unconfirmed.
+func confirm(prompt string, yes bool) bool {
+	interactive := isTTY(os.Stdin) && isTTY(os.Stdout)
+	switch decision, msg := shouldProceed(interactive, yes); decision {
+	case decisionProceed:
 		return true
+	case decisionAbort:
+		fmt.Printf("%s %s\n", iconWarn(), msg)
+		return false
 	}
 	os.Stdout.WriteString(prompt + " [y/N]: ")
 	reader := bufio.NewReader(os.Stdin)

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestShouldProceed(t *testing.T) {
+	tests := []struct {
+		name        string
+		interactive bool
+		yes         bool
+		want        confirmDecision
+		wantMsg     bool
+	}{
+		{
+			name:        "non-interactive without yes aborts with a message",
+			interactive: false,
+			yes:         false,
+			want:        decisionAbort,
+			wantMsg:     true,
+		},
+		{
+			name:        "non-interactive with yes proceeds",
+			interactive: false,
+			yes:         true,
+			want:        decisionProceed,
+		},
+		{
+			name:        "interactive without yes asks the user",
+			interactive: true,
+			yes:         false,
+			want:        decisionAsk,
+		},
+		{
+			name:        "interactive with yes proceeds without asking",
+			interactive: true,
+			yes:         true,
+			want:        decisionProceed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, msg := shouldProceed(tc.interactive, tc.yes)
+			if got != tc.want {
+				t.Fatalf("shouldProceed(%t, %t) = %v, want %v", tc.interactive, tc.yes, got, tc.want)
+			}
+			if tc.wantMsg {
+				if !strings.Contains(msg, "--yes") {
+					t.Fatalf("shouldProceed(%t, %t) msg = %q, want it to mention --yes", tc.interactive, tc.yes, msg)
+				}
+			} else if msg != "" {
+				t.Fatalf("shouldProceed(%t, %t) msg = %q, want empty", tc.interactive, tc.yes, msg)
+			}
+		})
+	}
+}

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -14,7 +14,7 @@ import (
 )
 
 // RunRemove executes the remove command
-func RunRemove(packageName string, all bool) error {
+func RunRemove(packageName string, all bool, yes bool) error {
 	// Get current directory
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -41,7 +41,7 @@ func RunRemove(packageName string, all bool) error {
 			fmt.Println("No linked packages to remove")
 			return nil
 		}
-		if !confirm(fmt.Sprintf("Remove all %d linked package(s) from this project?", len(packagesToRemove))) {
+		if !confirm(fmt.Sprintf("Remove all %d linked package(s) from this project?", len(packagesToRemove)), yes) {
 			fmt.Println("Aborted.")
 			return nil
 		}

--- a/tests/end_to_end_test.go
+++ b/tests/end_to_end_test.go
@@ -52,7 +52,7 @@ func TestE2EPublishAddRemove(t *testing.T) {
 				env.AssertDirectoryExists(filepath.Join(projectDir, "node_modules", scope), true)
 			}
 
-			if err := cli.RunRemove(tc.pkgName, false); err != nil {
+			if err := cli.RunRemove(tc.pkgName, false, false); err != nil {
 				t.Fatalf("Failed to remove package: %v", err)
 			}
 
@@ -95,7 +95,7 @@ func TestE2EMultiplePackagesMultipleProjects(t *testing.T) {
 
 	// Remove one package from one project; the other project is unaffected.
 	env.chdir(projectDirs["project-1"])
-	if err := cli.RunRemove("pkg-b", false); err != nil {
+	if err := cli.RunRemove("pkg-b", false, false); err != nil {
 		t.Fatalf("Failed to remove pkg-b from project-1: %v", err)
 	}
 	env.AssertSymlinkMissing(projectDirs["project-1"], "pkg-b")
@@ -142,7 +142,7 @@ func TestE2EMixedDependencies(t *testing.T) {
 	env.AssertDatabaseLink("prod-pkg", projectDir)
 	env.AssertDatabaseLink("dev-pkg", projectDir)
 
-	if err := cli.RunRemove("dev-pkg", false); err != nil {
+	if err := cli.RunRemove("dev-pkg", false, false); err != nil {
 		t.Fatalf("Failed to remove dev package: %v", err)
 	}
 

--- a/tests/gc_test.go
+++ b/tests/gc_test.go
@@ -17,12 +17,12 @@ func TestGCRemovesOrphans(t *testing.T) {
 		env := setupTest(t)
 
 		env.publishAndAdd("gc-pkg")
-		if err := cli.RunRemove("gc-pkg", false); err != nil {
+		if err := cli.RunRemove("gc-pkg", false, false); err != nil {
 			t.Fatalf("Failed to remove package: %v", err)
 		}
 		env.AssertPackageInDatabase("gc-pkg", true) // orphaned, not yet collected
 
-		if err := cli.RunGC(false, "", false); err != nil {
+		if err := cli.RunGC(false, "", false, true); err != nil {
 			t.Fatalf("Failed to run GC: %v", err)
 		}
 		env.AssertPackageInDatabase("gc-pkg", false)
@@ -37,7 +37,7 @@ func TestGCRemovesOrphans(t *testing.T) {
 			env.AssertPackageInDatabase(name, true)
 		}
 
-		if err := cli.RunGC(false, "", false); err != nil {
+		if err := cli.RunGC(false, "", false, true); err != nil {
 			t.Fatalf("Failed to run GC: %v", err)
 		}
 		for _, name := range packages {
@@ -46,17 +46,52 @@ func TestGCRemovesOrphans(t *testing.T) {
 	})
 }
 
-// TestGCDryRun tests that dry-run mode reports but does not delete.
-func TestGCDryRun(t *testing.T) {
+// TestGCWithoutYesKeepsOrphans tests that a non-interactive GC without --yes
+// refuses to delete: the orphan stays in the database and in the store.
+func TestGCWithoutYesKeepsOrphans(t *testing.T) {
 	env := setupTest(t)
 
-	env.simplePkg("dryrun-pkg")
-	env.AssertPackageInDatabase("dryrun-pkg", true)
+	env.publishPkg("unconfirmed-pkg", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'test';",
+	})
+	env.AssertPackageInDatabase("unconfirmed-pkg", true)
 
-	if err := cli.RunGC(true, "", false); err != nil {
-		t.Fatalf("Failed to run GC dry-run: %v", err)
+	pkg, err := env.Database.GetPackageByName("unconfirmed-pkg")
+	if err != nil || pkg == nil {
+		t.Fatalf("Failed to get package: %v", err)
 	}
-	env.AssertPackageInDatabase("dryrun-pkg", true)
+	storePath := pkg.StorePath
+
+	if err := cli.RunGC(false, "", false, false); err != nil {
+		t.Fatalf("Failed to run GC without --yes: %v", err)
+	}
+
+	env.AssertPackageInDatabase("unconfirmed-pkg", true)
+	if _, err := os.Stat(storePath); err != nil {
+		t.Errorf("Store path was deleted without confirmation: %v", err)
+	}
+}
+
+// TestGCDryRun tests that dry-run mode reports but does not delete, whether or
+// not --yes is given.
+func TestGCDryRun(t *testing.T) {
+	for _, yes := range []bool{false, true} {
+		name := "without --yes"
+		if yes {
+			name = "with --yes"
+		}
+		t.Run(name, func(t *testing.T) {
+			env := setupTest(t)
+
+			env.simplePkg("dryrun-pkg")
+			env.AssertPackageInDatabase("dryrun-pkg", true)
+
+			if err := cli.RunGC(true, "", false, yes); err != nil {
+				t.Fatalf("Failed to run GC dry-run: %v", err)
+			}
+			env.AssertPackageInDatabase("dryrun-pkg", true)
+		})
+	}
 }
 
 // TestGCWithAge exercises the --older-than age filter.
@@ -80,7 +115,7 @@ func TestGCWithAge(t *testing.T) {
 
 	// A large threshold must PROTECT freshly published orphans: nothing older
 	// than ~100 years exists, so neither package may be removed.
-	if err := cli.RunGC(false, "36500d", false); err != nil {
+	if err := cli.RunGC(false, "36500d", false, true); err != nil {
 		t.Fatalf("Failed to run GC with large age threshold: %v", err)
 	}
 	env.AssertPackageInDatabase("old-pkg", true)
@@ -89,7 +124,7 @@ func TestGCWithAge(t *testing.T) {
 	// A zero threshold ("0d") bypasses the age check entirely, so the orphaned
 	// packages must now be removed. This proves the filter is actually wired to
 	// the threshold rather than always-protecting or always-deleting.
-	if err := cli.RunGC(false, "0d", false); err != nil {
+	if err := cli.RunGC(false, "0d", false, true); err != nil {
 		t.Fatalf("Failed to run GC with zero age threshold: %v", err)
 	}
 	env.AssertPackageInDatabase("old-pkg", false)
@@ -120,7 +155,7 @@ func TestGCOrphanedLinks(t *testing.T) {
 	}
 	env.AssertDatabaseLink("link-pkg", projectDir) // still recorded, now orphaned
 
-	if err := cli.RunGC(false, "", true); err != nil {
+	if err := cli.RunGC(false, "", true, true); err != nil {
 		t.Fatalf("Failed to run GC: %v", err)
 	}
 	env.AssertDatabaseNoLink("link-pkg", projectDir)
@@ -142,7 +177,7 @@ func TestGCPartiallyOrphanedLinks(t *testing.T) {
 		t.Fatalf("Failed to remove project-1: %v", err)
 	}
 
-	if err := cli.RunGC(false, "", true); err != nil {
+	if err := cli.RunGC(false, "", true, true); err != nil {
 		t.Fatalf("Failed to run GC: %v", err)
 	}
 
@@ -164,7 +199,7 @@ func TestGCKeepsLinkedAndCollectsOrphans(t *testing.T) {
 	env.addPkg(projectDir, "linked-pkg", false, false)
 	env.AssertDatabaseLink("linked-pkg", projectDir)
 
-	if err := cli.RunGC(false, "", false); err != nil {
+	if err := cli.RunGC(false, "", false, true); err != nil {
 		t.Fatalf("Failed to run GC: %v", err)
 	}
 
@@ -177,7 +212,7 @@ func TestGCKeepsLinkedAndCollectsOrphans(t *testing.T) {
 func TestGCNoPackages(t *testing.T) {
 	_ = setupTest(t)
 
-	if err := cli.RunGC(false, "", false); err != nil {
+	if err := cli.RunGC(false, "", false, true); err != nil {
 		t.Fatalf("Failed to run GC: %v", err)
 	}
 }
@@ -200,7 +235,7 @@ func TestGCStorePathCleanup(t *testing.T) {
 		t.Fatalf("Store path doesn't exist: %v", err)
 	}
 
-	if err := cli.RunGC(false, "", false); err != nil {
+	if err := cli.RunGC(false, "", false, true); err != nil {
 		t.Fatalf("Failed to run GC: %v", err)
 	}
 	if _, err := os.Stat(storePath); !os.IsNotExist(err) {
@@ -212,7 +247,7 @@ func TestGCStorePathCleanup(t *testing.T) {
 func TestGCInvalidDuration(t *testing.T) {
 	_ = setupTest(t)
 
-	if err := cli.RunGC(false, "invalid", false); err == nil {
+	if err := cli.RunGC(false, "invalid", false, false); err == nil {
 		t.Fatal("Expected error with invalid duration, got nil")
 	}
 }
@@ -223,7 +258,7 @@ func TestGCDurationFormats(t *testing.T) {
 
 	env.simplePkg("duration-pkg")
 	for _, dur := range []string{"24h", "7d", "1w"} {
-		if err := cli.RunGC(true, dur, false); err != nil {
+		if err := cli.RunGC(true, dur, false, false); err != nil {
 			t.Errorf("GC failed with duration %s: %v", dur, err)
 		}
 	}

--- a/tests/remove_test.go
+++ b/tests/remove_test.go
@@ -32,7 +32,7 @@ func TestRemoveVariants(t *testing.T) {
 			env.AssertSymlinkExists(projectDir, tc.pkgName)
 			env.AssertDatabaseLink(tc.pkgName, projectDir)
 
-			if err := cli.RunRemove(tc.pkgName, false); err != nil {
+			if err := cli.RunRemove(tc.pkgName, false, false); err != nil {
 				t.Fatalf("Failed to remove package: %v", err)
 			}
 
@@ -61,7 +61,7 @@ func TestRemoveRestoresOriginalVersion(t *testing.T) {
 	env.addPkg(projectDir, "remove-pkg", false, false)
 	env.AssertPackageJSON(projectDir, "remove-pkg", "file:.lnpm/remove-pkg")
 
-	if err := cli.RunRemove("remove-pkg", false); err != nil {
+	if err := cli.RunRemove("remove-pkg", false, false); err != nil {
 		t.Fatalf("Failed to remove package: %v", err)
 	}
 	env.AssertPackageJSON(projectDir, "remove-pkg", "^1.0.0")
@@ -72,7 +72,7 @@ func TestRemovePackageNotLinked(t *testing.T) {
 	env := setupTest(t)
 
 	env.newProject("test-project")
-	if err := cli.RunRemove("nonexistent-pkg", false); err == nil {
+	if err := cli.RunRemove("nonexistent-pkg", false, false); err == nil {
 		t.Fatal("Expected error when removing non-linked package, got nil")
 	}
 }
@@ -87,7 +87,7 @@ func TestRemoveNoOriginalVersion(t *testing.T) {
 	env.addPkg(projectDir, "pure-pkg", false, true)
 	env.AssertPackageJSONMissing(projectDir, "pure-pkg")
 
-	if err := cli.RunRemove("pure-pkg", false); err != nil {
+	if err := cli.RunRemove("pure-pkg", false, false); err != nil {
 		t.Fatalf("Failed to remove package: %v", err)
 	}
 	env.AssertPackageJSONMissing(projectDir, "pure-pkg")
@@ -106,7 +106,7 @@ func TestRemoveAllPackages(t *testing.T) {
 		env.addPkg(projectDir, name, false, false)
 	}
 
-	if err := cli.RunRemove("", true); err != nil {
+	if err := cli.RunRemove("", true, true); err != nil {
 		t.Fatalf("Failed to remove all packages: %v", err)
 	}
 
@@ -118,12 +118,37 @@ func TestRemoveAllPackages(t *testing.T) {
 	env.AssertLockfileExists(projectDir, false)
 }
 
+// TestRemoveAllWithoutYesKeepsPackages tests that a non-interactive --all
+// without --yes refuses: every link, symlink and the lock file survive.
+func TestRemoveAllWithoutYesKeepsPackages(t *testing.T) {
+	env := setupTest(t)
+
+	packages := []string{"keep-a", "keep-b"}
+	for _, name := range packages {
+		env.simplePkg(name)
+	}
+	projectDir := env.newProject("test-project")
+	for _, name := range packages {
+		env.addPkg(projectDir, name, false, false)
+	}
+
+	if err := cli.RunRemove("", true, false); err != nil {
+		t.Fatalf("Remove --all without --yes failed: %v", err)
+	}
+
+	for _, name := range packages {
+		env.AssertSymlinkExists(projectDir, name)
+		env.AssertDatabaseLink(name, projectDir)
+	}
+	env.AssertLockfileExists(projectDir, true)
+}
+
 // TestRemoveAllNoPackages tests --all when nothing is linked is a safe no-op.
 func TestRemoveAllNoPackages(t *testing.T) {
 	env := setupTest(t)
 
 	projectDir := env.newProject("test-project")
-	if err := cli.RunRemove("", true); err != nil {
+	if err := cli.RunRemove("", true, true); err != nil {
 		t.Fatalf("Remove --all with no packages failed: %v", err)
 	}
 	env.AssertLockfileExists(projectDir, false)
@@ -143,7 +168,7 @@ func TestRemoveKeepsOthers(t *testing.T) {
 		env.addPkg(projectDir, name, false, false)
 	}
 
-	if err := cli.RunRemove("pkg-b", false); err != nil {
+	if err := cli.RunRemove("pkg-b", false, false); err != nil {
 		t.Fatalf("Failed to remove pkg-b: %v", err)
 	}
 


### PR DESCRIPTION
Closes #160

## Problem

`confirm()` returned `true` (proceed) whenever stdin or stdout was not a terminal, so every non-interactive invocation of a destructive command deleted immediately with no prompt — and there was no `--yes` flag, so no safe non-interactive path existed either. `lnpm gc --older-than 30d | tee gc.log` silently deleted every matching package from the store because stdout was a pipe. Same under CI, `nohup`, or plain output redirection.

Two commands were affected: `lnpm gc` (deletes store packages) and `lnpm remove --all` (unlinks every package from the project).

## Change

- Extracted the policy into a pure `shouldProceed(interactive, yes) (confirmDecision, string)` returning one of `decisionAsk` / `decisionProceed` / `decisionAbort`. `confirm` is now a thin wrapper that determines `interactive` from the TTY checks and only falls through to the real prompt when the decision is `decisionAsk`. The three-valued return is what lets the interactive path stay reachable while the decision itself is testable without touching `os.Stdin`/`os.Stdout`.
- Added `--yes`/`-y` to `gcCmd` and `removeCmd`, threaded through `RunGC` and `RunRemove` to the two `confirm` call sites.
- Non-interactive without `--yes` now aborts with `Refusing to proceed without confirmation; re-run with --yes`; non-interactive with `--yes` proceeds; the interactive prompt is unchanged.

`--yes` also skips the prompt on a TTY, matching the universal meaning of `-y` in `apt`/`npm`/`dnf`. A flag that silently did nothing depending on where stdout pointed would give it two meanings.

## Acceptance criteria

- [x] `lnpm gc | cat` and `lnpm remove --all | cat` abort with a clear message and delete nothing
- [x] `lnpm gc --yes | cat` and `lnpm remove --all --yes | cat` proceed with deletion
- [x] `lnpm gc` interactively still prompts and honors `y`/`n`
- [x] `--dry-run` still reports without deleting regardless of `--yes`

## Tests

- `TestShouldProceed` — the pure decision, all four `(interactive, yes)` combinations.
- `TestGCWithoutYesKeepsOrphans` — a real orphan survives `RunGC(..., yes=false)` in both the database and the store.
- `TestRemoveAllWithoutYesKeepsPackages` — symlinks, database links and the lock file all survive `RunRemove("", true, false)`.
- `TestGCDryRun` is now a two-case loop over `yes`, pinning the "regardless of `--yes`" half of the dry-run criterion.

The command-level tests were mutation-verified: flipping `shouldProceed`'s abort branch back to `decisionProceed` fails `TestGCWithoutYesKeepsOrphans`, `TestRemoveAllWithoutYesKeepsPackages` and `TestShouldProceed`.

Existing `gc`/`remove` tests that relied on the old non-interactive auto-proceed to actually delete now pass `yes=true` — a restoration of the behavior they depended on, not a weakened assertion. Dry-run and error paths keep `yes=false`.

Verified against a real binary in a throwaway `HOME` with a live orphan in the store: `gc | cat` refuses and the package is still listed afterwards; `gc --yes | cat` removes it.