### PR TITLE
fix(remove): keep the lock entry when remove fails to restore package.json

### DIFF
--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -75,15 +75,23 @@ func RunRemove(packageName string, all bool, yes bool) error {
 			continue
 		}
 
-		// Restore original package.json dependency
+		// Restore original package.json dependency. A failure here aborts this
+		// package: the lock entry's OriginalVersion is the only surviving copy
+		// of the user's specifier, so dropping the entry after a failed write
+		// would leave package.json referencing an unlinked .lnpm path with
+		// nothing left to restore it from.
 		if lockEntry.OriginalVersion != "" {
 			if err := restorePackageJSON(cwd, name, lockEntry.OriginalVersion); err != nil {
-				fmt.Printf("  %s Failed to restore package.json: %v\n", iconWarn(), err)
+				fmt.Printf("  %s Failed to restore package.json: %v\n", iconFail(), err)
+				failed++
+				continue
 			}
 		} else {
 			// Remove the dependency entirely
 			if err := removeFromPackageJSON(cwd, name); err != nil {
-				fmt.Printf("  %s Failed to update package.json: %v\n", iconWarn(), err)
+				fmt.Printf("  %s Failed to update package.json: %v\n", iconFail(), err)
+				failed++
+				continue
 			}
 		}
 

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -75,11 +75,10 @@ func RunRemove(packageName string, all bool, yes bool) error {
 			continue
 		}
 
-		// Restore original package.json dependency. A failure here aborts this
-		// package: the lock entry's OriginalVersion is the only surviving copy
-		// of the user's specifier, so dropping the entry after a failed write
-		// would leave package.json referencing an unlinked .lnpm path with
-		// nothing left to restore it from.
+		// Update package.json for this removal. A failure aborts the package: the
+		// lock entry is the only record that it was ever linked (and, when set,
+		// the only copy of the user's specifier), so dropping it would strand a
+		// file:.lnpm/<pkg> reference with nothing left to drive a retry.
 		if lockEntry.OriginalVersion != "" {
 			if err := restorePackageJSON(cwd, name, lockEntry.OriginalVersion); err != nil {
 				fmt.Printf("  %s Failed to restore package.json: %v\n", iconFail(), err)

--- a/tests/remove_test.go
+++ b/tests/remove_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
@@ -152,6 +153,77 @@ func TestRemoveAllNoPackages(t *testing.T) {
 		t.Fatalf("Remove --all with no packages failed: %v", err)
 	}
 	env.AssertLockfileExists(projectDir, false)
+}
+
+// TestRemoveKeepsLockEntryWhenRestoreFails tests that a failed package.json
+// restore aborts the removal instead of silently dropping the lock entry. The
+// entry's OriginalVersion is the only surviving copy of the user's specifier,
+// so losing it would leave package.json pointing at an unlinked .lnpm path with
+// nothing left to restore from.
+func TestRemoveKeepsLockEntryWhenRestoreFails(t *testing.T) {
+	env := setupTest(t)
+
+	projectDir := env.CreateTestPackage("test-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":         "test-project",
+		"version":      "1.0.0",
+		"dependencies": map[string]interface{}{"restore-fail-pkg": "^1.0.0"},
+	})
+
+	env.simplePkg("restore-fail-pkg")
+	env.addPkg(projectDir, "restore-fail-pkg", false, false)
+	env.AssertPackageJSON(projectDir, "restore-fail-pkg", "file:.lnpm/restore-fail-pkg")
+
+	// Unparseable package.json: restorePackageJSON fails at json.Unmarshal.
+	env.writeFile(filepath.Join(projectDir, "package.json"), "{not valid json")
+
+	if err := cli.RunRemove("restore-fail-pkg", false, false); err == nil {
+		t.Error("Expected error when package.json restore fails, got nil")
+	}
+
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		pkg, ok := lock.Get("restore-fail-pkg")
+		if !ok {
+			t.Fatal("Expected restore-fail-pkg to remain in lockfile after failed restore")
+		}
+		if pkg.OriginalVersion != "^1.0.0" {
+			t.Errorf("Expected OriginalVersion ^1.0.0 to survive, got %q", pkg.OriginalVersion)
+		}
+	})
+	env.AssertDatabaseLink("restore-fail-pkg", projectDir)
+}
+
+// TestRemoveKeepsLockEntryWhenPackageJSONRemovalFails covers the other failure
+// branch: a package added when package.json had no prior entry has an empty
+// OriginalVersion, so remove takes the "delete the dependency" path. A failure
+// there must abort the removal too, keeping the lock entry and database link.
+func TestRemoveKeepsLockEntryWhenPackageJSONRemovalFails(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("remove-fail-pkg")
+	projectDir := env.newProject("test-project")
+	env.addPkg(projectDir, "remove-fail-pkg", false, false)
+	env.AssertPackageJSON(projectDir, "remove-fail-pkg", "file:.lnpm/remove-fail-pkg")
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		pkg, _ := lock.Get("remove-fail-pkg")
+		if pkg.OriginalVersion != "" {
+			t.Fatalf("Test needs an empty OriginalVersion to reach the removal branch, got %q", pkg.OriginalVersion)
+		}
+	})
+
+	// Unparseable package.json: removeFromPackageJSON fails at json.Unmarshal.
+	env.writeFile(filepath.Join(projectDir, "package.json"), "{not valid json")
+
+	if err := cli.RunRemove("remove-fail-pkg", false, false); err == nil {
+		t.Error("Expected error when package.json update fails, got nil")
+	}
+
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		if !lock.Has("remove-fail-pkg") {
+			t.Error("Expected remove-fail-pkg to remain in lockfile after failed package.json update")
+		}
+	})
+	env.AssertDatabaseLink("remove-fail-pkg", projectDir)
 }
 
 // TestRemoveKeepsOthers tests that removing one package keeps the rest linked and

--- a/tests/remove_test.go
+++ b/tests/remove_test.go
@@ -156,10 +156,8 @@ func TestRemoveAllNoPackages(t *testing.T) {
 }
 
 // TestRemoveKeepsLockEntryWhenRestoreFails tests that a failed package.json
-// restore aborts the removal instead of silently dropping the lock entry. The
-// entry's OriginalVersion is the only surviving copy of the user's specifier,
-// so losing it would leave package.json pointing at an unlinked .lnpm path with
-// nothing left to restore from.
+// restore aborts the removal, keeping the lock entry (with its OriginalVersion)
+// and the database link.
 func TestRemoveKeepsLockEntryWhenRestoreFails(t *testing.T) {
 	env := setupTest(t)
 
@@ -178,7 +176,7 @@ func TestRemoveKeepsLockEntryWhenRestoreFails(t *testing.T) {
 	env.writeFile(filepath.Join(projectDir, "package.json"), "{not valid json")
 
 	if err := cli.RunRemove("restore-fail-pkg", false, false); err == nil {
-		t.Error("Expected error when package.json restore fails, got nil")
+		t.Fatal("Expected error when package.json restore fails, got nil")
 	}
 
 	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
@@ -205,7 +203,10 @@ func TestRemoveKeepsLockEntryWhenPackageJSONRemovalFails(t *testing.T) {
 	env.addPkg(projectDir, "remove-fail-pkg", false, false)
 	env.AssertPackageJSON(projectDir, "remove-fail-pkg", "file:.lnpm/remove-fail-pkg")
 	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
-		pkg, _ := lock.Get("remove-fail-pkg")
+		pkg, ok := lock.Get("remove-fail-pkg")
+		if !ok {
+			t.Fatal("Expected remove-fail-pkg in lockfile after add")
+		}
 		if pkg.OriginalVersion != "" {
 			t.Fatalf("Test needs an empty OriginalVersion to reach the removal branch, got %q", pkg.OriginalVersion)
 		}
@@ -215,7 +216,7 @@ func TestRemoveKeepsLockEntryWhenPackageJSONRemovalFails(t *testing.T) {
 	env.writeFile(filepath.Join(projectDir, "package.json"), "{not valid json")
 
 	if err := cli.RunRemove("remove-fail-pkg", false, false); err == nil {
-		t.Error("Expected error when package.json update fails, got nil")
+		t.Fatal("Expected error when package.json update fails, got nil")
 	}
 
 	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {


### PR DESCRIPTION
Closes #157.

## The bug

In `RunRemove`'s per-package loop, a failed `restorePackageJSON` or `removeFromPackageJSON` only printed a warning. Execution then fell through to `lock.Remove(name)`, which dropped the entry unconditionally, and the lock was saved without it.

The entry's `OriginalVersion` is the only place the user's real specifier is stored. So a `package.json` that had become unparseable between `add` and `remove` produced this end state: `linker.Unlink` had already deleted `.lnpm/<pkg>`, `package.json` still said `"pkg": "file:.lnpm/pkg"` pointing at that now-missing directory, and the lock no longer recorded that `pkg`'s original version was `^1.2.3`. Nothing in lnpm could reconstruct it.

## The fix

Both `package.json` failure branches now print with `iconFail()`, increment `failed`, and `continue` — mirroring the `Unlink` failure branch directly above them. The `continue` skips `lock.Remove`, the database `DeleteLink`, and the `Removed <pkg>` success line, so the lock entry and the DB link survive and `RunRemove` returns non-zero via the existing `failed > 0` check.

A retry after the user repairs `package.json` genuinely recovers: `link.Unlink` is idempotent — `os.RemoveAll` on the already-deleted `.lnpm/<pkg>` returns nil, the `node_modules` removal tolerates `IsNotExist`, and the empty-`.lnpm` cleanup is error-tolerant — so the second `remove` reaches `restorePackageJSON` with the entry intact.

## Tests

Both new tests fail against the pre-fix code, verified by restoring the parent's `remove.go` rather than by argument:

- `TestRemoveKeepsLockEntryWhenRestoreFails` — the `OriginalVersion != ""` branch. Pre-fix: `Expected error when package.json restore fails, got nil`.
- `TestRemoveKeepsLockEntryWhenPackageJSONRemovalFails` — the `else` branch, reached via a package added to a project whose `package.json` never listed it, which yields an empty `OriginalVersion`. The test asserts that precondition explicitly so it cannot silently drift into testing the other branch.

Both branches are named in the acceptance criteria, so both are covered.

## Known limitation, reported not fixed

`restorePackageJSON` only rewrites an **existing** key. If the user repairs a broken `package.json` by deleting the dependency line rather than fixing the syntax, a retried `remove` returns nil without restoring the specifier, and it is silently lost. The other natural repair — fixing the JSON syntax with the line intact — works. Whether restoring a dependency the user has just deleted is even desirable is a genuine question, so this is flagged rather than filed.

Also note that between the failure and the retry, the lock entry and DB link describe a package that is already unlinked on disk. That is a deliberate consequence of acceptance criterion 4 (the DB link must survive), not an oversight.

## Out of scope

`add`'s write ordering (#155, #156), the lock-file format, and `retreat` (#153) are untouched. No existing test encoded the old exit-zero behaviour, and every pre-existing `RunRemove` caller still gets `nil`.

## Verification

`go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `gofmt -l .` clean, full `( umask 022; go test ./... )` green, cross-compiles clean for `windows/amd64` and `darwin/arm64`. `-race` is covered by CI only.