### PR TITLE
Make lnpm update report network failures instead of "Already up to date"

### DIFF
--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -64,9 +64,13 @@ func RunUpdate(checkOnly bool, currentVersion string) error {
 		return fmt.Errorf("failed to check for updates: %w", err)
 	}
 
+	// CheckFresh returns a nil result only for the dev-build skip, which the
+	// guard at the top of this function already rejects - so this is unreachable
+	// today. It stays because that agreement is two copies of the same condition
+	// in two packages: widen CheckFresh's skip list and this would panic on the
+	// next line instead of exiting cleanly.
 	if result == nil {
-		fmt.Println("Already up to date")
-		return nil
+		return fmt.Errorf("update check returned no result")
 	}
 
 	if !result.UpdateAvailable {
@@ -96,8 +100,7 @@ func RunUpdate(checkOnly bool, currentVersion string) error {
 func getLatestVersion(currentVersion string) (*update.Result, error) {
 	// Use fresh check when user explicitly runs 'lnpm update' command
 	// This ensures we always fetch latest from GitHub, not cached version
-	result := update.CheckFresh(currentVersion)
-	return result, nil
+	return update.CheckFresh(currentVersion)
 }
 
 // wasInstalledViaGo checks if lnpm was installed via 'go install'

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -62,6 +62,35 @@ func TestReleaseBaseURLDefault(t *testing.T) {
 	}
 }
 
+// failingTransport makes every outbound request fail, standing in for a network
+// that cannot reach the GitHub API.
+type failingTransport struct{}
+
+func (failingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("simulated network failure")
+}
+
+// An update check that never reached GitHub used to be reported as "Already up
+// to date" with exit code 0, leaving users on an outdated version believing they
+// were current.
+//
+// Don't use t.Parallel() here - this swaps the process-wide default transport.
+func TestRunUpdateReportsCheckFailure(t *testing.T) {
+	t.Setenv("LNPM_STORE", t.TempDir())
+
+	prev := http.DefaultTransport
+	http.DefaultTransport = failingTransport{}
+	t.Cleanup(func() { http.DefaultTransport = prev })
+
+	err := RunUpdate(true, "1.0.0")
+	if err == nil {
+		t.Fatal("RunUpdate = nil, want an error when the update check cannot reach GitHub")
+	}
+	if !strings.Contains(err.Error(), "failed to check for updates") {
+		t.Errorf("RunUpdate error = %q, want it to contain %q", err, "failed to check for updates")
+	}
+}
+
 func TestBuildDownloadURL(t *testing.T) {
 	ext := ".tar.gz"
 	if runtime.GOOS == "windows" {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -16,9 +16,14 @@ import (
 )
 
 const (
-	githubRepo     = "pedrosousa13/lnpm"
-	checkInterval  = 24 * time.Hour
+	githubRepo    = "pedrosousa13/lnpm"
+	checkInterval = 24 * time.Hour
+	// requestTimeout bounds the background check, which runs alongside ordinary
+	// commands and must never noticeably delay them.
 	requestTimeout = 500 * time.Millisecond
+	// freshRequestTimeout bounds the explicit `lnpm update` check, which the user
+	// is waiting on and which must not give up on a merely slow connection.
+	freshRequestTimeout = 15 * time.Second
 )
 
 // githubAPIBaseURL is the GitHub API root. It is a var so tests can point it at
@@ -43,28 +48,32 @@ type Result struct {
 
 // CheckFresh checks for latest version without using cache
 // Used when user explicitly runs 'lnpm update'
-func CheckFresh(currentVersion string) *Result {
+//
+// It returns (nil, nil) only for the dev-build skip. A failed fetch is returned
+// as an error rather than swallowed, so the caller can tell "no update
+// available" apart from "could not check".
+func CheckFresh(currentVersion string) (*Result, error) {
 	if currentVersion == "dev" || currentVersion == "" {
-		return nil
+		return nil, nil
 	}
 
 	debug.Logf("update: checking for fresh version %s (bypassing cache)", currentVersion)
 
 	// Fetch from GitHub directly
-	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), freshRequestTimeout)
 	defer cancel()
 
 	latest, err := fetchLatestVersion(ctx)
 	if err != nil {
 		debug.Logf("update: fetch failed: %v", err)
-		return nil
+		return nil, fmt.Errorf("failed to fetch latest release from %s: %w", githubAPIBaseURL, err)
 	}
 
 	// Update cache
 	_, cachePath := loadCache()
 	saveCache(cachePath, latest)
 
-	return compareVersions(currentVersion, latest)
+	return compareVersions(currentVersion, latest), nil
 }
 
 // CheckAsync starts a background version check and returns a channel

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -239,7 +239,10 @@ func TestCheckFreshBypassesCache(t *testing.T) {
 		_, _ = w.Write([]byte(`{"tag_name": "v3.0.0"}`))
 	})
 
-	result := CheckFresh("1.0.0")
+	result, err := CheckFresh("1.0.0")
+	if err != nil {
+		t.Fatalf("CheckFresh returned error: %v", err)
+	}
 	if got := hits.Load(); got != 1 {
 		t.Errorf("server hits = %d, want 1 (CheckFresh must ignore a fresh cache)", got)
 	}
@@ -256,6 +259,45 @@ func TestCheckFreshBypassesCache(t *testing.T) {
 	}
 }
 
+// A failed fetch must be reported, not swallowed: returning a bare nil made a
+// network failure indistinguishable from "no update available", so `lnpm update`
+// printed "Already up to date" and exited 0 without ever reaching GitHub.
+func TestCheckFreshReturnsErrorWhenFetchFails(t *testing.T) {
+	t.Setenv("LNPM_STORE", t.TempDir())
+	startAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	result, err := CheckFresh("1.0.0")
+	if err == nil {
+		t.Errorf("CheckFresh error = nil, want non-nil when the fetch fails")
+	}
+	if result != nil {
+		t.Errorf("CheckFresh = %+v, want nil result when the fetch fails", result)
+	}
+}
+
+// The happy path must survive the error plumbing: a successful check that finds
+// no newer version still reports success, so the caller prints "Already up to
+// date" and exits 0.
+func TestCheckFreshSucceedsWhenAlreadyUpToDate(t *testing.T) {
+	t.Setenv("LNPM_STORE", t.TempDir())
+	startAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name": "v1.0.0"}`))
+	})
+
+	result, err := CheckFresh("1.0.0")
+	if err != nil {
+		t.Fatalf("CheckFresh returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("CheckFresh returned nil result for a successful check")
+	}
+	if result.UpdateAvailable {
+		t.Errorf("CheckFresh = %+v, want UpdateAvailable false", result)
+	}
+}
+
 func TestCheckFreshSkipsDevBuilds(t *testing.T) {
 	t.Setenv("LNPM_STORE", t.TempDir())
 	startAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
@@ -263,10 +305,57 @@ func TestCheckFreshSkipsDevBuilds(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
+	// The dev-build skip is not a failure, so it must not surface as an error.
 	for _, v := range []string{"dev", ""} {
-		if result := CheckFresh(v); result != nil {
-			t.Errorf("CheckFresh(%q) = %+v, want nil", v, result)
+		result, err := CheckFresh(v)
+		if result != nil || err != nil {
+			t.Errorf("CheckFresh(%q) = (%+v, %v), want (nil, nil)", v, result, err)
 		}
+	}
+}
+
+// The explicit path has a user waiting on it, so it must not give up on a
+// merely slow connection the way the background check does.
+func TestCheckFreshToleratesSlowResponse(t *testing.T) {
+	t.Setenv("LNPM_STORE", t.TempDir())
+	startAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(requestTimeout + 100*time.Millisecond)
+		_, _ = w.Write([]byte(`{"tag_name": "v2.0.0"}`))
+	})
+
+	result, err := CheckFresh("1.0.0")
+	if err != nil {
+		t.Fatalf("CheckFresh returned error: %v", err)
+	}
+	if result == nil || result.LatestVersion != "v2.0.0" {
+		t.Errorf("CheckFresh = %+v, want LatestVersion v2.0.0", result)
+	}
+}
+
+func TestBackgroundRequestTimeoutStaysShort(t *testing.T) {
+	// The background check runs alongside ordinary commands, so it must keep a
+	// timeout short enough that a slow network never noticeably delays them.
+	if requestTimeout > time.Second {
+		t.Errorf("requestTimeout = %v, want at most 1s for the background check", requestTimeout)
+	}
+}
+
+func TestFreshRequestTimeoutIsGenerous(t *testing.T) {
+	// The explicit `lnpm update` check is interactive, so it must allow for a
+	// slow connection rather than reporting a failure the user cannot act on.
+	if freshRequestTimeout < 10*time.Second {
+		t.Errorf("freshRequestTimeout = %v, want at least 10s", freshRequestTimeout)
+	}
+}
+
+func TestCheckStaysSilentOnFetchFailure(t *testing.T) {
+	t.Setenv("LNPM_STORE", t.TempDir())
+	startAPIServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if result := check("1.0.0"); result != nil {
+		t.Errorf("check = %+v, want nil (the background check must fail silently)", result)
 	}
 }
 


### PR DESCRIPTION
Closes #144.

## The bug

Two returns of bare `nil` meant the caller could not tell them apart:

- `CheckFresh` returned `nil` for the dev-build skip, and
- `CheckFresh` returned `nil` when the GitHub fetch **failed**, swallowing the error.

`getLatestVersion` then hardcoded `return result, nil`, so `RunUpdate`'s `if err != nil` branch was dead and `if result == nil` printed **"Already up to date"** with exit 0.

So on any network problem — hostile Wi-Fi, a captive portal, a GitHub hiccup — an explicit `lnpm update` reported success and did nothing. A user on an outdated version runs the update command, is reassured, and stays outdated.

Compounding it, the request timeout was **500ms**, shared with the background check. That is right for a check running alongside every ordinary command, and far too tight for an interactive command the user is waiting on — so the failure fired on merely slow links, not just outages.

## The fix

- `CheckFresh` returns `(*Result, error)` and propagates the fetch error. `(nil, nil)` now means only the dev-build skip.
- A separate `freshRequestTimeout = 15s` for the explicit path. `requestTimeout = 500ms` and the background `check`/`CheckAsync` path are deliberately untouched — silent failure is correct there.
- `getLatestVersion` propagates, which brings `RunUpdate`'s existing error branch to life and produces a non-zero exit.

## On the nil guard

The `if result == nil` branch was the line that emitted the false success, and with dev builds rejected earlier in `RunUpdate` it is now unreachable. It was initially deleted, and is restored — as an **error return**, not a print.

The invariant that makes it unreachable is real but fragile: it rests on `currentVersion == "dev" || currentVersion == ""` being duplicated in two packages. Adding one value to `CheckFresh`'s skip list makes the next line a nil dereference. Verified, not assumed — with `"unknown"` added to that list, the guard returns a clean error and removing it panics.

A one-line guard that converts a panic into a clean exit is worth keeping in an exported function, even unreachable. The comment explains why it should never fire.

## Error context

`CheckFresh`'s forwarded error is wrapped with the endpoint. These errors previously only reached `debug.Logf`; this change makes them user-facing, so bare `status 500` would have been unactionable. A user now sees:

```
failed to check for updates: failed to fetch latest release from https://api.github.com: status 500
```

## Tests

Extended `internal/update/update_test.go` (which already existed, from #181, along with the `githubAPIBaseURL` + `httptest` harness — the issue's suggestion to create both was stale).

The test that matters asserts on the **error**, not on a nil result: the result was nil before this fix too, so a nil-result assertion alone would have been hollow. Mutation-checked — re-swallowing the error fails it on the error assertion specifically. Also covered: the happy path still returns `(result, nil)`, the dev skip still returns `(nil, nil)` rather than becoming an error, the background check still swallows, and each timeout constant is pinned by a separately named test.

`TestRunUpdateReportsCheckFailure` covers the acceptance criterion end-to-end at the command level. Under the full pre-fix behavior it fails **and** prints "Already up to date", reproducing the reported bug verbatim.

All tests route through `httptest`; confirmed no test can reach the live API by re-running with the proxy pointed at a dead port.