### PR TITLE
Upgrade the pinned Go toolchain off end-of-life 1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -65,10 +65,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
           only-new-issues: true
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -112,7 +112,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Build for all platforms
         run: make release

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -36,13 +36,13 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Run tests
         run: go test -v -race ./...
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -118,7 +118,7 @@ Reliability and correctness across all platforms. Every operation must work corr
 - **Package manager compatibility**: Must support npm, yarn, pnpm, bun — all existing integrations must continue working
 - **Backward compatibility**: Cannot break existing databases or lock files — migration paths required for schema changes
 - **No external dependencies**: CLI tool remains standalone binary with no runtime dependencies
-- **Go 1.22+**: Maintain current Go version requirement
+- **Go 1.26+**: Maintain current Go version requirement
 
 ## Key Decisions
 

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -5,7 +5,7 @@
 ## Languages
 
 **Primary:**
-- Go 1.22 - All application code, CLI, internal packages
+- Go 1.26 - All application code, CLI, internal packages
 
 **Secondary:**
 - Shell script - Installation script (`install.sh`)
@@ -14,7 +14,7 @@
 ## Runtime
 
 **Environment:**
-- Go 1.22+
+- Go 1.26+
 
 **Package Manager:**
 - Go modules (go.mod/go.sum)
@@ -72,7 +72,7 @@
 ## Platform Requirements
 
 **Development:**
-- Go 1.22+ required
+- Go 1.26+ required
 - Optional: golangci-lint, goimports, entr (for watch mode)
 - Git hooks support via `.githooks/`
 

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -229,7 +229,7 @@ env.AssertLockfile(projectPath, func(lock *lockfile.LockFile) {
 
 **Platform Testing:**
 - Primary: `ubuntu-latest`
-- Go version: `1.22` (defined in workflow and `go.mod`)
+- Go version: `1.26` (defined in `go.mod`, which workflows read via `go-version-file`)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ make bench-compare  # Compare vs yalc (if installed)
 
 ## Requirements
 
-- Go 1.22+ (for building from source)
+- Go 1.26+ (for building from source)
 - Node.js project with `package.json`
 
 ## Contributing
@@ -446,7 +446,7 @@ Contributions are welcome!
 
 ### Prerequisites
 
-- Go 1.22+
+- Go 1.26+
 - Node.js (for integration tests that invoke npm)
 
 ### Setup & Testing

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pedrosousa13/lnpm
 
-go 1.22
+go 1.26
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1


### PR DESCRIPTION
Closes #173

## Problem

Go supports only the two most recent major releases. Verified against the live release list today, the supported lines are **1.26.6** and **1.25.13** — so `go 1.22` is end of life and no longer receives standard-library security fixes. Every binary published to GitHub Releases silently missed them, with no error anywhere in the pipeline to make the drift visible.

## Change

- `go.mod`: `go 1.22` → `go 1.26`. `go mod tidy` produces a zero-byte diff; `go.sum` is untouched.
- All **five** `actions/setup-go@v5` steps now use `go-version-file: go.mod` instead of a hardcoded version — four in `ci.yaml` (Test, Lint, Test (Windows), Build) and one in `release-please.yaml`. `go.mod` becomes the single source of truth, so the version can no longer drift between files.
- Corrected the Go version claims in `README.md` and in the tracked `.planning/` docs, which are the same drift this issue is about. `.planning/codebase/TESTING.md` also asserted the version was "defined in workflow and `go.mod`" — no longer true, since the workflows now read it.

### Why 1.26 and not the brief's suggested 1.25

1.25 leaves support the moment 1.27 ships, and 1.26.6 is already out on the usual six-month cadence — picking the line that expires soonest would recreate this issue within weeks. The acceptance criterion asks only for "a currently supported Go version".

### No `toolchain` directive

Deliberately absent. `actions/setup-go` treats a `toolchain` line in `go.mod` as an exact pin, so one would freeze CI on a single patch release and stop it picking up Go patch-level security fixes — precisely the failure this issue is about. With a bare `go 1.26`, setup-go installs the newest available 1.26.x.

## Acceptance criteria

- [x] `go.mod` declares a currently supported Go version
- [x] All five `setup-go` steps use `go-version-file: go.mod`
- [x] `go test -race ./...` passes — **CI's evidence**, see below
- [x] `make release` produces binaries for all platforms — **CI's evidence**, see below
- [ ] The CI and release workflows pass on this PR

## Verification

Locally, under the toolchain the new directive selects (`go version` reports `go1.26.0`, up from `go1.24.2`): `go build ./...`, `go vet ./...` and `gofmt -l .` all clean, and `go test -count=1 ./...` green in every package. The stricter 1.26 vet found nothing, and no `.go` file needed changing.

Two criteria could not be checked on the dev machine and are CI's to prove:

- **`-race`** cannot link there — no gcc, so the race runtime is unavailable. CI runs `go test -race` on both Linux and Windows.
- **`make release`** — `make` is not installed there. The five `go build` lines from the `release:` target were run verbatim instead, producing all five platform binaries, each confirmed with `file` to be the right OS/arch (linux amd64/arm64, darwin amd64/arm64, windows amd64). CI's Build job runs the real `make release`.

## Out of scope

No dependency versions changed — `golang.org/x/mod` stays at `v0.17.0`. Unpinning it needs the newer toolchain and belongs to #176. No CI matrix changes, no new Go language features.

## Follow-on

This unblocks the macOS CI job proposed in #174: Go 1.22.12 on darwin-arm64 emits a Mach-O binary with no `LC_UUID` load command, which Apple's `dyld` refuses to load, so that job could not run a single test under the old toolchain. Draft PR #215 is the verification and should be re-run and taken out of draft once this lands — which in turn unblocks #135.