### PR TITLE
Normalize root-anchored and directory patterns in the files whitelist

### DIFF
--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -406,9 +406,33 @@ func matchesIgnorePattern(relPath, baseName, pattern string, anchored, negated b
 	return !negated && strings.HasPrefix(relPath, pattern+"/")
 }
 
-// isIncluded checks if a path matches any include pattern (files field)
+// isIncluded checks if a path matches any include pattern (files field).
+//
+// Each pattern is normalized before matching, the way npm reads a "files"
+// entry. A leading "/" anchors the pattern to the package root rather than
+// naming an absolute path, and it is dropped because every match below is
+// against the full relative path: isIncluded never matches a basename, so
+// anchoring is already how it behaves and the "/" carries no information.
+// Contrast isExcluded, which keeps the leading "/" as its anchored flag
+// precisely because it does match basenames and must suppress that. Teaching
+// isIncluded to match basenames (npm's "files" does match a bare "*.md"
+// against a nested path) would mean handling anchoring here too.
+//
+// A trailing "/" marks a directory whose contents are included, and is dropped
+// only from patterns with no glob metacharacter. npm does not read a trailing
+// slash on a glob as a directory marker, so "dist/**/" matches nothing and
+// must not be normalized into "dist/**", which matches everything under dist.
+//
+// So "dist", "/dist", "dist/" and "/dist/" are all equivalent, as they are to
+// npm, and "dist/**" and "/dist/**" are equivalent to each other. "dist/**/"
+// is equivalent to none of them.
 func isIncluded(relPath string, patterns []string) bool {
 	for _, pattern := range patterns {
+		pattern = strings.TrimPrefix(pattern, "/")
+		if !strings.Contains(pattern, "*") {
+			pattern = strings.TrimSuffix(pattern, "/")
+		}
+
 		// Direct match
 		if pattern == relPath {
 			return true

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -216,6 +216,44 @@ func TestIsIncluded(t *testing.T) {
 	}
 }
 
+// TestIsIncludedPatternForms pins every spelling of a directory entry in the
+// "files" whitelist against one path. npm treats a leading "/" as anchoring to
+// the package root rather than as an absolute path, and a trailing "/" as a
+// directory marker, so the plain, anchored and "/**" spellings of "dist" all
+// ship dist/cli/index.js.
+//
+// "dist/**/" is the exception that keeps the trailing-slash normalization
+// honest: npm ships nothing from dist for it, because a trailing slash on a
+// glob is not a directory marker. Each expectation here was verified against
+// "npm pack --dry-run" on a fixture package.
+func TestIsIncludedPatternForms(t *testing.T) {
+	const relPath = "dist/cli/index.js"
+
+	tests := []struct {
+		pattern string
+		want    bool
+	}{
+		{"dist", true},
+		{"/dist", true},
+		{"dist/", true},
+		{"/dist/", true},
+		{"dist/**", true},
+		{"/dist/**", true},
+		{"dist/**/", false},
+		{"lib", false},
+		{"/lib", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern, func(t *testing.T) {
+			got := isIncluded(relPath, []string{tt.pattern})
+			if got != tt.want {
+				t.Errorf("isIncluded(%q, [%q]) = %v, want %v", relPath, tt.pattern, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsDefaultInclude(t *testing.T) {
 	tests := []struct {
 		path string
@@ -316,6 +354,84 @@ func TestPack(t *testing.T) {
 		if fileNames[name] {
 			t.Errorf("expected file %q to be excluded", name)
 		}
+	}
+}
+
+// TestPackRootAnchoredFilesWhitelist packs a real package whose "files"
+// whitelist is spelled with a leading "/", the form npm treats as anchored to
+// the package root. Regression test for #207: the anchored entries matched
+// nothing, so dist/ was silently dropped and the reporting package published
+// without the CLI entry point its "bin" field pointed at.
+//
+// Every assertion below names a path the whitelist actually controls. The
+// fixture's package.json and README.md are deliberately not asserted: they ship
+// via isDefaultInclude whatever "files" says, so asserting them would pass even
+// with the whitelist broken, which is what this test exists to catch.
+func TestPackRootAnchoredFilesWhitelist(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pkgJSON := `{
+		"name": "root-anchored-files",
+		"version": "1.0.0",
+		"files": ["/dist", "/dist-cjs", "README.md"]
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(pkgJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "README.md"), []byte("# Test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cliDir := filepath.Join(tmpDir, "dist", "cli")
+	if err := os.MkdirAll(cliDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cliDir, "index.js"), []byte("#!/usr/bin/env node"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "dist", "index.js"), []byte("module.exports = {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cjsDir := filepath.Join(tmpDir, "dist-cjs")
+	if err := os.MkdirAll(cjsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cjsDir, "index.cjs"), []byte("module.exports = {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	srcDir := filepath.Join(tmpDir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "index.ts"), []byte("export {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, files, err := Pack(tmpDir)
+	if err != nil {
+		t.Fatalf("Pack() error: %v", err)
+	}
+
+	packed := make(map[string]bool)
+	for _, f := range files {
+		packed[f.RelPath] = true
+	}
+
+	expected := []string{
+		"dist/index.js",
+		"dist/cli/index.js",
+		"dist-cjs/index.cjs",
+	}
+	for _, name := range expected {
+		if !packed[name] {
+			t.Errorf("expected %q to be packed, packed set was %v", name, packed)
+		}
+	}
+
+	if packed["src/index.ts"] {
+		t.Errorf("%q is outside the whitelist and must not be packed", "src/index.ts")
 	}
 }
 


### PR DESCRIPTION
Closes #207

## Problem

`isIncluded` matched package.json `files` entries against root-relative paths like `dist/cli/index.js` without stripping a leading `/`. So `files: ["/dist"]` matched nothing and `dist/` was **silently omitted** from the published package. A trailing `/` failed the same way, because the directory branch built the prefix `dist//`.

npm treats `"/dist"` and `"dist"` identically, so a package that publishes correctly with `npm publish` published an unusable one through `lnpm publish`. Reported against a real package (`files: ["/dist","/dist-cjs","README.md"]`, `bin: ./dist/cli/index.js`): **8 files collected instead of 349.**

The omission was self-concealing. The content hash is computed from the collected set, so a developer who notices, rebuilds, and republishes gets `already published with same content (hash: ...)` and nothing happens — the rebuild looks like the no-op, not the publish. `push` then reports `Pushed to 1/1 projects` for a package whose `bin` entrypoint does not exist, and `doctor` passes its store-integrity check because the stored files are intact; they are just not the right ones.

## Change

Normalization inside `isIncluded`, four lines:

```go
pattern = strings.TrimPrefix(pattern, "/")
if !strings.Contains(pattern, "*") {
    pattern = strings.TrimSuffix(pattern, "/")
}
```

The leading `/` is dropped unconditionally. The trailing `/` is dropped **only from patterns with no glob metacharacter** — see below.

## Every pattern form was verified against real npm

`npm pack --dry-run` (npm 11.16.0) on fixture packages, for `relPath = dist/cli/index.js`:

| pattern | npm ships it? | lnpm before | lnpm after |
| --- | --- | --- | --- |
| `dist` | yes | yes | yes |
| `/dist` | yes | **no** | yes |
| `dist/` | yes | **no** | yes |
| `/dist/` | yes | **no** | yes |
| `dist/**` | yes | yes | yes |
| `/dist/**` | yes | **no** | yes |
| `dist/**/` | **no** | no | no |
| `lib` | no | no | no |
| `/lib` | no | no | no |

`dist/**/` is why the trailing-slash trim is conditional. **npm ships nothing from `dist` for it**, because a trailing slash on a glob is not a directory marker. An unconditional trim would normalize it to `dist/**` and include everything under `dist` — over-inclusion, the mirror image of the bug being fixed here. That regression was present in the first cut of this change and was caught in review; the conditional trim is what closes it.

## Tests

- `TestIsIncludedPatternForms` — table over all 9 forms above, expectations taken from npm's observed behavior.
- `TestPackRootAnchoredFilesWhitelist` — a `Pack()`-level regression test, which is the level the bug actually manifested at. The issue notes a unit test alone would not have caught the real-world failure.

Every assertion in the regression test names a path the whitelist actually controls. `package.json` and `README.md` are deliberately **not** asserted: they ship via `isDefaultInclude` whatever `files` says, so asserting them would pass even with the whitelist completely broken. The first cut did assert them; review caught it.

**Mutation-checked**, and re-checked after the test was tightened:

```
--- FAIL: TestPackRootAnchoredFilesWhitelist
    expected "dist/index.js" to be packed, packed set was map[README.md:true package.json:true]
    expected "dist/cli/index.js" to be packed, packed set was map[README.md:true package.json:true]
    expected "dist-cjs/index.cjs" to be packed, packed set was map[README.md:true package.json:true]
```

## `isExcluded` was left alone, deliberately

The issue says there is "no equivalent normalization in `isExcluded`". That is **stale** — #150 landed since filing and `isExcluded` now handles leading-`/` anchoring at `pack.go:331-336`.

The issue also suggests extracting a shared normalization helper. Not done, on purpose: `isExcluded` keeps the leading `/` as an `anchored` **flag** because it matches basenames and must suppress that when anchored; `isIncluded` never matches basenames, so anchoring is already its default and the flag would be dead code. The two have genuinely different needs. `isIncluded`'s doc comment now records that contrast and names the trap — teaching `isIncluded` to match basenames later would mean handling anchoring here too.

## End-to-end

The issue's own two-package reproduction, against a binary built from this branch, cross-checked against npm on the same fixtures:

```
files=['/dist', '/dist-cjs', 'README.md']   lnpm=17  npm=17  AGREE
files=['dist', 'dist-cjs', 'README.md']     lnpm=17  npm=17  AGREE
files=['dist/**/']                          lnpm=2   npm=2   AGREE
```

Before the fix the anchored spelling collected **2**; it now collects 17, the same as the unanchored spelling and the same as npm.

## Verification

`go build`, `go vet`, `gofmt -l` clean; `go test -count=1 ./...` green across all 14 packages; `internal/pack` coverage 87.5%. golangci-lint v2.12.2 with `--new-from-merge-base=main`: 0 issues. `-race` is CI's — the dev machine has no gcc.

## Out of scope

Per the issue: the exclude direction (#150, landed), the content-hash short-circuit that conceals the omission, and `doctor`'s store-integrity check.

Found while reviewing this and **filed separately as #227**: a degenerate entry of `"/"`, `"//"` or `""` normalizes to the empty pattern and matches nothing, where npm ships *everything*. Same self-concealing silent-drop class as #207, but genuinely pre-existing — identical before and after this change — and fixing it needs a semantic decision about what an empty `files` entry should mean, so it is not folded in here.