### PR TITLE
fix(update): stage the updated binary next to the target to avoid cross-filesystem rename failures

### DIFF
--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -202,8 +202,10 @@ func installLatestViaBinary(version string) error {
 		return fmt.Errorf("failed to backup current binary: %w", err)
 	}
 
-	// Replace with new binary
-	if err := os.Rename(newBin, binPath); err != nil {
+	// Replace with new binary. installFile stages inside binPath's own
+	// directory and chmods it, so there is no cross-filesystem rename and no
+	// separate chmod to do here.
+	if err := installFile(newBin, binPath); err != nil {
 		// Restore backup on failure
 		if restoreErr := os.Rename(backup, binPath); restoreErr != nil {
 			return fmt.Errorf("failed to install new binary: %w (and failed to restore backup: %v)", err, restoreErr)
@@ -211,16 +213,66 @@ func installLatestViaBinary(version string) error {
 		return fmt.Errorf("failed to install new binary: %w", err)
 	}
 
-	// Make it executable
-	if err := os.Chmod(binPath, 0755); err != nil {
-		return fmt.Errorf("failed to make binary executable: %w", err)
-	}
-
 	// Remove backup
 	_ = os.Remove(backup)
 
 	fmt.Printf("✓ Successfully updated to latest version\n")
 	fmt.Printf("  Binary location: %s\n", binPath)
+	return nil
+}
+
+// installFile puts src's bytes at dst, staging the copy inside dst's own
+// directory so the final rename stays within one filesystem. The downloaded
+// binary lives under the system temp dir, which is frequently a separate mount
+// from the install location - renaming it straight onto dst fails there with
+// EXDEV, and the update can never succeed.
+func installFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open downloaded binary: %w", err)
+	}
+	defer func() { _ = in.Close() }()
+
+	destDir := filepath.Dir(dst)
+	staged, err := os.CreateTemp(destDir, ".lnpm-update-*")
+	if err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("cannot write to %s: re-run with sufficient privileges (for example under sudo): %w", destDir, err)
+		}
+		return fmt.Errorf("failed to stage new binary in %s: %w", destDir, err)
+	}
+
+	// Cleared once the rename has consumed the staging file, so this cleanup
+	// can never delete the freshly installed binary - or, later, some unrelated
+	// file that happens to reuse the name.
+	stagedPath := staged.Name()
+	defer func() {
+		if stagedPath != "" {
+			_ = os.Remove(stagedPath)
+		}
+	}()
+
+	if _, err := io.Copy(staged, in); err != nil {
+		_ = staged.Close()
+		return fmt.Errorf("failed to write new binary: %w", err)
+	}
+
+	// chmod explicitly rather than relying on the process umask: os.CreateTemp
+	// makes the file 0600, and the installed binary has to be executable
+	// whatever umask the user happens to run with.
+	if err := staged.Chmod(0755); err != nil {
+		_ = staged.Close()
+		return fmt.Errorf("failed to make new binary executable: %w", err)
+	}
+	if err := staged.Close(); err != nil {
+		return fmt.Errorf("failed to write new binary: %w", err)
+	}
+
+	if err := os.Rename(stagedPath, dst); err != nil {
+		return fmt.Errorf("failed to move the staged binary into place: %w", err)
+	}
+	stagedPath = ""
+
 	return nil
 }
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -196,9 +196,32 @@ func installLatestViaBinary(version string) error {
 	}
 	defer func() { _ = os.Remove(newBin) }()
 
+	if err := replaceBinary(newBin, binPath); err != nil {
+		return err
+	}
+
+	fmt.Printf("✓ Successfully updated to latest version\n")
+	fmt.Printf("  Binary location: %s\n", binPath)
+	return nil
+}
+
+// replaceBinary swaps newBin in for the binary at binPath, keeping a backup so
+// a failed install leaves the working binary in place.
+//
+// This is a separate function purely so the backup/restore contract can be
+// tested: installLatestViaBinary resolves its target through os.Executable(),
+// which is process-global and cannot be injected.
+func replaceBinary(newBin, binPath string) error {
 	// Backup current binary
 	backup := binPath + ".bak"
 	if err := os.Rename(binPath, backup); err != nil {
+		// The backup rename is the first thing that touches the install
+		// directory, so it - not installFile - is where a root-owned
+		// /usr/local/bin actually stops the update. os.IsPermission unwraps the
+		// *os.LinkError os.Rename returns.
+		if os.IsPermission(err) {
+			return insufficientPrivilegesError(filepath.Dir(binPath), err)
+		}
 		return fmt.Errorf("failed to backup current binary: %w", err)
 	}
 
@@ -215,10 +238,18 @@ func installLatestViaBinary(version string) error {
 
 	// Remove backup
 	_ = os.Remove(backup)
-
-	fmt.Printf("✓ Successfully updated to latest version\n")
-	fmt.Printf("  Binary location: %s\n", binPath)
 	return nil
+}
+
+// insufficientPrivilegesError reports that dir cannot be written, shared by
+// every step of the swap that needs write permission on the install directory
+// so they all tell the user the same thing.
+//
+// Deliberate deviation from the "failed to X: %w" convention: this string is
+// read by an end user deciding whether to re-run the update under sudo, so it
+// leads with the problem and the fix rather than a chain of internal steps.
+func insufficientPrivilegesError(dir string, err error) error {
+	return fmt.Errorf("cannot write to %s: re-run with sufficient privileges (for example under sudo): %w", dir, err)
 }
 
 // installFile puts src's bytes at dst, staging the copy inside dst's own
@@ -237,7 +268,7 @@ func installFile(src, dst string) error {
 	staged, err := os.CreateTemp(destDir, ".lnpm-update-*")
 	if err != nil {
 		if os.IsPermission(err) {
-			return fmt.Errorf("cannot write to %s: re-run with sufficient privileges (for example under sudo): %w", destDir, err)
+			return insufficientPrivilegesError(destDir, err)
 		}
 		return fmt.Errorf("failed to stage new binary in %s: %w", destDir, err)
 	}

--- a/internal/cli/update_permissions_test.go
+++ b/internal/cli/update_permissions_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// requirePermissionEnforcement skips tests that depend on the filesystem
+// actually refusing an operation. root bypasses permission bits, and Windows
+// does not model them the way these tests assume.
+func requirePermissionEnforcement(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not enforced the same way on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses the permission checks this test relies on")
+	}
+}
+
+// The downloaded binary lives under the system temp dir, which is frequently a
+// different filesystem from the install location - there, renaming it onto the
+// target fails with EXDEV and the update can never succeed. installFile must
+// therefore stage inside the target's own directory and copy the bytes in.
+//
+// A source directory the process may not write stands in for that filesystem
+// boundary: renaming a file out of a directory needs write permission on that
+// directory, reading its bytes does not. An implementation that renames from
+// the source cannot pass this test; one that copies into the destination
+// directory does not care.
+func TestInstallFileDoesNotRenameOutOfTheSourceDirectory(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	src, dst := writeInstallFixture(t, "new-binary", "old-binary")
+
+	srcDir := filepath.Dir(src)
+	if err := os.Chmod(srcDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(srcDir, 0755) })
+
+	if err := installFile(src, dst); err != nil {
+		t.Fatalf("installFile returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "new-binary" {
+		t.Errorf("installed content = %q, want %q", data, "new-binary")
+	}
+}
+
+// Installing into a directory the user cannot write is the common "installed
+// under /usr/local/bin" case. The error has to say what to do about it rather
+// than surfacing a bare permission-denied on a temp file name the user has
+// never seen.
+func TestInstallFileReportsInsufficientPrivileges(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	src, dst := writeInstallFixture(t, "new-binary", "old-binary")
+
+	dstDir := filepath.Dir(dst)
+	if err := os.Chmod(dstDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dstDir, 0755) })
+
+	err := installFile(src, dst)
+	if err == nil {
+		t.Fatal("installFile returned nil for an unwritable destination directory, want an error")
+	}
+	if !strings.Contains(err.Error(), "privileges") {
+		t.Errorf("error = %q, want it to tell the user to re-run with sufficient privileges", err)
+	}
+}
+
+// The privileges guidance has to be reachable on the path a real user takes.
+// replaceBinary backs the current binary up before it ever calls installFile,
+// and that rename needs write permission on the very same directory - so an
+// lnpm installed under a root-owned /usr/local/bin fails there first. Guidance
+// that only installFile produces is guidance the user never sees.
+func TestReplaceBinaryReportsInsufficientPrivileges(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	src, dst := writeInstallFixture(t, "new-binary", "old-binary")
+
+	dstDir := filepath.Dir(dst)
+	if err := os.Chmod(dstDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dstDir, 0755) })
+
+	err := replaceBinary(src, dst)
+	if err == nil {
+		t.Fatal("replaceBinary returned nil for an unwritable destination directory, want an error")
+	}
+	if !strings.Contains(err.Error(), "privileges") {
+		t.Errorf("error = %q, want it to tell the user to re-run with sufficient privileges", err)
+	}
+	if !strings.Contains(err.Error(), dstDir) {
+		t.Errorf("error = %q, want it to name the directory %q", err, dstDir)
+	}
+}

--- a/internal/cli/update_permissions_test.go
+++ b/internal/cli/update_permissions_test.go
@@ -8,15 +8,24 @@ import (
 	"testing"
 )
 
+// requirePermissionBits skips tests that depend on Unix permission bits. On
+// Windows os models only a read-only bit, so Mode().Perm() reports 0666 or
+// 0444 whatever was chmodded, and chmod cannot express the rest.
+func requirePermissionBits(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows reports only a read-only bit, not Unix permission bits")
+	}
+}
+
 // requirePermissionEnforcement skips tests that depend on the filesystem
 // actually refusing an operation. root bypasses permission bits, and Windows
 // does not model them the way these tests assume.
 func requirePermissionEnforcement(t *testing.T) {
 	t.Helper()
 
-	if runtime.GOOS == "windows" {
-		t.Skip("permission bits are not enforced the same way on Windows")
-	}
+	requirePermissionBits(t)
 	if os.Geteuid() == 0 {
 		t.Skip("running as root bypasses the permission checks this test relies on")
 	}
@@ -105,5 +114,27 @@ func TestReplaceBinaryReportsInsufficientPrivileges(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), dstDir) {
 		t.Errorf("error = %q, want it to name the directory %q", err, dstDir)
+	}
+}
+
+// The staging file is created by os.CreateTemp, which makes it 0600 and
+// unusable as a binary. installFile owns making the installed file executable.
+// root does not change what chmod records, so this one only needs the bits to
+// exist at all - it must still run as root.
+func TestInstallFileMakesTheInstalledBinaryExecutable(t *testing.T) {
+	requirePermissionBits(t)
+
+	src, dst := writeInstallFixture(t, "new-binary", "old-binary")
+
+	if err := installFile(src, dst); err != nil {
+		t.Fatalf("installFile returned error: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0755 {
+		t.Errorf("installed binary mode = %04o, want 0755", got)
 	}
 }

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -474,24 +474,6 @@ func TestInstallFileLeavesNoStagingFileOnSuccess(t *testing.T) {
 	}
 }
 
-// The staging file is created by os.CreateTemp, which makes it 0600 and
-// unusable as a binary. installFile owns making the installed file executable.
-func TestInstallFileMakesTheInstalledBinaryExecutable(t *testing.T) {
-	src, dst := writeInstallFixture(t, "new-binary", "old-binary")
-
-	if err := installFile(src, dst); err != nil {
-		t.Fatalf("installFile returned error: %v", err)
-	}
-
-	info, err := os.Stat(dst)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := info.Mode().Perm(); got != 0755 {
-		t.Errorf("installed binary mode = %04o, want 0755", got)
-	}
-}
-
 // A failure partway through the copy must not leave a half-written staging file
 // next to the target.
 func TestInstallFileRemovesStagingFileWhenTheCopyFails(t *testing.T) {

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -436,68 +436,20 @@ func TestVerifyChecksumNotListed(t *testing.T) {
 	}
 }
 
-// requirePermissionEnforcement skips tests that depend on the filesystem
-// actually refusing an operation. root bypasses permission bits, and Windows
-// does not model them the way these tests assume.
-func requirePermissionEnforcement(t *testing.T) {
-	t.Helper()
-
-	if runtime.GOOS == "windows" {
-		t.Skip("permission bits are not enforced the same way on Windows")
-	}
-	if os.Geteuid() == 0 {
-		t.Skip("running as root bypasses the permission checks this test relies on")
-	}
-}
-
 // writeInstallFixture lays down a source file in its own directory and a
 // destination file in another, returning both paths.
-func writeInstallFixture(t *testing.T, srcContent, dstContent string) (src, dst string) {
+func writeInstallFixture(t *testing.T, srcContent, dstContent string) (string, string) {
 	t.Helper()
 
-	src = filepath.Join(t.TempDir(), "lnpm-downloaded")
+	src := filepath.Join(t.TempDir(), "lnpm-downloaded")
 	if err := os.WriteFile(src, []byte(srcContent), 0644); err != nil {
 		t.Fatal(err)
 	}
-	dst = filepath.Join(t.TempDir(), "lnpm")
+	dst := filepath.Join(t.TempDir(), "lnpm")
 	if err := os.WriteFile(dst, []byte(dstContent), 0755); err != nil {
 		t.Fatal(err)
 	}
 	return src, dst
-}
-
-// The downloaded binary lives under the system temp dir, which is frequently a
-// different filesystem from the install location - there, renaming it onto the
-// target fails with EXDEV and the update can never succeed. installFile must
-// therefore stage inside the target's own directory and copy the bytes in.
-//
-// A source directory the process may not write stands in for that filesystem
-// boundary: renaming a file out of a directory needs write permission on that
-// directory, reading its bytes does not. An implementation that renames from
-// the source cannot pass this test; one that copies into the destination
-// directory does not care.
-func TestInstallFileDoesNotRenameOutOfTheSourceDirectory(t *testing.T) {
-	requirePermissionEnforcement(t)
-
-	src, dst := writeInstallFixture(t, "new-binary", "old-binary")
-
-	srcDir := filepath.Dir(src)
-	if err := os.Chmod(srcDir, 0555); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(srcDir, 0755) })
-
-	if err := installFile(src, dst); err != nil {
-		t.Fatalf("installFile returned error: %v", err)
-	}
-
-	data, err := os.ReadFile(dst)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != "new-binary" {
-		t.Errorf("installed content = %q, want %q", data, "new-binary")
-	}
 }
 
 // A successful install must not leave its staging file sitting next to the
@@ -540,30 +492,6 @@ func TestInstallFileMakesTheInstalledBinaryExecutable(t *testing.T) {
 	}
 }
 
-// Installing into a directory the user cannot write is the common "installed
-// under /usr/local/bin" case. The error has to say what to do about it rather
-// than surfacing a bare permission-denied on a temp file name the user has
-// never seen.
-func TestInstallFileReportsInsufficientPrivileges(t *testing.T) {
-	requirePermissionEnforcement(t)
-
-	src, dst := writeInstallFixture(t, "new-binary", "old-binary")
-
-	dstDir := filepath.Dir(dst)
-	if err := os.Chmod(dstDir, 0555); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(dstDir, 0755) })
-
-	err := installFile(src, dst)
-	if err == nil {
-		t.Fatal("installFile returned nil for an unwritable destination directory, want an error")
-	}
-	if !strings.Contains(err.Error(), "privileges") {
-		t.Errorf("error = %q, want it to tell the user to re-run with sufficient privileges", err)
-	}
-}
-
 // A failure partway through the copy must not leave a half-written staging file
 // next to the target.
 func TestInstallFileRemovesStagingFileWhenTheCopyFails(t *testing.T) {
@@ -586,5 +514,32 @@ func TestInstallFileRemovesStagingFileWhenTheCopyFails(t *testing.T) {
 			names = append(names, e.Name())
 		}
 		t.Errorf("destination directory holds %v after a failed install, want only %q", names, filepath.Base(dst))
+	}
+}
+
+// A failed update must leave the user with a working lnpm: the original binary
+// back at its own path, and no stray .bak beside it for the next update to trip
+// over.
+//
+// A directory as the replacement makes the install step fail without touching
+// the backup rename, so the restore path is what is under test.
+func TestReplaceBinaryRestoresTheOriginalWhenTheInstallFails(t *testing.T) {
+	_, dst := writeInstallFixture(t, "unused", "old-binary")
+	unreadable := t.TempDir()
+
+	if err := replaceBinary(unreadable, dst); err == nil {
+		t.Fatal("replaceBinary returned nil when the new binary could not be read, want an error")
+	}
+
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("original binary is gone after a failed install: %v", err)
+	}
+	if string(data) != "old-binary" {
+		t.Errorf("binary content = %q after a failed install, want the original %q", data, "old-binary")
+	}
+
+	if _, err := os.Stat(dst + ".bak"); !os.IsNotExist(err) {
+		t.Errorf("backup %q still exists after a failed install (stat err %v)", dst+".bak", err)
 	}
 }

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -435,3 +435,156 @@ func TestVerifyChecksumNotListed(t *testing.T) {
 		t.Errorf("error = %q, want it to mention no checksum was listed", err)
 	}
 }
+
+// requirePermissionEnforcement skips tests that depend on the filesystem
+// actually refusing an operation. root bypasses permission bits, and Windows
+// does not model them the way these tests assume.
+func requirePermissionEnforcement(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not enforced the same way on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses the permission checks this test relies on")
+	}
+}
+
+// writeInstallFixture lays down a source file in its own directory and a
+// destination file in another, returning both paths.
+func writeInstallFixture(t *testing.T, srcContent, dstContent string) (src, dst string) {
+	t.Helper()
+
+	src = filepath.Join(t.TempDir(), "lnpm-downloaded")
+	if err := os.WriteFile(src, []byte(srcContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	dst = filepath.Join(t.TempDir(), "lnpm")
+	if err := os.WriteFile(dst, []byte(dstContent), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return src, dst
+}
+
+// The downloaded binary lives under the system temp dir, which is frequently a
+// different filesystem from the install location - there, renaming it onto the
+// target fails with EXDEV and the update can never succeed. installFile must
+// therefore stage inside the target's own directory and copy the bytes in.
+//
+// A source directory the process may not write stands in for that filesystem
+// boundary: renaming a file out of a directory needs write permission on that
+// directory, reading its bytes does not. An implementation that renames from
+// the source cannot pass this test; one that copies into the destination
+// directory does not care.
+func TestInstallFileDoesNotRenameOutOfTheSourceDirectory(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	src, dst := writeInstallFixture(t, "new-binary", "old-binary")
+
+	srcDir := filepath.Dir(src)
+	if err := os.Chmod(srcDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(srcDir, 0755) })
+
+	if err := installFile(src, dst); err != nil {
+		t.Fatalf("installFile returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "new-binary" {
+		t.Errorf("installed content = %q, want %q", data, "new-binary")
+	}
+}
+
+// A successful install must not leave its staging file sitting next to the
+// installed binary.
+func TestInstallFileLeavesNoStagingFileOnSuccess(t *testing.T) {
+	src, dst := writeInstallFixture(t, "new-binary", "old-binary")
+
+	if err := installFile(src, dst); err != nil {
+		t.Fatalf("installFile returned error: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(dst))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != filepath.Base(dst) {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("destination directory holds %v, want only %q", names, filepath.Base(dst))
+	}
+}
+
+// The staging file is created by os.CreateTemp, which makes it 0600 and
+// unusable as a binary. installFile owns making the installed file executable.
+func TestInstallFileMakesTheInstalledBinaryExecutable(t *testing.T) {
+	src, dst := writeInstallFixture(t, "new-binary", "old-binary")
+
+	if err := installFile(src, dst); err != nil {
+		t.Fatalf("installFile returned error: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0755 {
+		t.Errorf("installed binary mode = %04o, want 0755", got)
+	}
+}
+
+// Installing into a directory the user cannot write is the common "installed
+// under /usr/local/bin" case. The error has to say what to do about it rather
+// than surfacing a bare permission-denied on a temp file name the user has
+// never seen.
+func TestInstallFileReportsInsufficientPrivileges(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	src, dst := writeInstallFixture(t, "new-binary", "old-binary")
+
+	dstDir := filepath.Dir(dst)
+	if err := os.Chmod(dstDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dstDir, 0755) })
+
+	err := installFile(src, dst)
+	if err == nil {
+		t.Fatal("installFile returned nil for an unwritable destination directory, want an error")
+	}
+	if !strings.Contains(err.Error(), "privileges") {
+		t.Errorf("error = %q, want it to tell the user to re-run with sufficient privileges", err)
+	}
+}
+
+// A failure partway through the copy must not leave a half-written staging file
+// next to the target.
+func TestInstallFileRemovesStagingFileWhenTheCopyFails(t *testing.T) {
+	_, dst := writeInstallFixture(t, "unused", "old-binary")
+	// A directory can be opened but not read as a stream, so the copy fails
+	// after the staging file has already been created.
+	src := t.TempDir()
+
+	if err := installFile(src, dst); err == nil {
+		t.Fatal("installFile returned nil when the source could not be read, want an error")
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(dst))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != filepath.Base(dst) {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("destination directory holds %v after a failed install, want only %q", names, filepath.Base(dst))
+	}
+}


### PR DESCRIPTION
Closes #145.

## The bug

To replace itself, the updater extracted the downloaded binary under `os.MkdirTemp("", "lnpm-update-")` and then renamed it straight onto the install path. On the many Linux configurations where `/tmp` is a separate `tmpfs` mount from `/usr/local/bin`, `rename(2)` returns `EXDEV` — "invalid cross-device link". The error handler then restored the backup, so the machine stayed on the old version. On those systems `lnpm update` could *never* succeed; it failed identically every time.

## The fix

`installFile(src, dst)` stages the copy inside the target's own directory (`os.CreateTemp(filepath.Dir(dst), ".lnpm-update-*")`), copies the bytes, chmods `0755` through the open handle, and only then renames — now within a single filesystem. The staging file is removed on every error path, and cleared from the cleanup closure once the rename has consumed it, so cleanup can never delete the freshly installed binary.

chmod-before-rename also removes a window the old code had: the binary is never briefly visible at the install path without its executable bit. The post-rename `os.Chmod(binPath, 0755)` is therefore gone.

## Reaching the user with the privileges hint

Review caught that the "re-run with sufficient privileges" guidance was unreachable in the exact case that motivates it. The backup rename runs *before* `installFile` and needs write permission on the same directory, so an `lnpm` under a root-owned `/usr/local/bin` failed there first with a bare `permission denied`. Both sites now share one message.

The swap is extracted into `replaceBinary`, which gives the backup/restore contract a testable seam — `installLatestViaBinary` resolves its target through `os.Executable()`, which is process-global and cannot be injected.

## Tests

Seven new tests. The three that pin the bug fail against the pre-fix `os.Rename`:

- `TestInstallFileDoesNotRenameOutOfTheSourceDirectory` — a source directory at `0555` stands in for the filesystem boundary: renaming a file *out of* a directory needs write permission on it, copying its bytes does not. A rename-based implementation dies here; a copy-based one does not care.
- `TestInstallFileMakesTheInstalledBinaryExecutable` — pins mode `0755`; a plain rename carries the fixture's `0644` through.
- `TestReplaceBinaryReportsInsufficientPrivileges` — written red against the pure extraction, and it failed with exactly the bare backup error described above.

`TestReplaceBinaryRestoresTheOriginalWhenTheInstallFails` covers the acceptance criterion that a failed install leaves the working binary in place, with both assertions mutation-checked. `TestInstallFileLeavesNoStagingFileOnSuccess` and `TestInstallFileRemovesStagingFileWhenTheCopyFails` cannot fail pre-fix — there is no staging file before the mechanism exists — and are honest leak guards for the new `defer`, not bug-pinning coverage.

Permission-dependent tests live in `internal/cli/update_permissions_test.go`, per the `*_permissions_test.go` convention.

## Out of scope

Checksum verification, rollback beyond the existing backup restore, and Windows replace semantics are untouched. The leaked `os.MkdirTemp` directory in `downloadBinary` is left for #147.

## Verification

`go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `gofmt -l` clean, full `go test ./...` green, and cross-compiles clean for `windows/amd64` and `darwin/arm64`. `-race` is covered by CI only.