### PR TITLE
fix(workspace): subtract negation patterns in publish --all instead of dropping them

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -187,7 +187,7 @@
 - Priority: High
 
 **Monorepo workspace detection:**
-- What's not tested: Edge cases in workspace file parsing, circular dependencies, invalid workspace configurations
+- What's not tested: Circular dependencies, invalid workspace configurations
 - Files: `internal/workspace/workspace.go`
 - Risk: Silent failures in complex monorepo setups
 - Priority: Medium

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -121,7 +121,7 @@ lnpm/
 **tests/fixtures:**
 - Purpose: Test workspace examples
 - Contains: Sample npm/yarn/pnpm workspaces for testing
-- Subdirectories: `npm-workspace/`, `yarn-workspace/`, `pnpm-workspace/`, `turborepo/`, `nx/`
+- Subdirectories: `npm-workspace/`, `npm-workspace-negation/`, `yarn-workspace/`, `pnpm-workspace/`, `turborepo/`, `nx/`
 
 ## Key File Locations
 

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -117,6 +117,7 @@ workspaceDir := env.CopyFixture("npm-workspace")
 
 **Available Fixtures:**
 - `npm-workspace/`: NPM workspace with multiple packages
+- `npm-workspace-negation/`: NPM workspace whose config negates one package
 - `pnpm-workspace/`: PNPM workspace structure
 - `yarn-workspace/`: Yarn workspace setup
 - `turborepo/`: Turborepo monorepo structure

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -153,14 +153,18 @@ func parsePackageJSONWorkspace(root, path string) (*Workspace, error) {
 	}, nil
 }
 
-// expandGlobs expands workspace glob patterns to actual package directories
+// expandGlobs expands workspace glob patterns to actual package directories.
+// Patterns prefixed with "!" are negations: they are collected while the
+// included patterns are expanded, then subtracted from the result.
 func expandGlobs(root string, patterns []string) ([]string, error) {
 	var packages []string
+	var negations []string
 	seen := make(map[string]bool)
 
 	for _, pattern := range patterns {
-		// Remove trailing negation patterns
+		// Collect negation patterns to subtract once all includes are expanded
 		if strings.HasPrefix(pattern, "!") {
+			negations = append(negations, strings.TrimPrefix(pattern, "!"))
 			continue
 		}
 
@@ -186,7 +190,30 @@ func expandGlobs(root string, patterns []string) ([]string, error) {
 		}
 	}
 
-	return packages, nil
+	if len(negations) == 0 {
+		return packages, nil
+	}
+
+	excluded := make(map[string]bool)
+	for _, pattern := range negations {
+		matches, err := doublestar.Glob(os.DirFS(root), pattern)
+		if err != nil {
+			continue
+		}
+
+		for _, match := range matches {
+			excluded[filepath.Join(root, match)] = true
+		}
+	}
+
+	filtered := make([]string, 0, len(packages))
+	for _, pkgPath := range packages {
+		if !excluded[pkgPath] {
+			filtered = append(filtered, pkgPath)
+		}
+	}
+
+	return filtered, nil
 }
 
 // ListPackages returns all packages in the workspace with their metadata

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,0 +1,132 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writePackage creates a directory under root containing a minimal package.json
+func writePackage(t *testing.T, root, relPath string) string {
+	t.Helper()
+
+	pkgDir := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(pkgDir, 0755); err != nil {
+		t.Fatalf("Failed to create package dir %s: %v", pkgDir, err)
+	}
+
+	name := filepath.Base(pkgDir)
+	contents := `{"name":"` + name + `","version":"1.0.0"}`
+	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(contents), 0644); err != nil {
+		t.Fatalf("Failed to write package.json in %s: %v", pkgDir, err)
+	}
+
+	return pkgDir
+}
+
+// assertPackages compares expanded package paths against the expected list, order included
+func assertPackages(t *testing.T, got, want []string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("Expected %d packages %v, got %d: %v", len(want), want, len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Expected package %d to be %s, got %s", i, want[i], got[i])
+		}
+	}
+}
+
+func TestExpandGlobsExcludesNegatedPackage(t *testing.T) {
+	root := t.TempDir()
+	pkgA := writePackage(t, root, "packages/package-a")
+	writePackage(t, root, "packages/package-b")
+
+	packages, err := expandGlobs(root, []string{"packages/*", "!packages/package-b"})
+	if err != nil {
+		t.Fatalf("Failed to expand globs: %v", err)
+	}
+
+	assertPackages(t, packages, []string{pkgA})
+}
+
+func TestExpandGlobsNegationMatchingNothingKeepsAllPackages(t *testing.T) {
+	root := t.TempDir()
+	pkgA := writePackage(t, root, "packages/package-a")
+	pkgB := writePackage(t, root, "packages/package-b")
+
+	packages, err := expandGlobs(root, []string{"packages/*", "!packages/does-not-exist"})
+	if err != nil {
+		t.Fatalf("Failed to expand globs: %v", err)
+	}
+
+	assertPackages(t, packages, []string{pkgA, pkgB})
+}
+
+func TestExpandGlobsNegationGlobExcludesEveryMatch(t *testing.T) {
+	root := t.TempDir()
+	pkgPublic := writePackage(t, root, "packages/public-api")
+	writePackage(t, root, "packages/internal-secret")
+	writePackage(t, root, "packages/internal-tools")
+
+	packages, err := expandGlobs(root, []string{"packages/*", "!packages/internal-*"})
+	if err != nil {
+		t.Fatalf("Failed to expand globs: %v", err)
+	}
+
+	assertPackages(t, packages, []string{pkgPublic})
+}
+
+func TestExpandGlobsWithoutNegationPreservesOrderAndDedup(t *testing.T) {
+	root := t.TempDir()
+	pkgB := writePackage(t, root, "packages/package-b")
+	pkgA := writePackage(t, root, "packages/package-a")
+
+	// package-b is listed explicitly first, then matched again by the wildcard
+	packages, err := expandGlobs(root, []string{"packages/package-b", "packages/*"})
+	if err != nil {
+		t.Fatalf("Failed to expand globs: %v", err)
+	}
+
+	assertPackages(t, packages, []string{pkgB, pkgA})
+}
+
+func TestExpandGlobsSkipsDirectoriesWithoutPackageJSON(t *testing.T) {
+	root := t.TempDir()
+	pkgA := writePackage(t, root, "packages/package-a")
+	if err := os.MkdirAll(filepath.Join(root, "packages", "not-a-package"), 0755); err != nil {
+		t.Fatalf("Failed to create directory: %v", err)
+	}
+
+	packages, err := expandGlobs(root, []string{"packages/*"})
+	if err != nil {
+		t.Fatalf("Failed to expand globs: %v", err)
+	}
+
+	assertPackages(t, packages, []string{pkgA})
+}
+
+func TestDetectPnpmWorkspaceExcludesNegatedPackage(t *testing.T) {
+	root := t.TempDir()
+	pkgA := writePackage(t, root, "packages/package-a")
+	writePackage(t, root, "packages/package-b")
+
+	yaml := "packages:\n  - 'packages/*'\n  - '!packages/package-b'\n"
+	if err := os.WriteFile(filepath.Join(root, "pnpm-workspace.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatalf("Failed to write pnpm-workspace.yaml: %v", err)
+	}
+
+	ws, err := Detect(root)
+	if err != nil {
+		t.Fatalf("Failed to detect workspace: %v", err)
+	}
+	if ws == nil {
+		t.Fatal("Expected workspace, got nil")
+	}
+	if ws.Type != "pnpm" {
+		t.Errorf("Expected pnpm, got %s", ws.Type)
+	}
+
+	assertPackages(t, ws.Packages, []string{pkgA})
+}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -107,7 +107,7 @@ func TestExpandGlobsSkipsDirectoriesWithoutPackageJSON(t *testing.T) {
 	assertPackages(t, packages, []string{pkgA})
 }
 
-func TestDetectPnpmWorkspaceExcludesNegatedPackage(t *testing.T) {
+func TestDetectPNPMWorkspaceExcludesNegatedPackage(t *testing.T) {
 	root := t.TempDir()
 	pkgA := writePackage(t, root, "packages/package-a")
 	writePackage(t, root, "packages/package-b")

--- a/tests/fixtures/npm-workspace-negation/package.json
+++ b/tests/fixtures/npm-workspace-negation/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "npm-workspace-negation-test",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*",
+    "!packages/package-b"
+  ]
+}

--- a/tests/fixtures/npm-workspace-negation/packages/package-a/index.js
+++ b/tests/fixtures/npm-workspace-negation/packages/package-a/index.js
@@ -1,0 +1,1 @@
+module.exports = 'package-a';

--- a/tests/fixtures/npm-workspace-negation/packages/package-a/package.json
+++ b/tests/fixtures/npm-workspace-negation/packages/package-a/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@npm-test/package-a",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/tests/fixtures/npm-workspace-negation/packages/package-b/index.js
+++ b/tests/fixtures/npm-workspace-negation/packages/package-b/index.js
@@ -1,0 +1,1 @@
+module.exports = 'package-b';

--- a/tests/fixtures/npm-workspace-negation/packages/package-b/package.json
+++ b/tests/fixtures/npm-workspace-negation/packages/package-b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@npm-test/package-b",
+  "version": "1.5.0",
+  "main": "index.js"
+}

--- a/tests/workspace_test.go
+++ b/tests/workspace_test.go
@@ -79,6 +79,28 @@ func TestDetectNPMWorkspace(t *testing.T) {
 	}
 }
 
+func TestDetectNPMWorkspaceWithNegation(t *testing.T) {
+	root := filepath.Join("fixtures", "npm-workspace-negation")
+	ws, err := workspace.Detect(root)
+	if err != nil {
+		t.Fatalf("Failed to detect workspace: %v", err)
+	}
+	if ws == nil {
+		t.Fatal("Expected workspace, got nil")
+	}
+
+	packages, err := ws.ListPackages()
+	if err != nil {
+		t.Fatalf("Failed to list packages: %v", err)
+	}
+	if len(packages) != 1 {
+		t.Fatalf("Expected 1 package, got %d: %v", len(packages), packages)
+	}
+	if packages[0].Name != "@npm-test/package-a" {
+		t.Errorf("Expected @npm-test/package-a, got %s", packages[0].Name)
+	}
+}
+
 func TestDetectYarnWorkspace(t *testing.T) {
 	root := filepath.Join("fixtures", "yarn-workspace")
 	ws, err := workspace.Detect(root)


### PR DESCRIPTION
Closes #151.

## The bug

`expandGlobs` in `internal/workspace/workspace.go` saw a `!packages/internal-secret` entry, hit a bare `continue`, and threw it away. The include glob `packages/*` then still matched the negated directory, so `lnpm publish --all` pushed a package the workspace config explicitly excluded into the shared store, where consuming projects could link it.

Both `package.json`'s `workspaces` and `pnpm-workspace.yaml`'s `packages` route through this one function, so both formats were affected.

## The fix

Negations are collected while the includes expand, then expanded the same way and subtracted from the result. Ordering and dedup are preserved, and the no-negation path returns early so it produces the identical slice it did before — "behaves exactly as before" holds at the identity level, not just by value.

## Behaviour note

This is **order-independent**. npm and pnpm apply workspace patterns sequentially, so `["!packages/a", "packages/*"]` re-includes `packages/a` there and excludes it here. That is the contract #151 specifies (its "How to fix" step 3 is collect-then-subtract), but it is a real divergence from the tools being emulated and worth knowing about.

## Tests

`internal/workspace` had **no test file at all**; this adds one. Four of the seven new tests fail against the pre-fix code — verified empirically by reverting `expandGlobs` and running the suite, not by argument:

- `TestExpandGlobsExcludesNegatedPackage` — "Expected 1 packages, got 2"
- `TestExpandGlobsNegationGlobExcludesEveryMatch` — "Expected 1 packages, got 3"
- `TestDetectPNPMWorkspaceExcludesNegatedPackage` — "Expected 1 packages, got 2" (covers the pnpm route end-to-end through `Detect`)
- `TestDetectNPMWorkspaceWithNegation` — "Expected 1 package, got 2" (integration, new `tests/fixtures/npm-workspace-negation/` fixture)

The remaining three — `NegationMatchingNothing`, `WithoutNegationPreservesOrderAndDedup`, `SkipsDirectoriesWithoutPackageJSON` — **cannot fail pre-fix** and are not bug-pinning. They are honest regression guards for acceptance criterion 2 ("non-negated globs behave exactly as before") and would catch an over-broad filter.

## Known limitation, filed separately

`expandGlobs` swallows glob errors on both loops (`if err != nil { continue }`), so a malformed negation such as `!packages/[bad` fails **open** — it publishes the package it was meant to exclude. The include side has swallowed errors the same way since before this change, and #151 step 2 explicitly required expanding negations "the same way includes are expanded", so fixing it here would have been scope creep. Filed as #241.

## Out of scope

File-level ignore matching (#150, #207), workspace discovery, and the publish pipeline beyond package selection are untouched.

## Verification

`go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `gofmt -l .` clean, full `( umask 022; go test ./... )` green, cross-compiles clean for `windows/amd64` and `darwin/arm64`. `-race` is covered by CI only.