### PR TITLE
Commit a golangci-lint config and pin the linter version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,8 +70,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
-          only-new-issues: true
+          version: v2.12.2
 
   test-windows:
     name: Test (Windows)

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.12.2
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,59 @@
+# golangci-lint configuration.
+#
+# The linter set is listed explicitly rather than inherited from upstream
+# defaults: which linters golangci-lint enables by default changes between
+# releases, and an unpinned rule set can start failing (or silently stop
+# checking things) with no corresponding change in this repository. The
+# version is pinned alongside this file in .github/workflows/ci.yaml and
+# .github/workflows/release-please.yaml.
+version: "2"
+
+linters:
+  # Ignore upstream's default selection entirely and opt in by name.
+  default: none
+
+  # golangci-lint v2's standard default set, pinned here explicitly.
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+  exclusions:
+    presets:
+      # Restores the legacy EXC0001 exclusion that golangci-lint v1 applied by
+      # default and v2 dropped. Without it v2 reports five pre-existing call
+      # sites that v1 never flagged.
+      #
+      # Be aware this is broad. It is a repo-wide, purely name-based regex:
+      #   .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|
+      #     .*print(f|ln)?|os\.(Un)?Setenv).
+      # so it also silences errcheck on any method named *Close or *Flush
+      # (including our own types), on Fprintf/Fprintln to any writer, and on
+      # os.Remove/os.RemoveAll anywhere. In particular, a genuinely dangerous
+      # unchecked Close on a file we just wrote will NOT be flagged — see #140,
+      # which tracks exactly that class of bug in internal/fsutil.
+      #
+      # We keep it because it matches the behaviour this repo was written
+      # against, and because narrowing it is a separate piece of work. errcheck
+      # remains active for every call that does not match the names above.
+      - std-error-handling
+
+    rules:
+      # ST1005 ("error strings should not end with punctuation") reached this
+      # repo only because v2 merged stylecheck into the default-enabled
+      # staticcheck. It flags one message, duplicated verbatim at two call
+      # sites (internal/cli/add.go:90 and :276): a multi-sentence user-facing
+      # string that needs rewording, and ideally de-duplicating, rather than a
+      # mechanical trailing-period strip.
+      #
+      # This rule suppresses ST1005 for internal/cli/add.go as a whole, not
+      # just those two lines, so a new punctuation-terminated error string
+      # added to this file would also go unreported. Only ST1005 is affected —
+      # every other staticcheck check still applies here.
+      # Follow-up: reword the message, de-duplicate it, and drop this rule.
+      - path: internal/cli/add\.go
+        linters:
+          - staticcheck
+        text: "ST1005:"

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -36,7 +36,8 @@
 **Linting:**
 - Tool: `golangci-lint` (preferred) or `go vet` (fallback)
 - Command: `make lint` or `make lint-staged` for pre-commit
-- CI: Uses `golangci/golangci-lint-action@v6` with `only-new-issues: true`
+- Config: `.golangci.yml` at the repo root defines the enabled linter set
+- CI: Uses `golangci/golangci-lint-action@v9` with the version pinned to `v2.12.2`; lints the full repo on every PR
 - Git hooks: Available via `make hooks-enable` at `.githooks/`
 
 ## Import Organization

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -63,6 +63,7 @@
 **Build:**
 - `go.mod` - Go module dependencies
 - `Makefile` - Build targets, testing, cross-platform compilation
+- `.golangci.yml` - Lint rule set (enabled linters and exclusions)
 - `.github/workflows/ci.yaml` - CI pipeline configuration
 
 **User Config:**

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -220,7 +220,7 @@ env.AssertLockfile(projectPath, func(lock *lockfile.LockFile) {
 
 **Jobs:**
 - `test`: Unit tests (`./internal/...`) and workspace tests (`./tests/...`)
-- `lint`: golangci-lint with `only-new-issues: true`
+- `lint`: golangci-lint (version pinned to `v2.12.2`), gating the whole repo — the rule set is defined by the committed `.golangci.yml`
 - `test-windows`: Same test suites on `windows-latest`, without coverage
 - `test-macos`: Same test suites on `macos-latest`, without coverage
 - `build`: Multi-platform compilation


### PR DESCRIPTION
Closes #178.

## Why this is urgent rather than housekeeping

Both workflow lint steps installed `version: latest` and the repo had no `.golangci.yml`, so the effective rule set was whatever golangci-lint release happened to be current when a workflow ran. That hazard already fired.

Moving `go.mod` to Go 1.26 (#173) forced `golangci-lint-action` from v6 to v9, which installs golangci-lint **v2** rather than v1. v2 dropped v1's legacy default exclusions and merged `stylecheck` into the default-enabled `staticcheck`, surfacing **7 findings on code that had not changed**.

CI stayed green only because `ci.yaml`'s Lint job set `only-new-issues: true`. But `release-please.yaml`'s lint step sets no such flag — it lints the whole repo, exits 1, and gates `Run GoReleaser` behind it. **The next release PR to merge would have failed there.**

## What this does

- Pins `v2.12.2` in both `ci.yaml` and `release-please.yaml`.
- Commits a `.golangci.yml` listing v2's standard set explicitly — `errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused` — under `default: none`, so an upstream default change can no longer alter this repo's rule set without a commit here. Verified equivalent to v2's current defaults, so pinning cost no coverage.
- Clears all 7 findings by configuration only, with no `.go` edits: the `std-error-handling` preset restores v1's EXC0001 behavior for the 5 errcheck hits, and a rule scoped to `internal/cli/add.go` covers the 2 ST1005 hits rather than disabling ST1005 repo-wide.
- Removes `only-new-issues: true`, so the full ruleset now gates every PR rather than only its new lines.

## The gate is real, not decorative

That was the failure mode worth guarding against — a config that excludes so much it catches nothing. Checked two ways, with throwaway probe files:

- An unchecked error on a repo-local, non-std, non-`Close` call is still reported, so `std-error-handling` narrowed errcheck rather than neutering it.
- The ST1005 rule does not mute `staticcheck` for the rest of `add.go`: `S1003` and `govet` findings injected into that file were both still caught.
- Deliberate `unused`, `ineffassign`, and `errcheck` violations all failed the run with exit 1.

## Exclusions are documented, not silent

Both carry comments stating exactly what they suppress, including the uncomfortable parts — `std-error-handling` is a repo-wide, name-based regex, so it also silences errcheck on any method named `*Close`/`*Flush` including our own types, and on `Fprintf` to any writer. A genuinely dangerous unchecked `Close` on a just-written file will not be flagged; the comment says so and points at #140, which tracks exactly that class of bug in `internal/fsutil`.

Follow-up for the ST1005 pair is filed as #230.

## Docs

`.planning/codebase/TESTING.md` and `CONVENTIONS.md` both described the Lint job as running with `only-new-issues: true` (CONVENTIONS.md also still said `action@v6`, stale since #173), and `STACK.md`'s config-file inventory predated `.golangci.yml`. All corrected here.