### PR TITLE
fix(add): save the lock file before rewriting package.json

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -73,8 +73,8 @@
 2. Database lookup: find package by name (or hash if version specified)
 3. `store.GetFiles()` retrieves file list from store
 4. `link.Link()` creates reflinks/hardlinks to `.lnpm/{pkg}/`, symlink to `node_modules/{pkg}/`
-5. Update package.json with `file:.lnpm/{pkg}`
-6. Update lnpm.lock with package metadata
+5. Update lnpm.lock with package metadata, including the original package.json specifier, which must reach the lock before step 6 overwrites it or a failure in between loses it
+6. Update package.json with `file:.lnpm/{pkg}`
 7. Database records Project and Link
 
 **Watch Flow:**

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -277,8 +277,14 @@ lnpm add my-package --dev
 2. Create a temporary directory alongside `.lnpm/{package}/`
 3. Hard link all files from store into it, then rename it to `.lnpm/{package}/`
 4. Create symlink `node_modules/{package}` → `.lnpm/{package}`
-5. Update `package.json` with `file:.lnpm/{package}`
-6. Update `lnpm.lock`
+5. Update `lnpm.lock`, recording the current `package.json` specifier as the
+   original version
+
+   The lock write stays ahead of the rewrite below: the original specifier
+   exists only in `package.json`, so a rewrite that ran first would overwrite
+   it and any later failure would leave `remove` nothing to restore.
+
+6. Update `package.json` with `file:.lnpm/{package}`
 7. Register link in bbolt
 
 ### `lnpm remove <package>`

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -29,7 +29,11 @@ type addResult struct {
 	pkg         *db.Package
 	linkType    link.LinkType
 	origVersion string
-	err         error
+	// pkgJSONUnreadable records that reading package.json for this package
+	// already failed, so the later write is skipped instead of reporting the
+	// same failure twice.
+	pkgJSONUnreadable bool
+	err               error
 }
 
 // RunAddMultiple adds multiple packages with parallel linking
@@ -152,33 +156,26 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 		return fmt.Errorf("failed to load lock file: %w", err)
 	}
 
-	// Update package.json for all successful packages
+	// ORDERING CONSTRAINT: the user's original specifiers exist only in
+	// package.json, and writing the lnpm references overwrites them. Read them
+	// and save them to the lock file BEFORE package.json is rewritten, so that
+	// a failure of the rewrite - or of anything after it, which for this path
+	// includes registering the project - still leaves remove/retreat able to
+	// restore the specifiers instead of deleting the dependencies. Do not move
+	// the package.json writes back above lock.Save.
 	if !pure {
 		for i := range successful {
-			origVersion, err := updatePackageJSON(pkgJSONPath, successful[i].pkg.Name, dev, useLink)
+			deps, err := readPackageJSONDeps(pkgJSONPath, successful[i].pkg.Name, dev)
 			if err != nil {
 				fmt.Printf("  %s Failed to update package.json for %s: %v\n", iconWarn(), successful[i].pkg.Name, err)
+				successful[i].pkgJSONUnreadable = true
 				continue
 			}
-			successful[i].origVersion = origVersion
+			successful[i].origVersion = deps.originalVersion
 		}
 	}
 
-	// Update lockfile and database for all successful packages
-	proj := &db.Project{
-		Path:           cwd,
-		Name:           getProjectName(cwd),
-		PackageManager: string(pm),
-	}
-	if err := database.InsertProject(proj); err != nil {
-		return fmt.Errorf("failed to register project: %w", err)
-	}
-
-	existingProj, err := database.GetProjectByPath(cwd)
-	if err != nil {
-		return fmt.Errorf("failed to get project: %w", err)
-	}
-
+	// Update lockfile for all successful packages
 	for _, r := range successful {
 		// Check for existing original version in lockfile
 		existingOrigVersion := ""
@@ -198,7 +195,40 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 			Linked:          time.Now(),
 			OriginalVersion: origVersion,
 		})
+	}
 
+	if err := lock.Save(cwd); err != nil {
+		return fmt.Errorf("failed to save lock file: %w", err)
+	}
+
+	// Update package.json for all successful packages
+	if !pure {
+		for _, r := range successful {
+			if r.pkgJSONUnreadable {
+				continue
+			}
+			if err := writeLnpmReference(pkgJSONPath, r.pkg.Name, dev, useLink); err != nil {
+				fmt.Printf("  %s Failed to update package.json for %s: %v\n", iconWarn(), r.pkg.Name, err)
+			}
+		}
+	}
+
+	// Update database for all successful packages
+	proj := &db.Project{
+		Path:           cwd,
+		Name:           getProjectName(cwd),
+		PackageManager: string(pm),
+	}
+	if err := database.InsertProject(proj); err != nil {
+		return fmt.Errorf("failed to register project: %w", err)
+	}
+
+	existingProj, err := database.GetProjectByPath(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to get project: %w", err)
+	}
+
+	for _, r := range successful {
 		dbLink := &db.Link{
 			PackageID: r.pkg.ID,
 			ProjectID: existingProj.ID,
@@ -209,10 +239,6 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 		}
 
 		fmt.Printf("%s Added %s@%s (%s)\n", iconOK(), r.pkg.Name, r.pkg.Version, r.linkType)
-	}
-
-	if err := lock.Save(cwd); err != nil {
-		return fmt.Errorf("failed to save lock file: %w", err)
 	}
 
 	if len(errors) > 0 {
@@ -322,13 +348,19 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useL
 		existingOriginalVersion = existing.OriginalVersion
 	}
 
-	// Update package.json (unless --pure)
+	// ORDERING CONSTRAINT: the user's original specifier exists only in
+	// package.json, and writing the lnpm reference overwrites it. Read it and
+	// save it to the lock file BEFORE package.json is rewritten, so that a
+	// failure of the rewrite - or of anything after it - still leaves
+	// remove/retreat able to restore the specifier instead of deleting the
+	// dependency. Do not move the package.json write back above lock.Save.
 	var originalVersion string
 	if !pure {
-		originalVersion, err = updatePackageJSON(pkgJSONPath, pkg.Name, dev, useLink)
+		deps, err := readPackageJSONDeps(pkgJSONPath, pkg.Name, dev)
 		if err != nil {
 			return fmt.Errorf("failed to update package.json: %w", err)
 		}
+		originalVersion = deps.originalVersion
 	}
 
 	// Use existing original version if we didn't find one (re-add scenario)
@@ -346,6 +378,13 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useL
 
 	if err := lock.Save(cwd); err != nil {
 		return fmt.Errorf("failed to save lock file: %w", err)
+	}
+
+	// Update package.json (unless --pure)
+	if !pure {
+		if err := writeLnpmReference(pkgJSONPath, pkg.Name, dev, useLink); err != nil {
+			return fmt.Errorf("failed to update package.json: %w", err)
+		}
 	}
 
 	// Register project and link in database
@@ -412,19 +451,38 @@ func parsePackageSpec(spec string) (name, version string) {
 	return spec, ""
 }
 
-// updatePackageJSON updates package.json with the lnpm dependency. When link is
-// true the dependency uses the "link:" protocol (symlink-style resolution,
-// which helps pnpm/yarn dedupe peer deps) instead of the default "file:".
-func updatePackageJSON(path string, packageName string, dev bool, useLink bool) (originalVersion string, err error) {
-	// Read existing package.json
+// packageJSONDeps is what reading package.json tells us about a dependency
+// before the lnpm reference is written: the parsed document, the field the
+// reference belongs in, and the specifier the user had there. The
+// field-selection rules live here alone so the read half and the write half
+// cannot drift apart.
+type packageJSONDeps struct {
+	doc             map[string]interface{}
+	field           string
+	originalVersion string
+}
+
+// otherField is the dependency field the entry does NOT belong in; the write
+// folds any entry found there into the chosen field.
+func (p *packageJSONDeps) otherField() string {
+	if p.field == "devDependencies" {
+		return "dependencies"
+	}
+	return "devDependencies"
+}
+
+// readPackageJSONDeps parses package.json and works out what writing the lnpm
+// reference would do, without writing anything. Callers can therefore persist
+// originalVersion to the lock file before the rewrite is attempted.
+func readPackageJSONDeps(path string, packageName string, dev bool) (*packageJSONDeps, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var pkgJSON map[string]interface{}
 	if err := json.Unmarshal(data, &pkgJSON); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Check where package currently exists
@@ -438,36 +496,45 @@ func updatePackageJSON(path string, packageName string, dev bool, useLink bool) 
 	// - If --dev flag: use devDependencies
 	// - Else if package exists in devDependencies: use devDependencies (preserve location)
 	// - Else: use dependencies (default)
-	depsField := "dependencies"
+	deps := &packageJSONDeps{doc: pkgJSON, field: "dependencies"}
 	if dev || (!inDeps && inDevDeps) {
-		depsField = "devDependencies"
+		deps.field = "devDependencies"
 	}
 
-	// Get or create dependencies object
-	deps, ok := pkgJSON[depsField].(map[string]interface{})
-	if !ok {
-		deps = make(map[string]interface{})
-		pkgJSON[depsField] = deps
-	}
-
-	// Save original version from target field (ignore lnpm references)
-	if v, ok := deps[packageName].(string); ok {
-		if !isLnpmReference(v) {
-			originalVersion = v
+	// Original version from the target field (ignore lnpm references)
+	if target, ok := pkgJSON[deps.field].(map[string]interface{}); ok {
+		if v, ok := target[packageName].(string); ok && !isLnpmReference(v) {
+			deps.originalVersion = v
 		}
 	}
 
 	// Also check other field for original version
-	otherField := "devDependencies"
-	if depsField == "devDependencies" {
-		otherField = "dependencies"
-	}
-	if otherDeps, ok := pkgJSON[otherField].(map[string]interface{}); ok {
+	if otherDeps, ok := pkgJSON[deps.otherField()].(map[string]interface{}); ok {
 		if v, ok := otherDeps[packageName].(string); ok {
-			if originalVersion == "" && !isLnpmReference(v) {
-				originalVersion = v
+			if deps.originalVersion == "" && !isLnpmReference(v) {
+				deps.originalVersion = v
 			}
-			// Remove from other field to avoid duplicate entries
+		}
+	}
+
+	return deps, nil
+}
+
+// write records the lnpm dependency in the parsed document and saves it. When
+// useLink is true the dependency uses the "link:" protocol (symlink-style
+// resolution, which helps pnpm/yarn dedupe peer deps) instead of the default
+// "file:".
+func (p *packageJSONDeps) write(path string, packageName string, useLink bool) error {
+	// Get or create dependencies object
+	deps, ok := p.doc[p.field].(map[string]interface{})
+	if !ok {
+		deps = make(map[string]interface{})
+		p.doc[p.field] = deps
+	}
+
+	// Remove from other field to avoid duplicate entries
+	if otherDeps, ok := p.doc[p.otherField()].(map[string]interface{}); ok {
+		if _, ok := otherDeps[packageName].(string); ok {
 			delete(otherDeps, packageName)
 		}
 	}
@@ -480,19 +547,28 @@ func updatePackageJSON(path string, packageName string, dev bool, useLink bool) 
 	deps[packageName] = fmt.Sprintf("%s:.lnpm/%s", protocol, packageName)
 
 	// Write back
-	output, err := json.MarshalIndent(pkgJSON, "", "  ")
+	output, err := json.MarshalIndent(p.doc, "", "  ")
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	// Add trailing newline
 	output = append(output, '\n')
 
-	if err := os.WriteFile(path, output, 0644); err != nil {
-		return "", err
-	}
+	return os.WriteFile(path, output, 0644)
+}
 
-	return originalVersion, nil
+// writeLnpmReference points package.json at the linked copy of packageName.
+//
+// It re-reads the file rather than reusing an earlier read, so that writing
+// several packages in sequence does not have each write clobber the previous
+// one with a stale document.
+func writeLnpmReference(path string, packageName string, dev bool, useLink bool) error {
+	deps, err := readPackageJSONDeps(path, packageName, dev)
+	if err != nil {
+		return err
+	}
+	return deps.write(path, packageName, useLink)
 }
 
 // isLnpmReference checks if a version string is an lnpm reference (file:.lnpm/ or link:.lnpm/)

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -167,7 +167,7 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 		for i := range successful {
 			deps, err := readPackageJSONDeps(pkgJSONPath, successful[i].pkg.Name, dev)
 			if err != nil {
-				fmt.Printf("  %s Failed to update package.json for %s: %v\n", iconWarn(), successful[i].pkg.Name, err)
+				fmt.Printf("  %s Failed to read package.json for %s: %v\n", iconWarn(), successful[i].pkg.Name, err)
 				successful[i].pkgJSONUnreadable = true
 				continue
 			}
@@ -358,7 +358,7 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useL
 	if !pure {
 		deps, err := readPackageJSONDeps(pkgJSONPath, pkg.Name, dev)
 		if err != nil {
-			return fmt.Errorf("failed to update package.json: %w", err)
+			return fmt.Errorf("failed to read package.json: %w", err)
 		}
 		originalVersion = deps.originalVersion
 	}

--- a/tests/original_version_permissions_test.go
+++ b/tests/original_version_permissions_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
 
-// requirePackageJSONWriteFailure skips tests that force a package.json rewrite
+// requirePermissionEnforcement skips tests that force a package.json rewrite
 // to fail by making the file read-only. Windows models only a read-only bit and
 // root ignores permission bits entirely, so neither can produce the failure
 // these tests depend on.
-func requirePackageJSONWriteFailure(t *testing.T) {
+func requirePermissionEnforcement(t *testing.T) {
 	t.Helper()
 
 	if runtime.GOOS == "windows" {
@@ -46,7 +46,7 @@ func makePackageJSONReadOnly(t *testing.T, projectDir string) {
 // reach the lock file before package.json is touched - a failed rewrite must
 // still leave the lock able to restore it.
 func TestAddRecordsOriginalVersionWhenPackageJSONWriteFails(t *testing.T) {
-	requirePackageJSONWriteFailure(t)
+	requirePermissionEnforcement(t)
 
 	env := setupTest(t)
 	env.simplePkg("failing-single-pkg")
@@ -73,7 +73,7 @@ func TestAddRecordsOriginalVersionWhenPackageJSONWriteFails(t *testing.T) {
 // The multi-package path has the same ordering constraint, and gets it wrong
 // for every package in the batch at once, so it needs its own coverage.
 func TestAddMultipleRecordsOriginalVersionsWhenPackageJSONWriteFails(t *testing.T) {
-	requirePackageJSONWriteFailure(t)
+	requirePermissionEnforcement(t)
 
 	env := setupTest(t)
 	env.simplePkg("failing-multi-a")

--- a/tests/original_version_permissions_test.go
+++ b/tests/original_version_permissions_test.go
@@ -1,0 +1,115 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
+)
+
+// requirePackageJSONWriteFailure skips tests that force a package.json rewrite
+// to fail by making the file read-only. Windows models only a read-only bit and
+// root ignores permission bits entirely, so neither can produce the failure
+// these tests depend on.
+func requirePackageJSONWriteFailure(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows reports only a read-only bit, not Unix permission bits")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses the permission checks this test relies on")
+	}
+}
+
+// makePackageJSONReadOnly makes projectDir's package.json unwritable, so the
+// rewrite that replaces the dependency specifier with an lnpm reference fails
+// while everything around it (reading package.json, writing lnpm.lock into the
+// still-writable directory) keeps working.
+func makePackageJSONReadOnly(t *testing.T, projectDir string) {
+	t.Helper()
+
+	path := filepath.Join(projectDir, "package.json")
+	if err := os.Chmod(path, 0444); err != nil {
+		t.Fatalf("Failed to chmod package.json: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0644) })
+}
+
+// The user's original specifier lives nowhere but package.json, and the add
+// overwrites it with an lnpm reference. If the lock file is written after that
+// rewrite, any failure in between destroys the specifier for good: remove and
+// retreat delete the dependency instead of restoring it. So the specifier must
+// reach the lock file before package.json is touched - a failed rewrite must
+// still leave the lock able to restore it.
+func TestAddRecordsOriginalVersionWhenPackageJSONWriteFails(t *testing.T) {
+	requirePackageJSONWriteFailure(t)
+
+	env := setupTest(t)
+	env.simplePkg("failing-single-pkg")
+
+	projectDir := env.CreateTestPackage("failing-single-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":         "failing-single-project",
+		"version":      "1.0.0",
+		"dependencies": map[string]interface{}{"failing-single-pkg": "^1.0.0"},
+	})
+	makePackageJSONReadOnly(t, projectDir)
+
+	env.chdir(projectDir)
+	if err := cli.RunAdd("failing-single-pkg", false, false, false); err == nil {
+		t.Fatal("Expected an error when package.json cannot be written, got nil")
+	}
+
+	// package.json is untouched, so the specifier is still recoverable - but
+	// only if the lock file recorded it.
+	env.AssertPackageJSON(projectDir, "failing-single-pkg", "^1.0.0")
+	assertOriginalVersion(t, env, projectDir, "failing-single-pkg", "^1.0.0")
+}
+
+// The multi-package path has the same ordering constraint, and gets it wrong
+// for every package in the batch at once, so it needs its own coverage.
+func TestAddMultipleRecordsOriginalVersionsWhenPackageJSONWriteFails(t *testing.T) {
+	requirePackageJSONWriteFailure(t)
+
+	env := setupTest(t)
+	env.simplePkg("failing-multi-a")
+	env.simplePkg("failing-multi-b")
+
+	projectDir := env.CreateTestPackage("failing-multi-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":    "failing-multi-project",
+		"version": "1.0.0",
+		"dependencies": map[string]interface{}{
+			"failing-multi-a": "^1.0.0",
+			"failing-multi-b": "~2.3.4",
+		},
+	})
+	makePackageJSONReadOnly(t, projectDir)
+
+	env.chdir(projectDir)
+	specs := []string{"failing-multi-a", "failing-multi-b"}
+	captureStdout(t, func() {
+		if err := cli.RunAddMultiple(specs, false, false, false, false); err != nil {
+			t.Errorf("RunAddMultiple returned error: %v", err)
+		}
+	})
+
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		for name, want := range map[string]string{
+			"failing-multi-a": "^1.0.0",
+			"failing-multi-b": "~2.3.4",
+		} {
+			p, ok := lock.Get(name)
+			if !ok {
+				t.Fatalf("Package %s not in lockfile", name)
+			}
+			if p.OriginalVersion != want {
+				t.Errorf("Expected original version %q for %s, got %q", want, name, p.OriginalVersion)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Closes #155.

## The bug

The user's original dependency specifier (`^1.2.3`) exists nowhere but `package.json`, and `add` overwrites it with `file:.lnpm/<pkg>`. It is captured during that rewrite and stored in `lnpm.lock` as `OriginalVersion` — and `remove`/`retreat` treat an empty `OriginalVersion` as "delete the dependency" rather than "restore it".

Both add paths wrote `package.json` before saving the lock, so any failure in between destroyed the specifier permanently. The multi path was worse: it saved the lock only *after* `InsertProject`, so a single database error lost the specifier for **every package in the batch**.

## The fix

Strategy 1 from the issue, the recommended one. Both paths now **read** the specifier → **`lock.Save`** → **rewrite `package.json`** → **database records**, with an `ORDERING CONSTRAINT:` comment in each so the sequence is not reordered later. Every step that can fail after the rewrite now happens after the lock is durable; between the read and `lock.Save` there is only an in-memory `lock.Add`.

`updatePackageJSON` is split into `readPackageJSONDeps` (read + field selection, no mutation) and `(*packageJSONDeps).write`. The field-selection rule — `dev || (!inDeps && inDevDeps)` → `devDependencies` — now lives in the reader alone and the write consumes it, so the two halves cannot drift apart.

`writeLnpmReference` deliberately **re-reads** rather than reusing an earlier parse: the multi path writes several packages in sequence, and a stale in-memory document would clobber each previous write. The re-read is safe because a package's field selection depends only on whether *its own* key is present — an earlier write can only touch its own key or create an empty `devDependencies` map, neither of which changes another package's selection.

## Behaviour note

Inherent to strategy 1: if the `package.json` rewrite then fails, the lock holds a full entry for a package whose `package.json` still shows the original specifier. That is the intended trade — linking into `.lnpm/<pkg>` already happened before this point, so the entry describes state that genuinely exists, and it is exactly what lets a later `remove` clean up. The visible effect is `remove` rewriting `^1.0.0` over an identical `^1.0.0`, a no-op. The alternative (record only on full success) is what the issue explicitly rejected.

## Tests

Two new tests in `tests/original_version_permissions_test.go`, both of which fail on the pre-fix code — verified by stashing `add.go` and re-running, not by argument:

- `TestAddRecordsOriginalVersionWhenPackageJSONWriteFails` — pre-fix: `Package failing-single-pkg not in lockfile` (the write fails first, so `lock.Save` is never reached).
- `TestAddMultipleRecordsOriginalVersionsWhenPackageJSONWriteFails` — pre-fix: `Expected original version "^1.0.0" … got ""` and `"~2.3.4" … got ""` (lock written, specifier already lost).

Both make `package.json` read-only while leaving the directory writable, so `lnpm.lock` can still be created, and skip on Windows and as root.

The issue also sketched a happy-path add → `remove` → assert-restored test. That already exists verbatim as `TestRemoveRestoresOriginalVersion`, with `TestRetreatRestoresOriginalVersion` covering the retreat variant; both pass pre-fix, so re-adding them would have been hollow coverage.

Per the repo convention these live in a `*_permissions_test.go` file rather than the `tests/original_version_test.go` the issue named.

## Docs

Both Add Flow descriptions (`ARCHITECTURE.md` and `.planning/codebase/ARCHITECTURE.md`) listed the `package.json` rewrite ahead of the lock write — the ordering this change forbids. Both are reordered, with a note on why, so the sequence is not tidied back.

## Out of scope

The `package.json` formatting question (#163), multi-add failure handling (#156), and rollback beyond restoring the prior specifier are untouched. Review confirmed the `InsertProject` move does not change which failures abort the batch — only the committed state at the point of abort, which is the issue's whole point.

## Verification

`go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `gofmt -l .` clean, full `( umask 022; go test ./... )` green, cross-compiles clean for `windows/amd64` and `darwin/arm64`. `-race` is covered by CI only.