### PR TITLE
fix(add): roll a package back when its package.json update fails in multi-add

### DIFF
--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -29,11 +29,17 @@ type addResult struct {
 	pkg         *db.Package
 	linkType    link.LinkType
 	origVersion string
-	// pkgJSONUnreadable records that reading package.json for this package
-	// already failed, so the later write is skipped instead of reporting the
-	// same failure twice.
-	pkgJSONUnreadable bool
-	err               error
+	// rolledBack records that this package's package.json handling failed and
+	// the package was undone, so every later step - the lock entry, the
+	// package.json write, the database link, the success line - skips it.
+	rolledBack bool
+	// priorLock is the lock entry this package already had when the batch
+	// started, and hadPriorLock whether there was one at all. Together they
+	// say whether this invocation created the package, which is what decides
+	// how far a rollback may go.
+	priorLock    lockfile.Package
+	hadPriorLock bool
+	err          error
 }
 
 // RunAddMultiple adds multiple packages with parallel linking
@@ -156,19 +162,60 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 		return fmt.Errorf("failed to load lock file: %w", err)
 	}
 
+	// Record what the lock already held for each package before anything
+	// touches it, so a rollback can tell what this invocation created from
+	// what it merely re-added.
+	for i := range successful {
+		successful[i].priorLock, successful[i].hadPriorLock = lock.Get(successful[i].pkg.Name)
+	}
+
+	// rollBack undoes a package whose package.json handling failed. How far it
+	// may go depends on whether this invocation created the package.
+	//
+	// With no prior lock entry the package is new to the project: the link
+	// phase created its .lnpm copy and node_modules symlink, and package.json
+	// still holds the user's own specifier because the rewrite never landed,
+	// so nothing about it should survive. Leaving a lock entry behind would be
+	// worse than useless: it would carry an empty OriginalVersion, and a later
+	// remove would read that as "delete the dependency" and destroy the
+	// specifier package.json still holds.
+	//
+	// With a prior entry the package was added by an earlier run, and undoing
+	// it would destroy state this invocation never created. package.json
+	// already holds the lnpm reference, so the user's real specifier survives
+	// nowhere but that entry's OriginalVersion, and Unlink removes the .lnpm
+	// copy package.json points at. So the prior entry is put back and the link
+	// - re-created by the link phase, still fresh, still what package.json
+	// references - is left alone. The package stays as it was, and the error is
+	// still recorded so the command exits non-zero.
+	rollBack := func(r *addResult, reason error) {
+		r.rolledBack = true
+		if r.hadPriorLock {
+			lock.Add(r.pkg.Name, r.priorLock)
+		} else {
+			lock.Remove(r.pkg.Name)
+			if err := linker.Unlink(r.pkg.Name); err != nil {
+				fmt.Printf("  %s Failed to unlink %s: %v\n", iconWarn(), r.pkg.Name, err)
+			}
+		}
+		errors = append(errors, fmt.Errorf("%s: %w", r.spec, reason))
+	}
+
 	// ORDERING CONSTRAINT: the user's original specifiers exist only in
 	// package.json, and writing the lnpm references overwrites them. Read them
 	// and save them to the lock file BEFORE package.json is rewritten, so that
-	// a failure of the rewrite - or of anything after it, which for this path
+	// a failure of anything after the lock is saved - which for this path
 	// includes registering the project - still leaves remove/retreat able to
 	// restore the specifiers instead of deleting the dependencies. Do not move
-	// the package.json writes back above lock.Save.
+	// the package.json writes back above lock.Save. A failure of the rewrite
+	// itself needs no such rescue for a package this run added: package.json was
+	// never touched, so it is rolled back instead.
 	if !pure {
 		for i := range successful {
 			deps, err := readPackageJSONDeps(pkgJSONPath, successful[i].pkg.Name, dev)
 			if err != nil {
 				fmt.Printf("  %s Failed to read package.json for %s: %v\n", iconWarn(), successful[i].pkg.Name, err)
-				successful[i].pkgJSONUnreadable = true
+				rollBack(&successful[i], fmt.Errorf("failed to read package.json: %w", err))
 				continue
 			}
 			successful[i].origVersion = deps.originalVersion
@@ -177,10 +224,14 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 
 	// Update lockfile for all successful packages
 	for _, r := range successful {
+		if r.rolledBack {
+			continue
+		}
+
 		// Check for existing original version in lockfile
 		existingOrigVersion := ""
-		if existing, ok := lock.Get(r.pkg.Name); ok && existing.OriginalVersion != "" {
-			existingOrigVersion = existing.OriginalVersion
+		if r.hadPriorLock {
+			existingOrigVersion = r.priorLock.OriginalVersion
 		}
 
 		origVersion := r.origVersion
@@ -201,14 +252,25 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 		return fmt.Errorf("failed to save lock file: %w", err)
 	}
 
-	// Update package.json for all successful packages
+	// Update package.json for all successful packages. A failure here is found
+	// with the lock already on disk, so rolling the package back - dropping its
+	// entry, or restoring the one it had before - means saving the lock a
+	// second time.
 	if !pure {
-		for _, r := range successful {
-			if r.pkgJSONUnreadable {
+		lockChanged := false
+		for i := range successful {
+			if successful[i].rolledBack {
 				continue
 			}
-			if err := writeLnpmReference(pkgJSONPath, r.pkg.Name, dev, useLink); err != nil {
-				fmt.Printf("  %s Failed to update package.json for %s: %v\n", iconWarn(), r.pkg.Name, err)
+			if err := writeLnpmReference(pkgJSONPath, successful[i].pkg.Name, dev, useLink); err != nil {
+				fmt.Printf("  %s Failed to update package.json for %s: %v\n", iconWarn(), successful[i].pkg.Name, err)
+				rollBack(&successful[i], fmt.Errorf("failed to update package.json: %w", err))
+				lockChanged = true
+			}
+		}
+		if lockChanged {
+			if err := lock.Save(cwd); err != nil {
+				return fmt.Errorf("failed to save lock file: %w", err)
 			}
 		}
 	}
@@ -229,6 +291,10 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 	}
 
 	for _, r := range successful {
+		if r.rolledBack {
+			continue
+		}
+
 		dbLink := &db.Link{
 			PackageID: r.pkg.ID,
 			ProjectID: existingProj.ID,
@@ -248,13 +314,23 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 		}
 	}
 
+	// Rolled-back packages are still in successful - they linked cleanly and
+	// only failed afterwards - so count what actually survived before advising
+	// on npm install, which has nothing to resolve if nothing was added.
+	added := 0
+	for _, r := range successful {
+		if !r.rolledBack {
+			added++
+		}
+	}
+
 	// Run npm install once at the end if requested
-	if runInstall && !pure && len(successful) > 0 {
+	if runInstall && !pure && added > 0 {
 		fmt.Println("\nRunning npm install...")
 		if err := hooks.RunPostAdd(cwd, true); err != nil {
 			fmt.Printf("  %s npm install failed: %v\n", iconWarn(), err)
 		}
-	} else if !pure && len(successful) > 0 {
+	} else if !pure && added > 0 {
 		fmt.Printf("\n  %s Run 'npm install' if you need to resolve peer dependencies\n", iconTip())
 	}
 

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -169,38 +169,6 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 		successful[i].priorLock, successful[i].hadPriorLock = lock.Get(successful[i].pkg.Name)
 	}
 
-	// rollBack undoes a package whose package.json handling failed. How far it
-	// may go depends on whether this invocation created the package.
-	//
-	// With no prior lock entry the package is new to the project: the link
-	// phase created its .lnpm copy and node_modules symlink, and package.json
-	// still holds the user's own specifier because the rewrite never landed,
-	// so nothing about it should survive. Leaving a lock entry behind would be
-	// worse than useless: it would carry an empty OriginalVersion, and a later
-	// remove would read that as "delete the dependency" and destroy the
-	// specifier package.json still holds.
-	//
-	// With a prior entry the package was added by an earlier run, and undoing
-	// it would destroy state this invocation never created. package.json
-	// already holds the lnpm reference, so the user's real specifier survives
-	// nowhere but that entry's OriginalVersion, and Unlink removes the .lnpm
-	// copy package.json points at. So the prior entry is put back and the link
-	// - re-created by the link phase, still fresh, still what package.json
-	// references - is left alone. The package stays as it was, and the error is
-	// still recorded so the command exits non-zero.
-	rollBack := func(r *addResult, reason error) {
-		r.rolledBack = true
-		if r.hadPriorLock {
-			lock.Add(r.pkg.Name, r.priorLock)
-		} else {
-			lock.Remove(r.pkg.Name)
-			if err := linker.Unlink(r.pkg.Name); err != nil {
-				fmt.Printf("  %s Failed to unlink %s: %v\n", iconWarn(), r.pkg.Name, err)
-			}
-		}
-		errors = append(errors, fmt.Errorf("%s: %w", r.spec, reason))
-	}
-
 	// ORDERING CONSTRAINT: the user's original specifiers exist only in
 	// package.json, and writing the lnpm references overwrites them. Read them
 	// and save them to the lock file BEFORE package.json is rewritten, so that
@@ -215,7 +183,8 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 			deps, err := readPackageJSONDeps(pkgJSONPath, successful[i].pkg.Name, dev)
 			if err != nil {
 				fmt.Printf("  %s Failed to read package.json for %s: %v\n", iconWarn(), successful[i].pkg.Name, err)
-				rollBack(&successful[i], fmt.Errorf("failed to read package.json: %w", err))
+				_, rolledBackErr := rollBack(lock, linker, &successful[i], fmt.Errorf("failed to read package.json: %w", err))
+				errors = append(errors, rolledBackErr)
 				continue
 			}
 			successful[i].origVersion = deps.originalVersion
@@ -253,9 +222,8 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 	}
 
 	// Update package.json for all successful packages. A failure here is found
-	// with the lock already on disk, so rolling the package back - dropping its
-	// entry, or restoring the one it had before - means saving the lock a
-	// second time.
+	// with the lock already on disk, so dropping a package's entry means saving
+	// the lock a second time.
 	if !pure {
 		lockChanged := false
 		for i := range successful {
@@ -264,8 +232,9 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 			}
 			if err := writeLnpmReference(pkgJSONPath, successful[i].pkg.Name, dev, useLink); err != nil {
 				fmt.Printf("  %s Failed to update package.json for %s: %v\n", iconWarn(), successful[i].pkg.Name, err)
-				rollBack(&successful[i], fmt.Errorf("failed to update package.json: %w", err))
-				lockChanged = true
+				removed, rolledBackErr := rollBack(lock, linker, &successful[i], fmt.Errorf("failed to update package.json: %w", err))
+				errors = append(errors, rolledBackErr)
+				lockChanged = lockChanged || removed
 			}
 		}
 		if lockChanged {
@@ -340,6 +309,37 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 	}
 
 	return nil
+}
+
+// rollBack undoes a package whose package.json handling failed, marks it so
+// every later step skips it, and returns the error to record for it. It reports
+// whether the lock file changed, so a caller that has already saved the lock
+// knows whether it must save it again.
+//
+// How far the undo may go depends on whether this invocation created the
+// package. With no prior lock entry the package is new to the project: the link
+// phase created its .lnpm copy and node_modules symlink, and package.json still
+// holds the user's own specifier because the rewrite never landed, so nothing
+// about it should survive. Leaving a lock entry behind would be worse than
+// useless: it would carry an empty OriginalVersion, and a later remove would
+// read that as "delete the dependency" and destroy the specifier package.json
+// still holds.
+//
+// A package added by an earlier run is left alone entirely. It must not be
+// unlinked - package.json points at the .lnpm copy Unlink would delete - and
+// its fresh lock entry already describes what the link phase just wrote, so
+// there is nothing to undo. Only the package.json write and the database link
+// are skipped, and the error is still recorded so the command exits non-zero.
+func rollBack(lock *lockfile.LockFile, linker *link.Linker, r *addResult, reason error) (lockChanged bool, recorded error) {
+	r.rolledBack = true
+	if !r.hadPriorLock {
+		lock.Remove(r.pkg.Name)
+		lockChanged = true
+		if err := linker.Unlink(r.pkg.Name); err != nil {
+			fmt.Printf("  %s Failed to unlink %s: %v\n", iconWarn(), r.pkg.Name, err)
+		}
+	}
+	return lockChanged, fmt.Errorf("%s: %w", r.spec, reason)
 }
 
 // runAddSingle adds a single package (internal implementation)

--- a/tests/add_ordering_permissions_test.go
+++ b/tests/add_ordering_permissions_test.go
@@ -1,0 +1,67 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+)
+
+// makeLockFileReadOnly seeds projectDir with an empty but valid lock file and
+// makes it unwritable, so loading it succeeds and saving it fails. Everything
+// else - reading and writing package.json in the still-writable directory -
+// keeps working.
+func makeLockFileReadOnly(t *testing.T, projectDir string) {
+	t.Helper()
+
+	path := filepath.Join(projectDir, "lnpm.lock")
+	if err := os.WriteFile(path, []byte("version: 1\npackages: {}\n"), 0644); err != nil {
+		t.Fatalf("Failed to write lnpm.lock: %v", err)
+	}
+	if err := os.Chmod(path, 0444); err != nil {
+		t.Fatalf("Failed to chmod lnpm.lock: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0644) })
+}
+
+// The multi-package add must save the lock file BEFORE it rewrites
+// package.json, because the user's original specifiers live nowhere else and
+// the rewrite overwrites them. This pins that ordering from the outside: with
+// the lock file unwritable, the save fails and the add returns before the
+// rewrite loop, so package.json still holds the user's specifiers.
+//
+// Move the save back below the rewrite loop and this test fails: package.json
+// would already hold file:.lnpm references with no lock entry to restore them
+// from, which is precisely the data loss the ordering prevents.
+func TestAddMultipleSavesLockBeforeRewritingPackageJSON(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	env := setupTest(t)
+	env.simplePkg("lock-order-a")
+	env.simplePkg("lock-order-b")
+
+	projectDir := env.CreateTestPackage("lock-order-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":    "lock-order-project",
+		"version": "1.0.0",
+		"dependencies": map[string]interface{}{
+			"lock-order-a": "^1.0.0",
+			"lock-order-b": "~2.3.4",
+		},
+	})
+	makeLockFileReadOnly(t, projectDir)
+
+	env.chdir(projectDir)
+	specs := []string{"lock-order-a", "lock-order-b"}
+	captureStdout(t, func() {
+		if err := cli.RunAddMultiple(specs, false, false, false, false); err == nil {
+			t.Error("Expected an error when the lock file cannot be saved, got nil")
+		}
+	})
+
+	// The lock never reached disk, so package.json must not have been rewritten:
+	// the specifiers are the only remaining record of what the user asked for.
+	env.AssertPackageJSON(projectDir, "lock-order-a", "^1.0.0")
+	env.AssertPackageJSON(projectDir, "lock-order-b", "~2.3.4")
+}

--- a/tests/add_test.go
+++ b/tests/add_test.go
@@ -360,3 +360,45 @@ func TestAddMultipleByVersionMismatch(t *testing.T) {
 	env.AssertPackageJSONMissing(projectDir, "pkg-a")
 	env.AssertDatabaseNoLink("pkg-a", projectDir)
 }
+
+// TestAddMultipleLeavesSucceedingPackageIntactWhenSiblingFails pins the other
+// half of the failure contract: a package that fails leaves the lock file with
+// no trace of itself, and the package beside it is recorded in full - symlink,
+// package.json reference, database link, and a lock entry carrying its real
+// original specifier.
+//
+// A package.json rewrite cannot be failed for one package alone (the batch
+// shares one file), so the failing sibling here is one that never resolves in
+// the store. It reaches the same end state the rewrite rollback aims for:
+// reported as an error, nothing recorded.
+func TestAddMultipleLeavesSucceedingPackageIntactWhenSiblingFails(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("survivor-pkg")
+
+	projectDir := env.CreateTestPackage("survivor-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":         "survivor-project",
+		"version":      "1.0.0",
+		"dependencies": map[string]interface{}{"survivor-pkg": "^3.1.0"},
+	})
+
+	env.chdir(projectDir)
+	captureStdout(t, func() {
+		if err := cli.RunAddMultiple([]string{"survivor-pkg", "missing-pkg"}, false, false, false, false); err == nil {
+			t.Error("Expected an error when one of the packages fails to add")
+		}
+	})
+
+	env.AssertSymlinkExists(projectDir, "survivor-pkg")
+	env.AssertPackageJSON(projectDir, "survivor-pkg", "file:.lnpm/survivor-pkg")
+	env.AssertDatabaseLink("survivor-pkg", projectDir)
+	assertOriginalVersion(t, env, projectDir, "survivor-pkg", "^3.1.0")
+
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		if lock.Has("missing-pkg") {
+			t.Error("Expected no lockfile entry for the package that failed to add")
+		}
+	})
+	env.AssertSymlinkMissing(projectDir, "missing-pkg")
+}

--- a/tests/original_version_permissions_test.go
+++ b/tests/original_version_permissions_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
 
-// requirePermissionEnforcement skips tests that force a package.json rewrite
-// to fail by making the file read-only. Windows models only a read-only bit and
-// root ignores permission bits entirely, so neither can produce the failure
-// these tests depend on.
+// requirePermissionEnforcement skips tests that force a write to fail by making
+// the target file read-only. Windows models only a read-only bit and root
+// ignores permission bits entirely, so neither can produce the failure these
+// tests depend on.
 func requirePermissionEnforcement(t *testing.T) {
 	t.Helper()
 
@@ -140,8 +140,8 @@ func TestAddMultipleRollsBackPackagesWhenPackageJSONWriteFails(t *testing.T) {
 // OriginalVersion. Dropping that entry would destroy the specifier outright,
 // and unlinking would delete the .lnpm copy package.json still points at -
 // exactly the data loss the rollback exists to prevent. So a failure on a
-// re-add must restore the prior lock entry and leave the link alone, while a
-// package this run added for the first time still rolls back completely.
+// re-add must leave the lock entry and the link alone, while a package this run
+// added for the first time still rolls back completely.
 func TestAddMultipleKeepsPriorStateWhenReAddPackageJSONWriteFails(t *testing.T) {
 	requirePermissionEnforcement(t)
 

--- a/tests/original_version_permissions_test.go
+++ b/tests/original_version_permissions_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
@@ -70,9 +71,15 @@ func TestAddRecordsOriginalVersionWhenPackageJSONWriteFails(t *testing.T) {
 	assertOriginalVersion(t, env, projectDir, "failing-single-pkg", "^1.0.0")
 }
 
-// The multi-package path has the same ordering constraint, and gets it wrong
-// for every package in the batch at once, so it needs its own coverage.
-func TestAddMultipleRecordsOriginalVersionsWhenPackageJSONWriteFails(t *testing.T) {
+// The multi-package path saves the lock file before it rewrites package.json,
+// so a failed rewrite is discovered with the lock already durable. Preserving
+// the specifier there would be pointless: the rewrite never landed, so
+// package.json still holds the user's own specifier, and the package was never
+// really added. Keeping a lock entry (and a database link, and a node_modules
+// symlink) for it would describe a dependency the project does not have. So the
+// batch rolls that package back completely - lock entry removed and the lock
+// re-saved, symlink and .lnpm copy unlinked - and reports it as a failure.
+func TestAddMultipleRollsBackPackagesWhenPackageJSONWriteFails(t *testing.T) {
 	requirePermissionEnforcement(t)
 
 	env := setupTest(t)
@@ -92,24 +99,155 @@ func TestAddMultipleRecordsOriginalVersionsWhenPackageJSONWriteFails(t *testing.
 
 	env.chdir(projectDir)
 	specs := []string{"failing-multi-a", "failing-multi-b"}
+	output := captureStdout(t, func() {
+		if err := cli.RunAddMultiple(specs, false, false, false, false); err == nil {
+			t.Error("Expected an error when package.json cannot be written, got nil")
+		}
+	})
+
+	// Nothing survived the batch, so add must not report progress or send the
+	// user on to npm install.
+	if strings.Contains(output, "npm install") {
+		t.Errorf("Expected no npm install advice when every package rolled back, got output:\n%s", output)
+	}
+	for _, name := range specs {
+		if strings.Contains(output, "Added "+name) {
+			t.Errorf("Expected %s not to be reported as added, got output:\n%s", name, output)
+		}
+	}
+
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		for _, name := range specs {
+			if p, ok := lock.Get(name); ok {
+				t.Errorf("Expected %s to be rolled back out of the lockfile, got %+v", name, p)
+			}
+		}
+	})
+
+	for _, name := range specs {
+		env.AssertSymlinkMissing(projectDir, name)
+		env.AssertDatabaseNoLink(name, projectDir)
+	}
+
+	// package.json was never rewritten, so the user's specifiers survive.
+	env.AssertPackageJSON(projectDir, "failing-multi-a", "^1.0.0")
+	env.AssertPackageJSON(projectDir, "failing-multi-b", "~2.3.4")
+}
+
+// Rolling a package back is only right when this invocation created it. A
+// package added by an earlier run is different: package.json already holds its
+// lnpm reference, so the user's real specifier survives nowhere but the lock's
+// OriginalVersion. Dropping that entry would destroy the specifier outright,
+// and unlinking would delete the .lnpm copy package.json still points at -
+// exactly the data loss the rollback exists to prevent. So a failure on a
+// re-add must restore the prior lock entry and leave the link alone, while a
+// package this run added for the first time still rolls back completely.
+func TestAddMultipleKeepsPriorStateWhenReAddPackageJSONWriteFails(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	env := setupTest(t)
+	env.simplePkg("readd-perm-existing")
+	env.simplePkg("readd-perm-new")
+
+	projectDir := env.CreateTestPackage("readd-perm-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":    "readd-perm-project",
+		"version": "1.0.0",
+		"dependencies": map[string]interface{}{
+			"readd-perm-existing": "^1.2.3",
+			"readd-perm-new":      "~2.3.4",
+		},
+	})
+
+	// The first add succeeds, so package.json now holds the lnpm reference and
+	// "^1.2.3" survives only as OriginalVersion in the lock.
+	env.addPkg(projectDir, "readd-perm-existing", false, false)
+	env.AssertPackageJSON(projectDir, "readd-perm-existing", "file:.lnpm/readd-perm-existing")
+	assertOriginalVersion(t, env, projectDir, "readd-perm-existing", "^1.2.3")
+
+	makePackageJSONReadOnly(t, projectDir)
+
+	env.chdir(projectDir)
+	specs := []string{"readd-perm-existing", "readd-perm-new"}
 	captureStdout(t, func() {
-		if err := cli.RunAddMultiple(specs, false, false, false, false); err != nil {
-			t.Errorf("RunAddMultiple returned error: %v", err)
+		if err := cli.RunAddMultiple(specs, false, false, false, false); err == nil {
+			t.Error("Expected an error when package.json cannot be written, got nil")
+		}
+	})
+
+	// The re-added package is left exactly as the earlier add left it.
+	assertOriginalVersion(t, env, projectDir, "readd-perm-existing", "^1.2.3")
+	env.AssertFilesLinked(projectDir, "readd-perm-existing")
+	env.AssertSymlinkExists(projectDir, "readd-perm-existing")
+	env.AssertPackageJSON(projectDir, "readd-perm-existing", "file:.lnpm/readd-perm-existing")
+
+	// The package this run added for the first time still rolls back.
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		if p, ok := lock.Get("readd-perm-new"); ok {
+			t.Errorf("Expected readd-perm-new to be rolled back out of the lockfile, got %+v", p)
+		}
+	})
+	env.AssertSymlinkMissing(projectDir, "readd-perm-new")
+	env.AssertDatabaseNoLink("readd-perm-new", projectDir)
+	env.AssertPackageJSON(projectDir, "readd-perm-new", "~2.3.4")
+}
+
+// package.json can also fail to be read, before the lock is built at all. That
+// package has no specifier to record and never gets its reference written, so
+// it is rolled back for the same reason a failed write is: a lock entry with an
+// empty OriginalVersion would tell a later remove to delete a dependency the
+// user still has.
+func TestAddMultipleRollsBackPackagesWhenPackageJSONReadFails(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	env := setupTest(t)
+	env.simplePkg("unreadable-multi-a")
+	env.simplePkg("unreadable-multi-b")
+
+	projectDir := env.CreateTestPackage("unreadable-multi-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":    "unreadable-multi-project",
+		"version": "1.0.0",
+		"dependencies": map[string]interface{}{
+			"unreadable-multi-a": "^1.0.0",
+			"unreadable-multi-b": "~2.3.4",
+		},
+	})
+
+	// Mode 0000 fails the read rather than the write, so the batch never
+	// learns any specifier. os.Stat still succeeds, so add gets far enough to
+	// link the packages first.
+	pkgJSONPath := filepath.Join(projectDir, "package.json")
+	if err := os.Chmod(pkgJSONPath, 0000); err != nil {
+		t.Fatalf("Failed to chmod package.json: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(pkgJSONPath, 0644) })
+
+	env.chdir(projectDir)
+	specs := []string{"unreadable-multi-a", "unreadable-multi-b"}
+	captureStdout(t, func() {
+		if err := cli.RunAddMultiple(specs, false, false, false, false); err == nil {
+			t.Error("Expected an error when package.json cannot be read, got nil")
 		}
 	})
 
 	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
-		for name, want := range map[string]string{
-			"failing-multi-a": "^1.0.0",
-			"failing-multi-b": "~2.3.4",
-		} {
-			p, ok := lock.Get(name)
-			if !ok {
-				t.Fatalf("Package %s not in lockfile", name)
-			}
-			if p.OriginalVersion != want {
-				t.Errorf("Expected original version %q for %s, got %q", want, name, p.OriginalVersion)
+		for _, name := range specs {
+			if p, ok := lock.Get(name); ok {
+				t.Errorf("Expected %s to be rolled back out of the lockfile, got %+v", name, p)
 			}
 		}
 	})
+
+	for _, name := range specs {
+		env.AssertSymlinkMissing(projectDir, name)
+		env.AssertDatabaseNoLink(name, projectDir)
+	}
+
+	// Restore access before reading: package.json is untouched.
+	if err := os.Chmod(pkgJSONPath, 0644); err != nil {
+		t.Fatalf("Failed to restore package.json mode: %v", err)
+	}
+	env.AssertPackageJSON(projectDir, "unreadable-multi-a", "^1.0.0")
+	env.AssertPackageJSON(projectDir, "unreadable-multi-b", "~2.3.4")
 }

--- a/tests/original_version_test.go
+++ b/tests/original_version_test.go
@@ -170,3 +170,40 @@ func TestAddNewPackageWithoutOriginal(t *testing.T) {
 	}
 	env.AssertPackageJSONMissing(projectDir, "new-pkg")
 }
+
+// TestAddMultipleRecordsOriginalVersions pins the invariant the multi-package
+// path exists to protect: every package added in one batch keeps its own
+// specifier, read out of the shared package.json before any of the rewrites
+// overwrite it. An entry may never end up with an empty OriginalVersion while
+// package.json held a real specifier for it.
+func TestAddMultipleRecordsOriginalVersions(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("multi-orig-a")
+	env.simplePkg("multi-orig-b")
+
+	projectDir := env.CreateTestPackage("multi-orig-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":    "multi-orig-project",
+		"version": "1.0.0",
+		"dependencies": map[string]interface{}{
+			"multi-orig-a": "^1.0.0",
+			"multi-orig-b": "^2.0.0",
+		},
+	})
+
+	env.chdir(projectDir)
+	if err := cli.RunAddMultiple([]string{"multi-orig-a", "multi-orig-b"}, false, false, false, false); err != nil {
+		t.Fatalf("Failed to add multiple packages: %v", err)
+	}
+
+	for name, want := range map[string]string{
+		"multi-orig-a": "^1.0.0",
+		"multi-orig-b": "^2.0.0",
+	} {
+		env.AssertSymlinkExists(projectDir, name)
+		env.AssertPackageJSON(projectDir, name, "file:.lnpm/"+name)
+		env.AssertDatabaseLink(name, projectDir)
+		assertOriginalVersion(t, env, projectDir, name, want)
+	}
+}


### PR DESCRIPTION
Closes #156.

## The bug

When a package's `package.json` handling failed during multi-add, the loop printed a warning and continued — but the package was still written to the lock with an empty `OriginalVersion`, still recorded in the database, and still left symlinked. Meanwhile `package.json` was never rewritten, so it still held the user's real specifier.

A later `lnpm remove` reads an empty `OriginalVersion` as "delete the dependency entirely" and destroys the `^1.2.3` the user actually depends on.

## Read this first: the brief was partly stale

#155 landed one commit earlier and reordered the exact loops this issue describes. `RunAddMultiple` now runs read → `lock.Add` → **`lock.Save`** → write `package.json` → database, so there are two failure points with the lock save *between* them. The issue's step 3 ("skip those packages in the lock/database loop") assumed the lock was saved after the writes, which is no longer true — a write failure is discovered with the lock already durable.

## The fix

A package whose `package.json` read or write fails is rolled back: skipped in the lock, skipped in the database, unlinked, and recorded in `errors` so the command exits non-zero.

**How far the rollback goes depends on whether this invocation created the package.**

- **First-time add** — removed entirely. `package.json` still holds the user's own specifier because the rewrite never landed, so nothing about the package should survive. Leaving a lock entry would be worse than useless: it would carry an empty `OriginalVersion` and a later `remove` would destroy the specifier `package.json` still holds. That is the bug.
- **Re-add** — left completely alone. `package.json` already holds the lnpm reference, so the user's real specifier survives nowhere but the lock, and `Unlink` removes the `.lnpm/<pkg>` copy `package.json` points at. Undoing it would recreate the very data loss the rollback exists to prevent. Only the write and the DB link are skipped, and the error is still recorded.

This does not contradict #155: its acceptance criterion concerns a failure of a step *following* the rewrite (a database error), where the lock entry is the only surviving record. Here the rewrite itself fails and nothing was lost, so there is nothing to rescue.

## Two things review changed

**The re-add originally restored the prior lock entry.** That was strictly worse than doing nothing. `readPackageJSONDeps` ignores lnpm references, so the re-add fallback had already carried `OriginalVersion` into the fresh entry — restoring the old one only reverted `Version`/`Hash` to values describing content `linker.Link` had already replaced. Now it leaves the entry alone.

**Inverting #155's guard test left the multi-path ordering pinned by nothing.** Review moved `lock.Save` below the write loop — the reordering the `ORDERING CONSTRAINT` comment forbids — and the entire suite still passed. `TestAddMultipleSavesLockBeforeRewritingPackageJSON` now pins it from the outside: with `lnpm.lock` unwritable the save fails *before* the rewrite loop, so `package.json` must still hold the user's specifiers. Verified to fail under the deliberate reordering with `found dep=file:.lnpm/lock-order-a` — exactly the data loss.

## Tests

Failing pre-fix (verified by stashing `add.go`, not by argument):

- `TestAddMultipleRollsBackPackagesWhenPackageJSONWriteFails` — pre-fix returned nil, kept both lock entries, symlinks and DB links.
- `TestAddMultipleRollsBackPackagesWhenPackageJSONReadFails` — reproduces the issue's exact bug: an entry with empty `OriginalVersion` while `package.json` still holds `^1.0.0`.
- `TestAddMultipleKeepsPriorStateWhenReAddPackageJSONWriteFails` — pins the re-add carve-out.
- `TestAddMultipleSavesLockBeforeRewritingPackageJSON` — pins the #155 ordering.

`TestAddMultipleRecordsOriginalVersions` and `TestAddMultipleLeavesSucceedingPackageIntactWhenSiblingFails` pass pre-fix and are reported as regression guards, not bug-pinning coverage.

**One honest limitation:** both packages share a single `package.json`, and the only per-package inputs to the read/write are the name and `dev` — so no lever makes one package's `package.json` handling fail while another's succeeds. Acceptance criterion 4 is covered by the closest honest substitute: the sibling fails at store resolution and reaches the same end state, while the survivor is asserted fully linked and recorded. No production injection point was added for tests.

`TestAddMultipleRecordsOriginalVersionsWhenPackageJSONWriteFails` (added by #155) was renamed and its expectations inverted rather than deleted — it asserted the pre-#156 behaviour that this issue calls a bug.

## Out of scope

`runAddSingle` is untouched (#155). No migration for empty-`OriginalVersion` entries already in existing lock files.

## Verification

`go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `gofmt -l .` clean, full `( umask 022; go test ./... )` green, cross-compiles clean for `windows/amd64` and `darwin/arm64`. `-race` is covered by CI only.