### PR TITLE
Make doctor honor the configured store_path when checking the store

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/pedrosousa13/lnpm/internal/config"
 	"github.com/pedrosousa13/lnpm/internal/db"
 )
 
@@ -17,9 +18,13 @@ func RunDoctor() error {
 	warnings := 0
 
 	// Check 1: Store directory exists and is writable
-	storePath := getStorePath()
 	fmt.Print("Checking store directory... ")
-	if info, err := os.Stat(storePath); err != nil {
+	storePath, err := config.GetStorePath()
+	if err != nil {
+		fmt.Println("✗ ERROR")
+		fmt.Printf("  Failed to resolve store path: %v\n", err)
+		issues++
+	} else if info, err := os.Stat(storePath); err != nil {
 		fmt.Println("✗ NOT FOUND")
 		fmt.Printf("  Store directory does not exist: %s\n", storePath)
 		fmt.Println("  Fix: Run 'lnpm publish' to create it")
@@ -128,14 +133,4 @@ func RunDoctor() error {
 	}
 
 	return nil
-}
-
-// getStorePath returns the lnpm store path
-func getStorePath() string {
-	if storePath := os.Getenv("LNPM_STORE"); storePath != "" {
-		return storePath
-	}
-
-	homeDir, _ := os.UserHomeDir()
-	return filepath.Join(homeDir, ".lnpm")
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -33,11 +33,13 @@ func TestRunDoctorChecksConfiguredStorePath(t *testing.T) {
 
 // TestRunDoctorReportsConfiguredStoreHealthy is the acceptance criterion read
 // the other way round: with the configured store present, doctor must not
-// report it missing.
+// report it missing. newDoctorStoreConfig redirects the home directory, so the
+// ~/.lnpm default is absent and a doctor that ignored store_path would report
+// it missing here rather than passing by luck.
 func TestRunDoctorReportsConfiguredStoreHealthy(t *testing.T) {
 	want := filepath.Join(newDoctorStoreConfig(t), "mystore")
 	if err := os.MkdirAll(want, 0755); err != nil {
-		t.Fatal(err)
+		t.Fatalf("Failed to create configured store %q: %v", want, err)
 	}
 
 	out := captureDoctorStdout(t)
@@ -70,6 +72,12 @@ func TestRunDoctorPrefersEnvStoreOverConfig(t *testing.T) {
 // temp dir. The configured directory itself is not created, so the caller
 // decides whether doctor should find it.
 //
+// The home directory is redirected into the same temp dir, so the ~/.lnpm
+// default resolves somewhere that does not exist. Without that, a machine
+// which happens to have a real ~/.lnpm reports it healthy, and a test asserting
+// the configured store was found passes even when doctor ignored the config
+// entirely.
+//
 // config caches the parsed file for the process, so the cache is dropped both
 // before the test (another test in this package may have populated it already)
 // and after it (so this test's config does not leak into the next one).
@@ -80,11 +88,13 @@ func newDoctorStoreConfig(t *testing.T) string {
 	cfgPath := filepath.Join(dir, "config.yaml")
 	storePath := filepath.Join(dir, "mystore")
 	if err := os.WriteFile(cfgPath, []byte("store_path: "+storePath+"\n"), 0644); err != nil {
-		t.Fatal(err)
+		t.Fatalf("Failed to write config file: %v", err)
 	}
 
 	t.Setenv("LNPM_CONFIG", cfgPath)
-	t.Setenv("LNPM_STORE", "") // empty is treated as unset, so config wins
+	t.Setenv("LNPM_STORE", "")   // empty is treated as unset, so config wins
+	t.Setenv("HOME", dir)        // os.UserHomeDir on unix
+	t.Setenv("USERPROFILE", dir) // os.UserHomeDir on windows
 
 	config.ResetForTesting()
 	t.Cleanup(config.ResetForTesting)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/config"
+	"github.com/pedrosousa13/lnpm/internal/db"
+)
+
+// TestRunDoctorChecksConfiguredStorePath pins that doctor inspects the store
+// resolved from store_path, not the ~/.lnpm default. The configured directory
+// is deliberately absent so doctor names it in its "does not exist" line: that
+// makes the assertion key on the configured path regardless of whether ~/.lnpm
+// happens to exist on the machine running the test.
+func TestRunDoctorChecksConfiguredStorePath(t *testing.T) {
+	want := filepath.Join(newDoctorStoreConfig(t), "mystore")
+
+	out := captureDoctorStdout(t)
+
+	if !strings.Contains(out, "Store directory does not exist: "+want) {
+		t.Errorf("RunDoctor did not check the configured store %q, output was:\n%s", want, out)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		if def := filepath.Join(home, ".lnpm"); strings.Contains(out, def) {
+			t.Errorf("RunDoctor named the default store %q instead of the configured one, output was:\n%s", def, out)
+		}
+	}
+}
+
+// TestRunDoctorReportsConfiguredStoreHealthy is the acceptance criterion read
+// the other way round: with the configured store present, doctor must not
+// report it missing.
+func TestRunDoctorReportsConfiguredStoreHealthy(t *testing.T) {
+	want := filepath.Join(newDoctorStoreConfig(t), "mystore")
+	if err := os.MkdirAll(want, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureDoctorStdout(t)
+
+	if strings.Contains(out, "NOT FOUND") {
+		t.Errorf("RunDoctor reported the existing configured store %q as missing, output was:\n%s", want, out)
+	}
+}
+
+// TestRunDoctorPrefersEnvStoreOverConfig pins that LNPM_STORE still wins over
+// store_path, so doctor keeps the resolution order the rest of lnpm uses.
+func TestRunDoctorPrefersEnvStoreOverConfig(t *testing.T) {
+	dir := newDoctorStoreConfig(t)
+	fromConfig := filepath.Join(dir, "mystore")
+	fromEnv := filepath.Join(dir, "from-env")
+	t.Setenv("LNPM_STORE", fromEnv)
+
+	out := captureDoctorStdout(t)
+
+	if !strings.Contains(out, "Store directory does not exist: "+fromEnv) {
+		t.Errorf("RunDoctor did not check the LNPM_STORE path %q, output was:\n%s", fromEnv, out)
+	}
+	if strings.Contains(out, fromConfig) {
+		t.Errorf("RunDoctor checked the configured store %q even though LNPM_STORE was set, output was:\n%s", fromConfig, out)
+	}
+}
+
+// newDoctorStoreConfig writes a config file setting store_path to a "mystore"
+// directory inside a fresh temp dir, points LNPM_CONFIG at it and returns the
+// temp dir. The configured directory itself is not created, so the caller
+// decides whether doctor should find it.
+//
+// config caches the parsed file for the process, so the cache is dropped both
+// before the test (another test in this package may have populated it already)
+// and after it (so this test's config does not leak into the next one).
+func newDoctorStoreConfig(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	storePath := filepath.Join(dir, "mystore")
+	if err := os.WriteFile(cfgPath, []byte("store_path: "+storePath+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("LNPM_CONFIG", cfgPath)
+	t.Setenv("LNPM_STORE", "") // empty is treated as unset, so config wins
+
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+
+	return dir
+}
+
+// captureDoctorStdout runs RunDoctor with os.Stdout redirected to a pipe and
+// returns what it printed. RunDoctor reports every check on stdout rather than
+// through its return value, so the findings are only readable this way.
+//
+// The reader goroutine starts before RunDoctor does, so it can write more than
+// the pipe buffer without deadlocking, and the teardown is deferred so
+// os.Stdout is restored however RunDoctor exits.
+//
+// RunDoctor opens the database, which is cached for the process and would keep
+// a file handle inside the test's temp dir, so it is released on the way out.
+func captureDoctorStdout(t *testing.T) (out string) {
+	t.Helper()
+
+	db.ResetForTesting()
+	t.Cleanup(db.ResetForTesting)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Failed to create pipe: %v", err)
+	}
+
+	done := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(r)
+		done <- string(data)
+	}()
+
+	orig := os.Stdout
+	os.Stdout = w
+
+	defer func() {
+		os.Stdout = orig
+		_ = w.Close() // unblocks the reader goroutine
+		out = <-done
+		_ = r.Close()
+	}()
+
+	if err := RunDoctor(); err != nil {
+		t.Errorf("RunDoctor() error = %v", err)
+	}
+	return
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,15 @@ func SaveConfig(cfg *Config) error {
 	return os.WriteFile(configPath, data, 0644)
 }
 
+// ResetForTesting clears the memoized config so a test can point LNPM_CONFIG at
+// a different file and have it take effect.
+// This should only be used in tests.
+func ResetForTesting() {
+	globalConfig = nil
+	globalConfigErr = nil
+	globalConfigOnce = sync.Once{}
+}
+
 // getConfigPath returns the path to the config file
 func getConfigPath() string {
 	if configPath := os.Getenv("LNPM_CONFIG"); configPath != "" {


### PR DESCRIPTION
`internal/cli/doctor.go` carried its own `getStorePath()` that read only
`LNPM_STORE` and otherwise fell back to `~/.lnpm`, ignoring the `store_path`
config key that `config.GetStorePath()` honors. So after `lnpm config store_path
/data/lnpm`, `doctor` inspected `~/.lnpm` — reporting a missing store while the
real one was healthy, or reporting "OK" for a directory the rest of the tool
never touches.

## Change

Deleted the local `getStorePath()` (it had exactly one caller) and switched
`RunDoctor` to `config.GetStorePath()`, handling the error in the style the
other checks already use. Resolution order is now the same one publish, add and
the database layer use: `LNPM_STORE` → `store_path` → `~/.lnpm`.

`internal/config` gains `ResetForTesting()`, mirroring the existing
`db.ResetForTesting()`. This is not optional: `LoadConfig` memoizes via
`sync.Once`, and an earlier-sorting test in package `cli` reaches
`config.Get()` and bakes in an empty config, so without the reset no
config-driven test in that package can work. The hook only drops the cache — it
changes no resolution order.

## Tests

`internal/cli/doctor_test.go`:

- `TestRunDoctorChecksConfiguredStorePath` — configured store deliberately
  absent, so doctor must name it in its "does not exist" line.
- `TestRunDoctorReportsConfiguredStoreHealthy` — configured store present, must
  not be reported missing.
- `TestRunDoctorPrefersEnvStoreOverConfig` — `LNPM_STORE` still wins.

The shared helper redirects `HOME`/`USERPROFILE` into the temp dir so the
`~/.lnpm` default cannot exist. Without that, the healthy-store test passed on
any machine that happens to have a real `~/.lnpm` even when doctor ignored the
config entirely. Both store-path tests were confirmed to fail against the
unmodified `doctor.go` for the right reason (doctor naming `<tmp>/.lnpm` instead
of `<tmp>/mystore`).

The tests live in `internal/cli/` rather than `tests/` because `tests`'s
`setupTest` helper sets `LNPM_STORE`, which is precisely the variable that must
be unset for a `store_path` test to mean anything.

Closes #161