### PR TITLE
Make publish --push fail when every linked-project push fails

### DIFF
--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -298,6 +298,12 @@ func pushToLinkedProjects(database *db.DB, pkg *db.Package, s *store.Store) erro
 		}
 	}
 
+	fmt.Printf("\nPushed to %d/%d projects\n", successCount, len(projects))
+
+	if successCount < len(projects) {
+		return fmt.Errorf("push failed for %d of %d project(s)", len(projects)-successCount, len(projects))
+	}
+
 	return nil
 }
 

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -252,7 +252,9 @@ func finishPublish(pkgPath string, pkgJSON *pack.PackageJSON, files []*pack.File
 	return nil
 }
 
-// pushToLinkedProjects pushes updates to all projects linked to this package
+// pushToLinkedProjects pushes updates to all projects linked to this package.
+// It returns an error if any linked project failed to update, matching push's
+// own pushToAllProjects.
 func pushToLinkedProjects(database *db.DB, pkg *db.Package, s *store.Store) error {
 	projects, err := database.GetProjectsForPackage(pkg.ID)
 	if err != nil {

--- a/tests/publish_test.go
+++ b/tests/publish_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
@@ -112,6 +113,42 @@ func TestPublishWithPush(t *testing.T) {
 	}
 
 	env.AssertLinkedFileContent(projectDir, "push-publish-pkg", "index.js", "module.exports = 'v2';")
+}
+
+// TestPublishWithPushReportsFailedProjects tests that publish --push returns an
+// error when a linked project cannot be updated, while still updating the
+// projects that are healthy.
+func TestPublishWithPushReportsFailedProjects(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("push-fail-pkg")
+
+	projectA := env.newProject("project-a")
+	env.addPkg(projectA, "push-fail-pkg", false, false)
+	projectB := env.newProject("project-b")
+	env.addPkg(projectB, "push-fail-pkg", false, false)
+
+	// Break project-b by replacing its .lnpm directory with a regular file, so
+	// creating .lnpm/push-fail-pkg inside it fails during the push.
+	lnpmPath := filepath.Join(projectB, ".lnpm")
+	if err := os.RemoveAll(lnpmPath); err != nil {
+		t.Fatalf("Failed to remove .lnpm: %v", err)
+	}
+	env.writeFile(lnpmPath, "not a directory")
+
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'v2';")
+
+	err := cli.RunPublish(true, false, true, true)
+	if err == nil {
+		t.Fatal("Expected publish --push to fail when a linked project fails")
+	}
+	if !strings.Contains(err.Error(), "push failed for 1 of 2") {
+		t.Errorf("Expected error to report 1 of 2 projects failed, got: %v", err)
+	}
+
+	// The healthy project still received the update.
+	env.AssertLinkedFileContent(projectA, "push-fail-pkg", "index.js", "module.exports = 'v2';")
 }
 
 // TestPublishConcurrentSamePackage tests concurrent publishes of same package.


### PR DESCRIPTION
`lnpm publish --push` reported success (exit 0) even when linked-project pushes
failed. `pushToLinkedProjects` counted successes but never checked the count,
returning `nil` unconditionally — so `lnpm publish --push && deploy.sh` proceeded
with consumers left stale.

## Change

`pushToLinkedProjects` now ends the way `push.go`'s `pushToAllProjects` already
did: a `Pushed to %d/%d projects` summary, then an error when
`successCount < len(projects)`. The wording matches `push.go` verbatim, so the
two commands' exit-code behavior is now identical.

`RunPublish` is unchanged — it already propagated the error. The
`len(projects) == 0` early return is untouched, so a publish with no linked
projects still exits zero.

## Test

`TestPublishWithPushReportsFailedProjects` links a package into two projects,
replaces one project's `.lnpm` directory with a regular file so `linker.Link`
fails with ENOTDIR for that project only, then republishes with `--push`. It
asserts the command reports `push failed for 1 of 2` and that the healthy
project still received the update.

Verified to fail without the production change (reverting `publish.go` alone
fails the test for the right reason — one genuine push failure, one genuine
success, `nil` returned).

## Behavior change worth noting

A partial push failure now skips the `post_publish` hook, because the push runs
inside `finishPublish` and the hook runs after it returns. This matches how
every other `finishPublish` failure (store, database) already behaves, and
`lnpm push` has no `post_publish` hook to diverge from. Restructuring
`RunPublish` to run the hook anyway was out of scope.

Closes #158