### PR TITLE
Add tests for the self-update flow (download, checksum, extraction, cache)

### DIFF
--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -26,6 +26,10 @@ import (
 // hung connection can't block the updater indefinitely.
 var updateHTTPClient = &http.Client{Timeout: 2 * time.Minute}
 
+// releaseBaseURL is the root under which release assets are published. It is a
+// var so tests can point it at a local httptest server instead of GitHub.
+var releaseBaseURL = "https://github.com/pedrosousa13/lnpm/releases/download"
+
 // updateCmd updates lnpm to the latest version
 var updateCmd = &cobra.Command{
 	Use:   "update",
@@ -230,7 +234,7 @@ func buildDownloadURL(version string) (string, string) {
 		filename = fmt.Sprintf("lnpm_%s_%s_%s.tar.gz", version, os, arch)
 	}
 
-	url := fmt.Sprintf("https://github.com/pedrosousa13/lnpm/releases/download/v%s/%s", version, filename)
+	url := fmt.Sprintf("%s/v%s/%s", releaseBaseURL, version, filename)
 	return filename, url
 }
 
@@ -300,7 +304,7 @@ func downloadToFile(url, dst string) error {
 // buildChecksumsURL returns the checksums.txt URL for a release version.
 func buildChecksumsURL(version string) string {
 	version = strings.TrimPrefix(version, "v")
-	return fmt.Sprintf("https://github.com/pedrosousa13/lnpm/releases/download/v%s/checksums.txt", version)
+	return fmt.Sprintf("%s/v%s/checksums.txt", releaseBaseURL, version)
 }
 
 // verifyChecksum computes the SHA-256 of filePath and compares it to the entry

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -1,8 +1,23 @@
 package cli
 
+// Note: the binary swap itself (RunUpdate / installLatestViaBinary) is not
+// covered here. It rewrites os.Executable() in place, which is process-global
+// and not safely reversible inside a test run; it is exercised manually on
+// each release instead.
+
 import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -36,5 +51,358 @@ func TestSha256File(t *testing.T) {
 	}
 	if got != want {
 		t.Errorf("sha256File = %s, want %s", got, want)
+	}
+}
+
+func TestReleaseBaseURLDefault(t *testing.T) {
+	// The base URL was extracted into a var purely for testability; the default
+	// must stay byte-identical to the previously hardcoded release root.
+	if releaseBaseURL != "https://github.com/pedrosousa13/lnpm/releases/download" {
+		t.Errorf("releaseBaseURL = %q, want https://github.com/pedrosousa13/lnpm/releases/download", releaseBaseURL)
+	}
+}
+
+func TestBuildDownloadURL(t *testing.T) {
+	ext := ".tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = ".zip"
+	}
+
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{"bare version", "1.2.3", "1.2.3"},
+		{"v-prefixed version", "v1.2.3", "1.2.3"},
+		{"pre-release version", "v2.0.0-rc.1", "2.0.0-rc.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wantFilename := fmt.Sprintf("lnpm_%s_%s_%s%s", tt.want, runtime.GOOS, runtime.GOARCH, ext)
+			wantURL := releaseBaseURL + "/v" + tt.want + "/" + wantFilename
+
+			filename, url := buildDownloadURL(tt.version)
+			if filename != wantFilename {
+				t.Errorf("buildDownloadURL(%q) filename = %q, want %q", tt.version, filename, wantFilename)
+			}
+			if url != wantURL {
+				t.Errorf("buildDownloadURL(%q) url = %q, want %q", tt.version, url, wantURL)
+			}
+		})
+	}
+}
+
+func TestBuildChecksumsURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{"bare version", "1.2.3", releaseBaseURL + "/v1.2.3/checksums.txt"},
+		{"v-prefixed version", "v1.2.3", releaseBaseURL + "/v1.2.3/checksums.txt"},
+		{"pre-release version", "v2.0.0-rc.1", releaseBaseURL + "/v2.0.0-rc.1/checksums.txt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildChecksumsURL(tt.version); got != tt.want {
+				t.Errorf("buildChecksumsURL(%q) = %q, want %q", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+type archiveEntry struct {
+	name    string
+	content string
+}
+
+// writeTarGz builds a gzipped tar from entries and returns its path.
+func writeTarGz(t *testing.T, entries []archiveEntry) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for _, e := range entries {
+		hdr := &tar.Header{Typeflag: tar.TypeReg, Name: e.name, Mode: 0755, Size: int64(len(e.content))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(e.content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(t.TempDir(), "archive.tar.gz")
+	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// writeZip builds a zip from entries and returns its path.
+func writeZip(t *testing.T, entries []archiveEntry) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, e := range entries {
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: e.name, Method: zip.Deflate})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(e.content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(t.TempDir(), "archive.zip")
+	if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// extractDirs returns a destination directory nested two levels under a root,
+// plus the path an entry named "../../evil/lnpm" would land on if the extractor
+// failed to neutralise it. The escape directory is created up front so a
+// vulnerable extractor would succeed in writing there, making the difference
+// between "protected" and "vulnerable" observable.
+func extractDirs(t *testing.T) (tmpDir, escapePath string) {
+	t.Helper()
+
+	root := t.TempDir()
+	tmpDir = filepath.Join(root, "nested", "dest")
+	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "evil"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return tmpDir, filepath.Join(root, "evil", "lnpm")
+}
+
+// assertExtracted checks the extractor returned a file directly inside tmpDir
+// holding exactly want.
+func assertExtracted(t *testing.T, got, tmpDir, want string) {
+	t.Helper()
+
+	if dir := filepath.Dir(got); dir != tmpDir {
+		t.Errorf("extracted to %q, want a file directly inside %q", got, tmpDir)
+	}
+	data, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatalf("reading extracted binary: %v", err)
+	}
+	if string(data) != want {
+		t.Errorf("extracted content = %q, want %q", data, want)
+	}
+}
+
+func TestExtractTarGzFindsBinary(t *testing.T) {
+	archive := writeTarGz(t, []archiveEntry{
+		{"README.md", "docs, not the binary"},
+		{"lnpm", "binary-payload"},
+	})
+	tmpDir := t.TempDir()
+
+	got, err := extractTarGz(archive, tmpDir)
+	if err != nil {
+		t.Fatalf("extractTarGz returned error: %v", err)
+	}
+	assertExtracted(t, got, tmpDir, "binary-payload")
+}
+
+func TestExtractTarGzBinaryMissing(t *testing.T) {
+	archive := writeTarGz(t, []archiveEntry{
+		{"README.md", "docs"},
+		{"LICENSE", "license"},
+	})
+
+	got, err := extractTarGz(archive, t.TempDir())
+	if err == nil {
+		t.Fatalf("extractTarGz = %q, want an error when no binary is present", got)
+	}
+	if !strings.Contains(err.Error(), "lnpm binary not found in archive") {
+		t.Errorf("error = %q, want it to mention the binary was not found", err)
+	}
+}
+
+func TestExtractTarGzRejectsPathTraversal(t *testing.T) {
+	archive := writeTarGz(t, []archiveEntry{{"../../evil/lnpm", "pwned"}})
+	tmpDir, escapePath := extractDirs(t)
+
+	got, err := extractTarGz(archive, tmpDir)
+	if err != nil {
+		t.Fatalf("extractTarGz returned error: %v", err)
+	}
+	assertExtracted(t, got, tmpDir, "pwned")
+	if _, err := os.Stat(escapePath); !os.IsNotExist(err) {
+		t.Errorf("traversal entry escaped the temp dir: %q exists (stat err %v)", escapePath, err)
+	}
+}
+
+func TestExtractZipFindsBinary(t *testing.T) {
+	archive := writeZip(t, []archiveEntry{
+		{"README.md", "docs, not the binary"},
+		{"lnpm.exe", "binary-payload"},
+	})
+	tmpDir := t.TempDir()
+
+	got, err := extractZip(archive, tmpDir)
+	if err != nil {
+		t.Fatalf("extractZip returned error: %v", err)
+	}
+	assertExtracted(t, got, tmpDir, "binary-payload")
+}
+
+func TestExtractZipBinaryMissing(t *testing.T) {
+	archive := writeZip(t, []archiveEntry{
+		{"README.md", "docs"},
+		{"LICENSE", "license"},
+	})
+
+	got, err := extractZip(archive, t.TempDir())
+	if err == nil {
+		t.Fatalf("extractZip = %q, want an error when no binary is present", got)
+	}
+	if !strings.Contains(err.Error(), "lnpm binary not found in archive") {
+		t.Errorf("error = %q, want it to mention the binary was not found", err)
+	}
+}
+
+func TestExtractZipRejectsPathTraversal(t *testing.T) {
+	archive := writeZip(t, []archiveEntry{{"../../evil/lnpm", "pwned"}})
+	tmpDir, escapePath := extractDirs(t)
+
+	got, err := extractZip(archive, tmpDir)
+	if err != nil {
+		t.Fatalf("extractZip returned error: %v", err)
+	}
+	assertExtracted(t, got, tmpDir, "pwned")
+	if _, err := os.Stat(escapePath); !os.IsNotExist(err) {
+		t.Errorf("traversal entry escaped the temp dir: %q exists (stat err %v)", escapePath, err)
+	}
+}
+
+func TestDownloadToFile(t *testing.T) {
+	const payload = "release-archive-bytes"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	dst := filepath.Join(t.TempDir(), "archive.tar.gz")
+	if err := downloadToFile(srv.URL+"/archive.tar.gz", dst); err != nil {
+		t.Fatalf("downloadToFile returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != payload {
+		t.Errorf("downloaded content = %q, want %q", data, payload)
+	}
+}
+
+func TestDownloadToFileNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	err := downloadToFile(srv.URL+"/missing.tar.gz", filepath.Join(t.TempDir(), "out"))
+	if err == nil {
+		t.Fatal("downloadToFile returned nil, want an error on 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error = %q, want it to mention status 404", err)
+	}
+}
+
+// startReleaseServer points releaseBaseURL at a local test server serving the
+// given checksums.txt body for the duration of the test.
+//
+// Don't use t.Parallel() in callers - this helper swaps the process-wide
+// releaseBaseURL var.
+func startReleaseServer(t *testing.T, checksums string) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/checksums.txt") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(checksums))
+	}))
+	t.Cleanup(srv.Close)
+
+	prev := releaseBaseURL
+	releaseBaseURL = srv.URL
+	t.Cleanup(func() { releaseBaseURL = prev })
+}
+
+// writeArchiveFixture writes content to a temp file and returns its path plus
+// the hex SHA-256 of the content, computed independently of production code.
+func writeArchiveFixture(t *testing.T, filename, content string) (string, string) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), filename)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256([]byte(content))
+	return path, hex.EncodeToString(sum[:])
+}
+
+func TestVerifyChecksumMatches(t *testing.T) {
+	const filename = "lnpm_1.2.3_linux_amd64.tar.gz"
+	path, sum := writeArchiveFixture(t, filename, "archive-bytes")
+	startReleaseServer(t, fmt.Sprintf("0000  other-file.zip\n%s  %s\n", sum, filename))
+
+	if err := verifyChecksum("1.2.3", filename, path); err != nil {
+		t.Errorf("verifyChecksum returned error: %v", err)
+	}
+}
+
+func TestVerifyChecksumMismatch(t *testing.T) {
+	const filename = "lnpm_1.2.3_linux_amd64.tar.gz"
+	path, _ := writeArchiveFixture(t, filename, "archive-bytes")
+	tampered := strings.Repeat("ab", 32)
+	startReleaseServer(t, fmt.Sprintf("%s  %s\n", tampered, filename))
+
+	err := verifyChecksum("1.2.3", filename, path)
+	if err == nil {
+		t.Fatal("verifyChecksum returned nil for a tampered archive, want a mismatch error")
+	}
+	if !strings.Contains(err.Error(), "mismatch") {
+		t.Errorf("error = %q, want it to mention a mismatch", err)
+	}
+}
+
+func TestVerifyChecksumNotListed(t *testing.T) {
+	const filename = "lnpm_1.2.3_linux_amd64.tar.gz"
+	path, sum := writeArchiveFixture(t, filename, "archive-bytes")
+	startReleaseServer(t, fmt.Sprintf("%s  lnpm_1.2.3_darwin_arm64.tar.gz\n", sum))
+
+	err := verifyChecksum("1.2.3", filename, path)
+	if err == nil {
+		t.Fatal("verifyChecksum returned nil for an unlisted file, want an error")
+	}
+	if !strings.Contains(err.Error(), "no checksum listed") {
+		t.Errorf("error = %q, want it to mention no checksum was listed", err)
 	}
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -21,6 +21,10 @@ const (
 	requestTimeout = 500 * time.Millisecond
 )
 
+// githubAPIBaseURL is the GitHub API root. It is a var so tests can point it at
+// a local httptest server instead of the real API.
+var githubAPIBaseURL = "https://api.github.com"
+
 type cacheFile struct {
 	LastCheck     time.Time `json:"last_check"`
 	LatestVersion string    `json:"latest_version"`
@@ -159,7 +163,7 @@ func saveCache(cachePath, version string) {
 }
 
 func fetchLatestVersion(ctx context.Context) (string, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", githubRepo)
+	url := fmt.Sprintf("%s/repos/%s/releases/latest", githubAPIBaseURL, githubRepo)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,6 +1,16 @@
 package update
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
 
 func TestCompareVersions(t *testing.T) {
 	tests := []struct {
@@ -33,4 +43,291 @@ func TestCompareVersions(t *testing.T) {
 			}
 		})
 	}
+}
+
+// startAPIServer points githubAPIBaseURL at a local test server for the
+// duration of the test and returns a counter of requests it received. The
+// counter is atomic because the handler runs on the server's goroutines.
+//
+// Don't use t.Parallel() in callers - this helper swaps the process-wide
+// githubAPIBaseURL var.
+func startAPIServer(t *testing.T, handler http.HandlerFunc) *atomic.Int64 {
+	t.Helper()
+
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		handler(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	prev := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	t.Cleanup(func() { githubAPIBaseURL = prev })
+
+	return &hits
+}
+
+func TestGithubAPIBaseURLDefault(t *testing.T) {
+	// The base URL was extracted into a var purely for testability; the default
+	// must stay byte-identical to the previously hardcoded API root.
+	if githubAPIBaseURL != "https://api.github.com" {
+		t.Errorf("githubAPIBaseURL = %q, want https://api.github.com", githubAPIBaseURL)
+	}
+}
+
+func TestFetchLatestVersion(t *testing.T) {
+	wantPath := "/repos/" + githubRepo + "/releases/latest"
+	hits := startAPIServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != wantPath {
+			t.Errorf("request path = %q, want %q", r.URL.Path, wantPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name": "v1.2.3"}`))
+	})
+
+	got, err := fetchLatestVersion(context.Background())
+	if err != nil {
+		t.Fatalf("fetchLatestVersion returned error: %v", err)
+	}
+	if got != "v1.2.3" {
+		t.Errorf("fetchLatestVersion = %q, want v1.2.3", got)
+	}
+	if n := hits.Load(); n != 1 {
+		t.Errorf("server hits = %d, want 1", n)
+	}
+}
+
+func TestFetchLatestVersionServerError(t *testing.T) {
+	startAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	got, err := fetchLatestVersion(context.Background())
+	if err == nil {
+		t.Fatalf("fetchLatestVersion = %q, want error on 500", got)
+	}
+	if got != "" {
+		t.Errorf("fetchLatestVersion = %q, want empty string on error", got)
+	}
+}
+
+func TestSaveAndLoadCacheRoundTrip(t *testing.T) {
+	store := t.TempDir()
+	t.Setenv("LNPM_STORE", store)
+
+	_, cachePath := loadCache()
+	if want := filepath.Join(store, "version_cache.json"); cachePath != want {
+		t.Fatalf("cachePath = %q, want %q", cachePath, want)
+	}
+
+	saveCache(cachePath, "v4.5.6")
+
+	cache, path := loadCache()
+	if path != cachePath {
+		t.Errorf("cachePath = %q, want %q", path, cachePath)
+	}
+	if cache == nil {
+		t.Fatal("loadCache returned nil cache after saveCache")
+	}
+	if cache.LatestVersion != "v4.5.6" {
+		t.Errorf("cache.LatestVersion = %q, want v4.5.6", cache.LatestVersion)
+	}
+	if time.Since(cache.LastCheck) > time.Minute {
+		t.Errorf("cache.LastCheck = %v, want ~now", cache.LastCheck)
+	}
+}
+
+func TestLoadCacheMissingFile(t *testing.T) {
+	t.Setenv("LNPM_STORE", t.TempDir())
+
+	cache, cachePath := loadCache()
+	if cache != nil {
+		t.Errorf("loadCache = %+v, want nil for a missing cache file", cache)
+	}
+	if cachePath == "" {
+		t.Error("loadCache returned an empty path; saveCache would then be a no-op")
+	}
+}
+
+func TestLoadCacheCorruptJSON(t *testing.T) {
+	store := t.TempDir()
+	t.Setenv("LNPM_STORE", store)
+
+	cachePath := filepath.Join(store, "version_cache.json")
+	if err := os.WriteFile(cachePath, []byte("{not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, path := loadCache()
+	if cache != nil {
+		t.Errorf("loadCache = %+v, want nil for corrupt JSON", cache)
+	}
+	if path != cachePath {
+		t.Errorf("cachePath = %q, want %q", path, cachePath)
+	}
+}
+
+// writeCache writes a cache file directly so the test can control LastCheck.
+func writeCache(t *testing.T, store string, lastCheck time.Time, version string) {
+	t.Helper()
+
+	data, err := json.Marshal(cacheFile{LastCheck: lastCheck, LatestVersion: version})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(store, "version_cache.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckUsesFreshCacheWithoutFetching(t *testing.T) {
+	store := t.TempDir()
+	t.Setenv("LNPM_STORE", store)
+	writeCache(t, store, time.Now(), "v9.9.9")
+
+	hits := startAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("check made an HTTP request despite a fresh cache")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	result := check("1.0.0")
+	if got := hits.Load(); got != 0 {
+		t.Errorf("server hits = %d, want 0", got)
+	}
+	if result == nil {
+		t.Fatal("check returned nil")
+	}
+	if result.LatestVersion != "v9.9.9" || !result.UpdateAvailable {
+		t.Errorf("check = %+v, want LatestVersion v9.9.9 with UpdateAvailable true", result)
+	}
+}
+
+func TestCheckRefetchesWhenCacheIsStale(t *testing.T) {
+	store := t.TempDir()
+	t.Setenv("LNPM_STORE", store)
+	writeCache(t, store, time.Now().Add(-25*time.Hour), "v9.9.9")
+
+	hits := startAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name": "v2.0.0"}`))
+	})
+
+	result := check("1.0.0")
+	if got := hits.Load(); got != 1 {
+		t.Errorf("server hits = %d, want 1", got)
+	}
+	if result == nil {
+		t.Fatal("check returned nil")
+	}
+	if result.LatestVersion != "v2.0.0" {
+		t.Errorf("check = %+v, want LatestVersion v2.0.0 from the refetch", result)
+	}
+
+	// The refetch must also refresh the cache on disk.
+	cache, _ := loadCache()
+	if cache == nil || cache.LatestVersion != "v2.0.0" {
+		t.Errorf("cache after refetch = %+v, want LatestVersion v2.0.0", cache)
+	}
+}
+
+func TestCheckFreshBypassesCache(t *testing.T) {
+	store := t.TempDir()
+	t.Setenv("LNPM_STORE", store)
+	writeCache(t, store, time.Now(), "v9.9.9")
+
+	hits := startAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name": "v3.0.0"}`))
+	})
+
+	result := CheckFresh("1.0.0")
+	if got := hits.Load(); got != 1 {
+		t.Errorf("server hits = %d, want 1 (CheckFresh must ignore a fresh cache)", got)
+	}
+	if result == nil {
+		t.Fatal("CheckFresh returned nil")
+	}
+	if result.LatestVersion != "v3.0.0" || !result.UpdateAvailable {
+		t.Errorf("CheckFresh = %+v, want LatestVersion v3.0.0 with UpdateAvailable true", result)
+	}
+
+	cache, _ := loadCache()
+	if cache == nil || cache.LatestVersion != "v3.0.0" {
+		t.Errorf("cache after CheckFresh = %+v, want LatestVersion v3.0.0", cache)
+	}
+}
+
+func TestCheckFreshSkipsDevBuilds(t *testing.T) {
+	t.Setenv("LNPM_STORE", t.TempDir())
+	startAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("CheckFresh made an HTTP request for a dev build")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	for _, v := range []string{"dev", ""} {
+		if result := CheckFresh(v); result != nil {
+			t.Errorf("CheckFresh(%q) = %+v, want nil", v, result)
+		}
+	}
+}
+
+// drain reads a result channel to completion, which also guarantees the
+// background goroutine has finished before the test's cleanups run.
+func drain(ch <-chan *Result) []*Result {
+	var got []*Result
+	for r := range ch {
+		got = append(got, r)
+	}
+	return got
+}
+
+func TestCheckAsyncDeliversAvailableUpdate(t *testing.T) {
+	t.Setenv("LNPM_NO_UPDATE_CHECK", "")
+	t.Setenv("LNPM_STORE", t.TempDir())
+	startAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name": "v9.0.0"}`))
+	})
+
+	got := drain(CheckAsync("1.0.0"))
+	if len(got) != 1 {
+		t.Fatalf("CheckAsync delivered %d results, want 1", len(got))
+	}
+	if got[0].LatestVersion != "v9.0.0" || !got[0].UpdateAvailable {
+		t.Errorf("CheckAsync = %+v, want LatestVersion v9.0.0 with UpdateAvailable true", got[0])
+	}
+}
+
+func TestCheckAsyncStaysSilentWhenUpToDate(t *testing.T) {
+	t.Setenv("LNPM_NO_UPDATE_CHECK", "")
+	t.Setenv("LNPM_STORE", t.TempDir())
+	startAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name": "v1.0.0"}`))
+	})
+
+	if got := drain(CheckAsync("1.0.0")); len(got) != 0 {
+		t.Errorf("CheckAsync delivered %+v, want nothing when already up to date", got)
+	}
+}
+
+func TestCheckAsyncDisabled(t *testing.T) {
+	t.Setenv("LNPM_STORE", t.TempDir())
+	startAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("CheckAsync made an HTTP request while disabled")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	t.Run("via LNPM_NO_UPDATE_CHECK", func(t *testing.T) {
+		t.Setenv("LNPM_NO_UPDATE_CHECK", "1")
+		if got := drain(CheckAsync("1.0.0")); len(got) != 0 {
+			t.Errorf("CheckAsync delivered %+v, want nothing", got)
+		}
+	})
+
+	t.Run("for dev builds", func(t *testing.T) {
+		t.Setenv("LNPM_NO_UPDATE_CHECK", "")
+		for _, v := range []string{"dev", ""} {
+			if got := drain(CheckAsync(v)); len(got) != 0 {
+				t.Errorf("CheckAsync(%q) delivered %+v, want nothing", v, got)
+			}
+		}
+	})
 }


### PR DESCRIPTION
Closes #181

## Problem

`lnpm update` downloads and replaces the running binary — the riskiest path in the tool — and it was essentially uncovered. `internal/update` sat at **6.0%**; the checksum and archive-extraction code, which is the security boundary, had no tests at all. A regression there installs a tampered binary or bricks an installation, silently.

## Change

A two-line testability refactor per package, then tests. `internal/update/update.go` gains `var githubAPIBaseURL`, and `internal/cli/update.go` gains `var releaseBaseURL` (used by both `buildDownloadURL` and `buildChecksumsURL`), so tests can point them at an `httptest.Server`. That is the entire production diff.

27 test functions cover version fetching, the 24h cache, URL construction, download, checksum verification, and `tar.gz`/`zip` extraction.

| Package | Before | After |
| --- | --- | --- |
| `internal/update` | 6.0% | **83.3%** |
| `internal/cli` | 4.7% | **9.7%** |
| whole program (`-coverpkg=./...`) | 64.6% | **69.4%** |

`internal/cli` is the whole CLI package, so per-function numbers are the meaningful figure there: `buildChecksumsURL` 100%, `buildDownloadURL` 88.9%, `extractTarGz` 82.1%, `extractZip` 81.8%, `verifyChecksum` 81.2%, `downloadToFile` 71.4%.

## The path-traversal tests are the point, so they were built not to be hollow

`extractTarGz`/`extractZip` neutralize malicious entry names like `../../evil/lnpm` by taking `filepath.Base` before writing. Nothing pinned that, so a refactor could silently reintroduce zip-slip.

A naive test extracts into a bare `t.TempDir()` — but then removing the `filepath.Base` protection makes the write target a directory that does not exist, `os.Create` fails, and the test "fails" on a missing directory rather than on the escape. It would prove nothing.

So `extractDirs` nests the destination two levels under a root and **pre-creates the escape directory**, making a vulnerable extractor genuinely succeed in writing outside the destination. The test then asserts both that the extracted file sits directly inside the destination and that `os.Stat(escapePath)` reports `IsNotExist`.

**All three security-critical tests were mutation-checked**, and a reviewer independently reproduced the kills:

- `extractTarGz` without `filepath.Base` → mutant writes `pwned` to `root/evil/lnpm`; both assertions fire.
- `extractZip` without `filepath.Base` → same.
- `verifyChecksum` returning `nil` unconditionally → `TestVerifyChecksumMismatch` and `TestVerifyChecksumNotListed` both fail. `TestVerifyChecksumMatches` survives, which is exactly why the mismatch case is the one carrying the security weight.

## Acceptance criteria

- [x] Table-driven tests for `compareVersions`, `buildDownloadURL`, `buildChecksumsURL`
- [x] `extractTarGz`/`extractZip` each tested for binary found, binary missing, and a path-traversal entry that must not escape
- [x] `downloadToFile`, `verifyChecksum`, `fetchLatestVersion` tested against a local `httptest.Server`, no real network
- [x] `loadCache`/`saveCache` round-trip plus corrupt and missing cases under a temp `LNPM_STORE`
- [x] Base-URL refactor changes no production behavior
- [x] `internal/update` coverage well above the >70% target; `internal/cli` rises measurably
- [ ] Tests pass with `-race` and on Windows — **this PR's CI is the only evidence**

## Two of the issue's premises were stale

Worth recording, because following the brief literally would have written a false claim into the suite:

1. The brief says `compareVersions` "is a lexical string comparison" and advises marking `1.9.0` vs `1.10.0` as a known limitation. **It is not** — #142 replaced it with `golang.org/x/mod/semver`, including an `IsValid` guard so an unparseable current version does not always look outdated. `{"1.9.0", "1.11.0", true}` already passes semver-correctly.
2. The brief describes `internal/update/update_test.go` as a new file. It already existed, with a table-driven `TestCompareVersions` of 13 subtests — so the first acceptance criterion was already satisfied for `compareVersions`. That test was reviewed for gaps, found adequate, and left **untouched**.

The brief's "~61.5%" whole-program coverage baseline was also stale; it measured 64.6%.

## Verification

`go build`, `go vet`, `gofmt -l` clean; `go test -count=1 ./...` green in all 14 packages; `go test -count=2 -shuffle=on` on both packages green, so no test-ordering coupling. `GOOS=windows go vet ./...` clean and both Windows test binaries compile. golangci-lint v2.12.2 with `--new-from-merge-base=main`: 0 issues.

No test can reach the network: every HTTP-touching test either overrides a base-URL var via a `t.Cleanup`-restored helper or is handed `srv.URL` directly.

**`-race` could not be run locally** — the dev machine has no gcc, so cgo cannot link the race runtime. One real race was found and fixed by reasoning rather than by a green run: a test server's hit counter was a plain `hits++` shared between the handler goroutine and the test goroutine, now an `atomic.Int64`. Reviewers found no remaining hazard on inspection, and there are no `t.Parallel()` calls in the diff, but CI is the authority here.

## Deliberately out of scope

`RunUpdate` and `installLatestViaBinary` remain untested, as the issue's step 6 directs — swapping `os.Executable()` is process-global and brittle. A comment at the top of `internal/cli/update_test.go` records that the swap is exercised manually on each release. `downloadBinary` and `wasInstalledViaGo` are also still uncovered; both appear under "Where to look" but in no acceptance criterion.

No updater behavior was changed. Separately: `internal/update/update.go:54-57` swallows fetch errors so `lnpm update` prints "Already up to date" when GitHub is unreachable — that is issue #144 and is left alone here.