### PR TITLE
Never delete the destination before the store's atomic rename

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -63,7 +63,7 @@
 
 1. `lnpm publish` → CLI command parses flags
 2. `pack.Pack()` scans package directory, filters files, calculates content hashes
-3. `store.Store()` copies/reflinks files to `~/.lnpm/store/{name}/{hash}/`
+3. `store.Store()` copies/reflinks files into a temp directory and renames it onto `~/.lnpm/store/{name}/{hash}/`, never destroying an entry already committed for that hash
 4. Database records Package, FileEntry records
 5. If `--push` flag: retrieve linked projects, re-link files
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -241,7 +241,16 @@ lnpm publish --push
 1. Read `package.json` for name/version
 2. Determine files to include (respects `.npmignore`, `files` field)
 3. Calculate content hash of all files
-4. Copy files to `~/.lnpm/store/{name}/{hash}/`
+4. Reflink or copy files into a temporary directory alongside
+   `~/.lnpm/store/{name}/{hash}/`, then rename it into place
+
+   The store commit is atomic: `~/.lnpm/store/{name}/{hash}/` appears all at
+   once, so a reader never sees a half-written package, and an interrupted
+   publish leaves only the temporary directory behind. An entry already
+   committed for the same hash is never destroyed — the store is
+   content-addressed, so an occupied destination already holds this exact
+   content.
+
 5. Record in bbolt database
 6. If `--push`, update all linked projects
 

--- a/internal/store/atomic_test.go
+++ b/internal/store/atomic_test.go
@@ -74,6 +74,52 @@ func TestStoreAtomicCommit(t *testing.T) {
 	noTempLeftovers(t, s, "atomic-pkg")
 }
 
+// TestStoreFinalizeKeepsExistingEntry pins the finalize step against destroying
+// a store entry another publisher already committed. finalize is exercised
+// directly because Store's early Exists() short-circuit means a plain
+// re-publish never reaches the rename with a populated destination.
+func TestStoreFinalizeKeepsExistingEntry(t *testing.T) {
+	t.Setenv("LNPM_STORE", t.TempDir())
+	s, err := New()
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	// A complete entry for this hash, as committed by someone who got there first.
+	finalPath := s.PackagePath("clobber-pkg", "feedface")
+	if err := os.MkdirAll(finalPath, 0755); err != nil {
+		t.Fatalf("seed final dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(finalPath, "index.js"), []byte("sentinel"), 0644); err != nil {
+		t.Fatalf("seed final file: %v", err)
+	}
+
+	// Our own fully built temp dir, about to lose the race to rename into place.
+	destPath, err := os.MkdirTemp(filepath.Dir(finalPath), ".feedface.tmp-")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(destPath, "index.js"), []byte("loser"), 0644); err != nil {
+		t.Fatalf("seed temp file: %v", err)
+	}
+
+	renamed, err := s.finalize("clobber-pkg", "feedface", destPath, finalPath)
+	if err != nil {
+		t.Fatalf("finalize should succeed against an existing entry: %v", err)
+	}
+	if renamed {
+		t.Error("finalize reported the temp dir as committed, but the destination was already occupied")
+	}
+
+	content, err := os.ReadFile(filepath.Join(finalPath, "index.js"))
+	if err != nil {
+		t.Fatalf("existing entry was destroyed: %v", err)
+	}
+	if string(content) != "sentinel" {
+		t.Errorf("existing entry content is %q, want %q", content, "sentinel")
+	}
+}
+
 // TestStoreConcurrentSameHash runs many concurrent stores of the same content
 // and verifies exactly one complete package and no temp leftovers result.
 func TestStoreConcurrentSameHash(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -246,17 +246,34 @@ func (s *Store) Store(name, hash string, files []*pack.FileInfo, sourceDir strin
 	}
 
 	// Atomically move the completed package into place.
-	_ = os.RemoveAll(finalPath)
-	if err := os.Rename(destPath, finalPath); err != nil {
-		// A concurrent publish of the same hash may have already created it.
-		if s.Exists(name, hash) {
-			return finalPath, nil // temp dir cleaned up by deferred guard
-		}
-		return "", fmt.Errorf("failed to finalize store package: %w", err)
+	renamed, err := s.finalize(name, hash, destPath, finalPath)
+	if err != nil {
+		return "", err
 	}
-	committed = true
+	committed = renamed
 
 	return finalPath, nil
+}
+
+// finalize atomically renames the fully built temp directory destPath onto
+// finalPath. It reports whether the rename consumed destPath, so the caller
+// knows whether the deferred temp-dir cleanup still has work to do.
+//
+// It never deletes finalPath. finalPath is keyed by the content hash, so an
+// occupied destination means another goroutine or process already committed
+// this exact content, and that entry is complete by construction.
+func (s *Store) finalize(name, hash, destPath, finalPath string) (bool, error) {
+	if err := os.Rename(destPath, finalPath); err != nil {
+		// A concurrent publish of the same hash may have already created it.
+		// Deliberately Exists(name, hash) rather than a bare stat of finalPath,
+		// even though the two are equivalent today: any future completeness
+		// check belongs in Exists, and this call site should inherit it.
+		if s.Exists(name, hash) {
+			return false, nil // temp dir cleaned up by deferred guard
+		}
+		return false, fmt.Errorf("failed to finalize store package: %w", err)
+	}
+	return true, nil
 }
 
 // GetFiles returns all files in a stored package


### PR DESCRIPTION
Closes #138.

## The bug

`Store.Store` built each package in a temp directory and renamed it into place — the right pattern — but immediately before the rename it ran `os.RemoveAll(finalPath)`, discarding the error.

If that deletion only partly succeeded, the destination stayed non-empty, the rename failed, and the error path checked `if s.Exists(name, hash) { return finalPath, nil }` — returning **success**, pointing at the wreckage. Since `Exists` is a bare `os.Stat`, the mangled entry read as a valid complete package from then on, and a later `lnpm add` would link the truncated package into a consumer.

The deletion could also destroy a *committed* entry belonging to another goroutine that had already won the rename.

## The evidence

This was previously seen once, as a Windows CI flake. It reproduces on Linux against pre-fix code under contention — confirmed independently twice, on separate scratch worktrees:

| build | harness | failing batches |
|---|---|---|
| pre-fix | `GOMAXPROCS=64`, 20 × `-count=100` | 4/20, then 3/20 |
| pre-fix | independent re-run by reviewer | 2/20 |
| post-fix | same harness | **0/20** |

Both error spellings appeared — `directory not empty` (ENOTEMPTY) and `file exists`. Note the failures that surface at all are the *loud* interleaving, where `Exists` also returns false. The common path is silent: the rename fails, `Exists` returns true, and the partial directory is returned as success without failing anything. That is why Linux CI stayed quiet on this for so long.

## The fix

Delete the `RemoveAll`. Keep the atomic rename and the `Exists` fallback.

That fallback becomes sound once nothing deletes the destination: `finalPath` is keyed by a content hash, so an occupied destination means another goroutine or process already committed *this exact content*, and it is complete by construction. Verified rather than assumed — both production callers derive the hash from `pack.HashFiles`, and `stripLifecycleScripts` (which rewrites `package.json` after hashing) is deterministic on the same input, so racers commit byte-identical trees.

**Stated precisely, because it is easy to over-claim**: `Store` avoids blessing a partial directory because nothing writes one, not because it can detect one. `Exists` is still a bare stat. A completeness marker is the real fix and is filed as #237, which also covers the remaining hole — `gc` ignores its own `RemoveAll` error, so an interrupted GC can still leave a partial entry.

## On the test

The obvious regression test — store, then re-store the same hash, assert the directory is untouched — would be **hollow**. The early `Exists` short-circuit returns before the rename is ever reached, so it passes identically with the bug present.

Hence the small `finalize` extraction: it moves the rename and its fallback into an unexported method so a test can pre-populate the destination and actually exercise the changed line. Behavior-preserving — the `committed` flag is set in exactly the cases it was before, so the deferred temp-dir cleanup neither leaks nor over-deletes.

`TestStoreFinalizeKeepsExistingEntry` was mutation-checked at both the original and the revised signature: restoring the `RemoveAll` fails it with the sentinel content destroyed, not on a setup path.

## Docs

`ARCHITECTURE.md`'s publish step 4 described neither the temp directory nor the rename, and gained a guarantee paragraph mirroring the one #137 added for relink. Neither doc line was *newly* falsified here — the imprecision predates this change — but this is the commit whose subject is the store's atomicity guarantee, so they are corrected with it. `README.md` is deliberately untouched; its coarser wording is still true.