### PR TITLE
Fix macOS reflink: call clonefile with the right signature

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -98,7 +98,7 @@
 
 **Reflink platform-specific implementations:**
 - Files: `internal/store/reflink_linux.go`, `internal/store/reflink_darwin.go`, `internal/link/reflink_linux.go`, `internal/link/reflink_darwin.go`
-- Why fragile: Direct syscalls using unsafe.Pointer, filesystem-dependent (APFS, Btrfs, XFS)
+- Why fragile: Filesystem-dependent (APFS, Btrfs, XFS) and only exercised on the matching platform; Linux still issues the FICLONE ioctl through a raw syscall, macOS goes through `golang.org/x/sys/unix`
 - Safe modification: Always test on target filesystems, verify fallback to hardlink/copy works
 - Test coverage: Limited testing on different filesystems
 
@@ -175,7 +175,7 @@
 - Priority: High
 
 **Reflink fallback scenarios:**
-- What's not tested: Cross-filesystem copies, filesystems without reflink support, permission errors during syscall
+- What's not tested: Cross-filesystem copies, permission errors during the clone, and the Btrfs/XFS success path (Linux CI runs on ext4, which has no reflink support). Filesystems without reflink support, and the APFS success path, are covered by `internal/fsutil/reflink_test.go`
 - Files: `internal/store/reflink_*.go`, `internal/link/reflink_*.go`
 - Risk: Silent fallback failures, performance degradation not detected
 - Priority: Medium

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -43,6 +43,7 @@
 **File Operations:**
 - `github.com/fsnotify/fsnotify` v1.7.0 - Cross-platform file system notifications for watch mode
 - `github.com/bmatcuk/doublestar/v4` v4.10.0 - Glob pattern matching for file filtering
+- `golang.org/x/sys` v0.47.0 - Low-level system calls for reflink/device detection
 
 **Performance:**
 - `github.com/cespare/xxhash/v2` v2.3.0 - Fast hashing for content-based deduplication
@@ -51,7 +52,6 @@
 **Infrastructure:**
 - `gopkg.in/yaml.v3` v3.0.1 - YAML parsing for configuration
 - `golang.org/x/sync` v0.22.0 - Extended synchronization primitives (indirect)
-- `golang.org/x/sys` v0.47.0 - Low-level system calls for reflink/device detection (indirect)
 
 ## Configuration
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -95,7 +95,7 @@ differ between the two hops:
 - **Safe**: modifications don't affect the original
 
 #### Platform Implementation
-- **macOS APFS**: Uses `clonefile()` syscall (SYS_CLONEFILE #462)
+- **macOS APFS**: Uses the `clonefile()` system call, via `golang.org/x/sys/unix`
 - **Linux Btrfs/XFS**: Uses `FICLONE` ioctl (#0x40049409)
 - **Other filesystems**: Gracefully falls back to hard links (store → project) or to a parallel copy (source → store)
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	go.etcd.io/bbolt v1.5.0
 	golang.org/x/mod v0.40.0
+	golang.org/x/sys v0.47.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -16,5 +17,4 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 )

--- a/internal/fsutil/reflink_darwin.go
+++ b/internal/fsutil/reflink_darwin.go
@@ -4,43 +4,19 @@ package fsutil
 
 import (
 	"fmt"
-	"syscall"
-	"unsafe"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/pedrosousa13/lnpm/internal/debug"
 )
 
-// SYS_CLONEFILE syscall number for macOS
-const SYS_CLONEFILE = 462
-
 // tryReflink attempts to create a copy-on-write clone on APFS.
 // Returns true if successful, false if not supported.
 func tryReflink(src, dst string) bool {
-	// clonefile syscall on macOS
-	// https://www.manpagez.com/man/2/clonefile/
-
-	srcPtr, err := syscall.BytePtrFromString(src)
-	if err != nil {
-		debug.Logf("reflink: BytePtrFromString(src) failed: %v", err)
-		return false
-	}
-
-	dstPtr, err := syscall.BytePtrFromString(dst)
-	if err != nil {
-		debug.Logf("reflink: BytePtrFromString(dst) failed: %v", err)
-		return false
-	}
-
 	// clonefile(const char *src, const char *dst, int flags)
-	_, _, errno := syscall.Syscall(
-		uintptr(SYS_CLONEFILE),
-		uintptr(unsafe.Pointer(srcPtr)),
-		uintptr(unsafe.Pointer(dstPtr)),
-		uintptr(0), // flags = 0 for default behavior
-	)
-
-	if errno != 0 {
-		debug.Logf("reflink: clonefile failed: %v (errno %d)", errno, errno)
+	// https://www.manpagez.com/man/2/clonefile/
+	if err := unix.Clonefile(src, dst, 0); err != nil {
+		debug.Logf("reflink: clonefile failed: %v", err)
 		return false
 	}
 

--- a/internal/fsutil/reflink_test.go
+++ b/internal/fsutil/reflink_test.go
@@ -1,0 +1,114 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// writeFile writes content to path, failing the test if it cannot.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write %s: %v", path, err)
+	}
+}
+
+// assertContent asserts that path holds exactly want.
+func assertContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Errorf("Content of %s = %q, want %q", path, string(got), want)
+	}
+}
+
+// TestReflink_ClonesIndependentCopy is the acceptance check for the darwin
+// clonefile path: Reflink must succeed on APFS (t.TempDir() is on APFS there)
+// and produce a logically independent copy. The two-way isolation check is what
+// distinguishes a copy-on-write clone from a hard link — a hard link shares the
+// inode, so a write through either name would be visible through the other.
+func TestReflink_ClonesIndependentCopy(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("Skipping - clonefile is darwin-only; other platforms have their own reflink path")
+	}
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	dst := filepath.Join(dir, "dst.txt")
+
+	writeFile(t, src, "original")
+
+	if err := Reflink(src, dst); err != nil {
+		t.Fatalf("Reflink failed on APFS: %v", err)
+	}
+
+	assertContent(t, dst, "original")
+
+	// Writing through dst must not be visible through src.
+	writeFile(t, dst, "changed via dst")
+	assertContent(t, src, "original")
+
+	// And writing through src must not be visible through dst.
+	writeFile(t, src, "changed via src")
+	assertContent(t, dst, "changed via dst")
+}
+
+// TestReflink_AgreesWithTryReflink pins the fallback contract that both callers
+// rely on: tryReflink reports whether cloning worked, Reflink turns that into a
+// nil error or a "not supported" error, and neither panics. It asserts the
+// relationship rather than a fixed outcome, so it holds on a filesystem without
+// cloning (ext4, the usual dev host) and on one with it (APFS, Btrfs, XFS).
+func TestReflink_AgreesWithTryReflink(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	writeFile(t, src, "payload")
+
+	probe := filepath.Join(dir, "probe.txt")
+	supported := tryReflink(src, probe)
+
+	dst := filepath.Join(dir, "dst.txt")
+	err := Reflink(src, dst)
+
+	if supported {
+		if err != nil {
+			t.Errorf("tryReflink reported success but Reflink returned %v", err)
+		}
+		assertContent(t, dst, "payload")
+		assertContent(t, probe, "payload")
+		return
+	}
+
+	// Unsupported filesystem: the caller must get an error to fall back on,
+	// not a panic and not a silent success.
+	if err == nil {
+		t.Error("tryReflink reported failure but Reflink returned nil, so callers would skip the copy fallback")
+	}
+	if _, statErr := os.Stat(probe); statErr == nil {
+		t.Error("tryReflink failed but left the destination behind; a partial file would be mistaken for a good copy")
+	}
+}
+
+// TestReflink_FailsWithoutPanicOnMissingSource exercises the failure branch on
+// every platform, including a CoW-capable one where the test above takes the
+// success branch. A missing source can never be cloned, so Reflink must report
+// "not supported" and leave nothing behind.
+func TestReflink_FailsWithoutPanicOnMissingSource(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "does-not-exist.txt")
+	dst := filepath.Join(dir, "dst.txt")
+
+	if tryReflink(src, dst) {
+		t.Fatal("tryReflink reported success for a source that does not exist")
+	}
+	if err := Reflink(src, dst); err == nil {
+		t.Error("Reflink returned nil for a source that does not exist")
+	}
+	if _, err := os.Stat(dst); err == nil {
+		t.Error("Reflink created a destination for a source that does not exist")
+	}
+}


### PR DESCRIPTION
Closes #135.

## The bug

`internal/fsutil/reflink_darwin.go` declared `SYS_CLONEFILE = 462` and invoked it through `syscall.Syscall` with three arguments — a source path pointer, a destination path pointer, and flags. But XNU syscall 462 is **`clonefileat`**, which takes five: `(src_dirfd, src_path, dst_dirfd, dst_path, flags)`. The source path pointer landed in the `src_dirfd` slot, so the kernel read a pointer as a file descriptor and the call failed `EINVAL` every time.

The failure was swallowed — `tryReflink` returned `false`, `Reflink` returned a generic "not supported", and both callers treated that as "this filesystem can't clone" and fell through. So on APFS, the default macOS filesystem, reflinks **never** worked. Every publish and every link silently hardlinked instead, and the `LNPM_DEBUG=1` "reflinked N" line always reported 0.

## The fix

Call `unix.Clonefile(src, dst, 0)` from `golang.org/x/sys/unix`, which wraps the real two-path `clonefile(2)`. This also removes the last raw-syscall/`unsafe.Pointer` use in `internal/` — direct syscalls are unsupported on darwin anyway, since Go goes through libSystem. `golang.org/x/sys` is promoted from indirect to a direct dependency.

Failure behavior is unchanged by design: `debug.Logf` the errno so a genuinely non-cloning volume stays diagnosable, return `false`, let the caller fall back to hardlink or copy.

## Tests

`internal/fsutil/reflink_test.go` is new — the package had no tests.

The darwin-gated test asserts isolation **in both directions**: write through the destination and check the source is unchanged, then write through the source and check the destination is unchanged. One direction alone is not enough, because `os.WriteFile` truncates in place on a shared inode, so a hardlink can survive a one-way check depending on ordering. That two-way assertion is what actually distinguishes a copy-on-write clone from the hardlink this bug silently produced.

Two further tests run on every platform: one pins the fallback contract by asserting the `tryReflink`/`Reflink` relationship rather than a fixed outcome, so it holds on ext4 and on a cloning filesystem alike; the other drives the error branch everywhere via a missing source.

## Verification, and its limits

`go build`, `go vet`, and the full suite are green locally, and both darwin arches cross-compile and vet clean — worth doing explicitly, since `//go:build darwin` means a native Linux build never compiles the changed file at all.

But the dev host is Linux on ext4 with no gcc, so **the darwin path cannot be executed there and the two darwin tests skip**. The `Test (macOS)` job added by #174 is the only place this code has ever run. Its green run on this PR is the acceptance evidence for criteria 1 and 2, not a formality — that is exactly why #135 was blocked behind #174.

## Docs

`ARCHITECTURE.md` documented the `SYS_CLONEFILE #462` constant this change deletes; `.planning/codebase/STACK.md` listed `x/sys` as indirect; `.planning/codebase/CONCERNS.md` cited `unsafe.Pointer` as the fragility and listed the unsupported-filesystem path as untested. All four corrected here.