### PR TITLE
Make relink atomic: populate a temp directory and rename-swap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -265,8 +265,8 @@ lnpm add my-package --dev
 
 **Process:**
 1. Find package in store (latest or specified version)
-2. Create `.lnpm/{package}/` directory
-3. Hard link all files from store
+2. Create a temporary directory alongside `.lnpm/{package}/`
+3. Hard link all files from store into it, then rename it to `.lnpm/{package}/`
 4. Create symlink `node_modules/{package}` → `.lnpm/{package}`
 5. Update `package.json` with `file:.lnpm/{package}`
 6. Update `lnpm.lock`
@@ -307,9 +307,14 @@ lnpm push --skip-hooks
 2. Calculate new content hash
 3. Update store with new version
 4. For each linked project:
-   - Remove old hard links
-   - Create new hard links
+   - Create new hard links in a temporary directory alongside `.lnpm/{package}/`
+   - Rename it over `.lnpm/{package}/`, then delete the old directory
    - Preserve `node_modules` symlink
+
+   The relink is atomic: `.lnpm/{package}/` holds the previous complete package
+   until the new one is fully built, so a consumer building against
+   `node_modules/{package}` never sees an empty or half-written package, and a
+   failed or interrupted push leaves the previous package in place.
 
 ### `lnpm status`
 

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -2,6 +2,7 @@ package link
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -46,7 +47,7 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	debug.Logf("link: linking %s from %s (%d files)", packageName, storePath, len(files))
 
 	// Guard against path traversal: packageName is joined into .lnpm/<name>
-	// (which we RemoveAll) and node_modules/<name>.
+	// (which we replace) and node_modules/<name>.
 	if err := pack.ValidatePackageName(packageName); err != nil {
 		return "", err
 	}
@@ -55,14 +56,27 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	linkType := l.determineLinkType(storePath)
 	debug.Logf("link: using %s mode", linkType)
 
-	// Create .lnpm/{package} directory
+	// Populate a temp directory next to .lnpm/{package} and rename it into
+	// place once it is complete. Clearing the live directory up front would
+	// expose a consumer building against node_modules/{package} to an empty or
+	// half-written package, and an interrupted link would leave that state
+	// behind permanently.
 	lnpmPath := filepath.Join(l.projectPath, ".lnpm", packageName)
-	if err := os.RemoveAll(lnpmPath); err != nil {
-		return "", fmt.Errorf("failed to clean .lnpm directory: %w", err)
-	}
-	if err := os.MkdirAll(lnpmPath, 0755); err != nil {
+	parentDir := filepath.Dir(lnpmPath)
+	if err := os.MkdirAll(parentDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create .lnpm directory: %w", err)
 	}
+	tempPath, err := newTempDir(parentDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp .lnpm directory: %w", err)
+	}
+	// Remove the temp dir unless it is successfully committed via rename.
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.RemoveAll(tempPath)
+		}
+	}()
 
 	// Track what methods we actually used (atomic for parallel access)
 	var reflinkCount, hardLinkCount, copyCount int32
@@ -92,7 +106,7 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 			defer wg.Done()
 			for f := range fileChan {
 				srcPath := filepath.Join(storePath, f.RelPath)
-				dstPath := filepath.Join(lnpmPath, f.RelPath)
+				dstPath := filepath.Join(tempPath, f.RelPath)
 
 				// Create parent directory
 				if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
@@ -217,6 +231,34 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 
 	if reflinkCount > 0 || hardLinkCount > 0 {
 		debug.Logf("link: reflinked %d, hard linked %d, copied %d files", reflinkCount, hardLinkCount, copyCount)
+	}
+
+	// Swap the completed package into place. The previous directory is renamed
+	// aside rather than deleted first, so .lnpm/{package} is missing for a
+	// single rename instead of for as long as a whole package tree takes to
+	// delete, and a failed swap can be rolled back.
+	retiredPath := tempPath + ".old"
+	hadPrevious := false
+	if _, err := os.Lstat(lnpmPath); err == nil {
+		if err := os.Rename(lnpmPath, retiredPath); err != nil {
+			return "", fmt.Errorf("failed to move aside existing linked package: %w", err)
+		}
+		hadPrevious = true
+	}
+	if err := os.Rename(tempPath, lnpmPath); err != nil {
+		if hadPrevious {
+			// If the rollback fails too, the previous package exists only at
+			// retiredPath. Name it in the error so it can be recovered by hand;
+			// deleting it here would destroy the user's only copy.
+			if rollbackErr := os.Rename(retiredPath, lnpmPath); rollbackErr != nil {
+				return "", fmt.Errorf("failed to finalize linked package: %w (the previous package could not be restored: %v, and is preserved at %s)", err, rollbackErr, retiredPath)
+			}
+		}
+		return "", fmt.Errorf("failed to finalize linked package: %w", err)
+	}
+	committed = true
+	if hadPrevious {
+		_ = os.RemoveAll(retiredPath)
 	}
 
 	// Create symlink in node_modules
@@ -361,11 +403,39 @@ func (l *Linker) ListLinked() ([]string, error) {
 
 	var packages []string
 	for _, entry := range entries {
-		if entry.IsDir() {
+		// Skip dot-prefixed entries: they are in-progress or crash-orphaned
+		// relink temp directories, not linked packages. This also skips a
+		// package whose name starts with a dot, which is safe in practice: npm
+		// forbids such names, so one can never have been linked here
+		// (ValidatePackageName itself only rejects "." and "..").
+		if entry.IsDir() && !strings.HasPrefix(entry.Name(), ".") {
 			packages = append(packages, entry.Name())
 		}
 	}
 	return packages, nil
+}
+
+// newTempDir creates a uniquely named directory inside parent and returns its
+// path. The name is dot-prefixed so ListLinked skips it and so the retired-path
+// scheme in Link stays inside the same namespace.
+//
+// This exists instead of os.MkdirTemp because MkdirTemp hardcodes mode 0700,
+// whereas the linked package directory has always been created with 0755 less
+// the process umask. os.Mkdir applies the umask, so the previous permissions
+// are preserved by construction; a follow-up Chmod would not preserve them,
+// since Chmod ignores the umask and would force 0755 unconditionally.
+func newTempDir(parent string) (string, error) {
+	for attempt := 0; attempt < 1000; attempt++ {
+		path := filepath.Join(parent, fmt.Sprintf(".tmp-%x", rand.Uint64()))
+		err := os.Mkdir(path, 0755)
+		if err == nil {
+			return path, nil
+		}
+		if !os.IsExist(err) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("failed to find an unused temp directory name in %s", parent)
 }
 
 // copyFile copies a file

--- a/internal/link/link_atomic_test.go
+++ b/internal/link/link_atomic_test.go
@@ -1,0 +1,195 @@
+package link
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/pack"
+)
+
+// writeStoreFiles creates files with the given relpath -> content mapping under
+// storePath and returns the matching pack.FileInfo slice.
+func writeStoreFiles(t *testing.T, storePath string, contents map[string]string) []*pack.FileInfo {
+	t.Helper()
+
+	var files []*pack.FileInfo
+	for relPath, content := range contents {
+		filePath := filepath.Join(storePath, filepath.FromSlash(relPath))
+		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		files = append(files, &pack.FileInfo{
+			Path:    filePath,
+			RelPath: relPath,
+			Size:    int64(len(content)),
+			Mode:    0644,
+		})
+	}
+	return files
+}
+
+// assertNoTempDirs fails if any entry under dir has a dot-prefixed name, which
+// is how the atomic relink names its in-progress temp directories.
+func assertNoTempDirs(t *testing.T, dir string) {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".") {
+			t.Errorf("leftover temp entry %q in %s", entry.Name(), dir)
+		}
+	}
+}
+
+// entryNames returns the names of the entries in dir.
+func entryNames(t *testing.T, dir string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", dir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+// TestLink_FailedRelinkLeavesPreviousPackageIntact asserts that when a relink
+// fails part way through populating the package, the previously linked package
+// is still complete and no temp directory survives.
+func TestLink_FailedRelinkLeavesPreviousPackageIntact(t *testing.T) {
+	tests := []struct {
+		name        string
+		packageName string
+	}{
+		{name: "unscoped", packageName: "my-package"},
+		{name: "scoped", packageName: "@org/my-package"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			projectPath := filepath.Join(tmpDir, "project")
+			if err := os.MkdirAll(projectPath, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			// First link: a complete, good package.
+			goodStore := filepath.Join(tmpDir, "store", "good")
+			original := map[string]string{
+				"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+				"dist/index.js": "module.exports = 1;\n",
+				"dist/utils.js": "module.exports = 2;\n",
+			}
+			goodFiles := writeStoreFiles(t, goodStore, original)
+
+			linker := New(projectPath)
+			if _, err := linker.Link(tt.packageName, goodStore, goodFiles); err != nil {
+				t.Fatalf("first Link() error: %v", err)
+			}
+
+			// Second link: the store is missing one of the declared files, so
+			// population fails part way through.
+			badStore := filepath.Join(tmpDir, "store", "bad")
+			badFiles := writeStoreFiles(t, badStore, map[string]string{
+				"package.json": `{"name":"my-package","version":"2.0.0"}`,
+			})
+			badFiles = append(badFiles, &pack.FileInfo{
+				Path:    filepath.Join(badStore, "dist", "missing.js"),
+				RelPath: "dist/missing.js",
+				Size:    10,
+				Mode:    0644,
+			})
+
+			if _, err := linker.Link(tt.packageName, badStore, badFiles); err == nil {
+				t.Fatal("second Link() succeeded, want error: the failure injection did not reach the error path")
+			}
+
+			// The previously linked package must still be complete.
+			lnpmPath := filepath.Join(projectPath, ".lnpm", filepath.FromSlash(tt.packageName))
+			for relPath, want := range original {
+				got, err := os.ReadFile(filepath.Join(lnpmPath, filepath.FromSlash(relPath)))
+				if err != nil {
+					t.Errorf("previously linked file %s missing after failed relink: %v", relPath, err)
+					continue
+				}
+				if string(got) != want {
+					t.Errorf("previously linked file %s = %q, want %q", relPath, string(got), want)
+				}
+			}
+
+			// No half-written file from the failed attempt leaked in.
+			if _, err := os.Stat(filepath.Join(lnpmPath, "dist", "missing.js")); !os.IsNotExist(err) {
+				t.Errorf("failed relink leaked dist/missing.js into %s", lnpmPath)
+			}
+
+			// No temp directory survives, at the .lnpm root or in the scope dir.
+			assertNoTempDirs(t, filepath.Join(projectPath, ".lnpm"))
+			assertNoTempDirs(t, filepath.Dir(lnpmPath))
+		})
+	}
+}
+
+// TestLink_NoTempDirsLeftBehind asserts a successful link leaves .lnpm/ holding
+// exactly the package and nothing else.
+func TestLink_NoTempDirsLeftBehind(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	storePath := filepath.Join(tmpDir, "store", "my-package")
+	files := writeStoreFiles(t, storePath, map[string]string{
+		"package.json":  `{"name":"my-package"}`,
+		"dist/index.js": "module.exports = 1;\n",
+	})
+
+	linker := New(projectPath)
+	// Link twice: the second call goes through the replace path.
+	for i := 0; i < 2; i++ {
+		if _, err := linker.Link("my-package", storePath, files); err != nil {
+			t.Fatalf("Link() attempt %d error: %v", i+1, err)
+		}
+	}
+
+	lnpmDir := filepath.Join(projectPath, ".lnpm")
+	names := entryNames(t, lnpmDir)
+	if len(names) != 1 || names[0] != "my-package" {
+		t.Errorf(".lnpm entries = %v, want [my-package]", names)
+	}
+}
+
+// TestListLinked_IgnoresDotPrefixedEntries asserts that in-progress or
+// crash-orphaned temp directories are never reported as linked packages.
+func TestListLinked_IgnoresDotPrefixedEntries(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+
+	lnpmDir := filepath.Join(projectPath, ".lnpm")
+	if err := os.MkdirAll(filepath.Join(lnpmDir, "real-package"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(lnpmDir, ".tmp-leftover"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	linker := New(projectPath)
+	linked, err := linker.ListLinked()
+	if err != nil {
+		t.Fatalf("ListLinked() error: %v", err)
+	}
+	if len(linked) != 1 || linked[0] != "real-package" {
+		t.Errorf("ListLinked() = %v, want [real-package]", linked)
+	}
+}

--- a/internal/link/link_permissions_test.go
+++ b/internal/link/link_permissions_test.go
@@ -168,6 +168,64 @@ func TestLink_DirectoryPermissions(t *testing.T) {
 	}
 }
 
+// TestLink_PackageDirectoryRespectsUmask tests that the package directory Link
+// leaves behind has the mode a plain os.MkdirAll(path, 0755) would produce
+// under the same umask. Link builds it as a temp directory and renames it into
+// place, and the temp directory must not be created in a way that bypasses the
+// umask (os.MkdirTemp's fixed 0700, or a Chmod, which ignores the umask and
+// would force 0755 no matter how restrictive the umask is).
+func TestLink_PackageDirectoryRespectsUmask(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - permission handling differs")
+	}
+
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatalf("Failed to create project dir: %v", err)
+	}
+
+	storeDir := filepath.Join(tmpDir, "store", "test-pkg")
+	if err := os.MkdirAll(storeDir, 0755); err != nil {
+		t.Fatalf("Failed to create store dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(storeDir, "index.js"), []byte("test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	files := []pack.FileEntryData{
+		{RelPath: "index.js", Size: 4, Mode: 0644, Hash: "test123"},
+	}
+	fileInfos := pack.FileInfoFromStore(storeDir, files)
+
+	// Reference directory, created the way Link used to create the package
+	// directory. Comparing against it pins umask-relative behaviour rather
+	// than a hardcoded mode.
+	refDir := filepath.Join(tmpDir, "reference")
+	if err := os.MkdirAll(refDir, 0755); err != nil {
+		t.Fatalf("Failed to create reference dir: %v", err)
+	}
+	refInfo, err := os.Stat(refDir)
+	if err != nil {
+		t.Fatalf("Failed to stat reference dir: %v", err)
+	}
+
+	linker := New(projectDir)
+	if _, err := linker.Link("test-pkg", storeDir, fileInfos); err != nil {
+		t.Fatalf("Failed to link: %v", err)
+	}
+
+	pkgInfo, err := os.Stat(filepath.Join(projectDir, ".lnpm", "test-pkg"))
+	if err != nil {
+		t.Fatalf("Failed to stat package dir: %v", err)
+	}
+
+	if pkgInfo.Mode().Perm() != refInfo.Mode().Perm() {
+		t.Errorf("Expected .lnpm/test-pkg mode %o (as os.MkdirAll(path, 0755) yields under this umask), got %o",
+			refInfo.Mode().Perm(), pkgInfo.Mode().Perm())
+	}
+}
+
 // TestLink_NodeModulesPermissions tests node_modules symlink creation permissions
 func TestLink_NodeModulesPermissions(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -310,8 +368,8 @@ func TestLink_ExistingReadOnlyFile(t *testing.T) {
 	}
 	fileInfos := pack.FileInfoFromStore(storeDir, files)
 
-	// Link wipes the existing .lnpm/{pkg} dir (RemoveAll) and re-links, so the
-	// stale read-only file is replaced with the new content.
+	// Link populates a temp dir and renames it over the existing .lnpm/{pkg},
+	// so the stale read-only file is replaced with the new content.
 	linker := New(projectDir)
 	if _, err := linker.Link("test-pkg", storeDir, fileInfos); err != nil {
 		t.Fatalf("Link should replace existing read-only file, got error: %v", err)

--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -160,10 +160,20 @@ func TestLinkScopedPackage(t *testing.T) {
 		t.Fatalf("Link() error for scoped package: %v", err)
 	}
 
+	// Relink to exercise the temp-and-swap replace path
+	if _, err := linker.Link("@org/my-package", storePath, files); err != nil {
+		t.Fatalf("second Link() error for scoped package: %v", err)
+	}
+
 	// Verify scoped .lnpm directory
 	lnpmPath := filepath.Join(projectPath, ".lnpm", "@org/my-package")
 	if _, err := os.Stat(lnpmPath); err != nil {
 		t.Errorf(".lnpm/@org/my-package not created: %v", err)
+	}
+
+	// The temp-and-swap path must not leave anything behind in the scope dir
+	if names := entryNames(t, filepath.Join(projectPath, ".lnpm", "@org")); len(names) != 1 || names[0] != "my-package" {
+		t.Errorf(".lnpm/@org entries = %v, want [my-package]", names)
 	}
 
 	// Verify scoped node_modules symlink


### PR DESCRIPTION
Closes #137.

## The bug

`Linker.Link` cleared the target up front — `os.RemoveAll(.lnpm/<pkg>)` then `os.MkdirAll` — and only then repopulated it file by file. But `node_modules/<pkg>` already symlinks to `.lnpm/<pkg>` from the previous link, so throughout the repopulation window a consumer resolves that symlink to a directory that is empty or half-filled. A `webpack --watch` re-resolving at that moment builds against garbage.

Worse, an error or interrupt partway through left the package permanently half-populated — and `IsLinked` is a bare `os.Stat`, so lnpm went on reporting it as linked. The broken state was invisible.

## The fix

Populate a temp directory and rename it into place, mirroring what `internal/store` already does. `.lnpm/<pkg>` is never written to; it transitions from the old complete package to the new one in a single `rename(2)`.

The temp directory is a **sibling of the target** — `.lnpm/.tmp-XXXX`, or `.lnpm/@org/.tmp-XXXX` for a scoped package — rather than a flat name at the `.lnpm/` root. That keeps the rename within one directory, so it is unambiguously atomic and same-filesystem, and no name sanitization is needed for scoped packages.

The swap renames the old directory aside before renaming the new one in, rather than deleting it first. `.lnpm/<pkg>` is then absent for one rename instead of for however long deleting a whole package tree takes, and a failed swap can be rolled back. If the rollback itself fails, the error names the path where the previous package survives, so it is recoverable by hand — deleting it there would destroy the user's only copy.

`ListLinked` now skips dot-prefixed entries. Not cosmetic: this change introduces dot-prefixed directories into the directory that function enumerates, and without the filter a crash-orphaned temp dir would be reported as a linked package forever.

## On directory permissions

The first cut of this used `os.MkdirTemp` plus `os.Chmod(0755)`, which looks equivalent to the old `os.MkdirAll(path, 0755)` and is not: **`Chmod` ignores umask**. Under `umask 077` the package directory came out `0755` instead of `0700` — unconditionally world-readable, and inconsistent with both its own parent and its own children.

It is invisible under umask 022 or 002, so neither the existing permission tests nor a normal local run would ever have shown it. The fix is a small `newTempDir` helper using `os.Mkdir(path, 0755)`, which applies umask by construction.

`TestLink_PackageDirectoryRespectsUmask` pins this by comparing against a reference directory created with `os.MkdirAll(ref, 0755)` under the same umask, rather than asserting a literal mode. Note the honest limitation: it only discriminates under a restrictive umask, and CI runs at 022, so it would not catch a regression there.

## Tests

`TestLink_FailedRelinkLeavesPreviousPackageIntact` is the one that pins the bug — a table over unscoped and scoped packages that links, then forces a second link to fail mid-population, and asserts the original files are all still intact. Verified to fail against pre-fix code for the right reason, both subtests.

Two others (`TestLink_NoTempDirsLeftBehind` and a new assertion on `TestLinkScopedPackage`) **cannot** fail pre-fix, since temp directories do not exist before the mechanism does. They are leak-guards for the new mechanism; both were mutation-checked against dropping the retired-directory cleanup and fail there.

## Docs

`ARCHITECTURE.md` described the old write sequence in two places — `lnpm add` step 2 and `lnpm push` step 4 ("Remove old hard links / Create new hard links"), a literal description of the deleted code. Both updated.