### PR TITLE
Run all applicable publish lifecycle scripts, not just the first

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,7 @@ lnpm automatically runs your package's build (prepare) scripts before publishing
 
 ### Prepare Scripts
 
-Before publishing or pushing, lnpm runs every one of these scripts that your
-`package.json` defines, in npm's publish order:
+Before publishing or pushing, lnpm runs every one of these scripts that your `package.json` defines, always in this order:
 
 1. `prepublishOnly` — Runs only on publish
 2. `prepare` — General build script

--- a/README.md
+++ b/README.md
@@ -222,11 +222,14 @@ lnpm automatically runs your package's build (prepare) scripts before publishing
 
 ### Prepare Scripts
 
-Before publishing or pushing, lnpm runs these scripts from your `package.json` (in order of precedence):
+Before publishing or pushing, lnpm runs every one of these scripts that your
+`package.json` defines, in npm's publish order:
 
-1. `prepare` — General build script
-2. `prepublishOnly` — Runs only on publish
+1. `prepublishOnly` — Runs only on publish
+2. `prepare` — General build script
 3. `prepack` — Runs before packing files
+
+If a script fails, the ones after it do not run and the command stops.
 
 **Example package.json:**
 ```json

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -14,7 +14,7 @@ import (
 
 // RunPrepare runs prepare scripts before publishing
 // Executes every prepublishOnly, prepare and prepack script present in
-// package.json, in that order (npm's publish order)
+// package.json, always in that order, and stops at the first one that fails
 func RunPrepare(pkgPath string, skipHooks bool) error {
 	// Check if hooks should be skipped
 	cfg := config.Get()
@@ -37,7 +37,7 @@ func RunPrepare(pkgPath string, skipHooks bool) error {
 		return fmt.Errorf("failed to parse package.json: %w", err)
 	}
 
-	// Run every applicable script, in npm's publish order
+	// Run every applicable script, in lnpm's publish order
 	scripts := []string{"prepublishOnly", "prepare", "prepack"}
 	ran := false
 	for _, scriptName := range scripts {

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -13,7 +13,8 @@ import (
 )
 
 // RunPrepare runs prepare scripts before publishing
-// Executes prepare, prepublishOnly, or prepack scripts from package.json
+// Executes every prepublishOnly, prepare and prepack script present in
+// package.json, in that order (npm's publish order)
 func RunPrepare(pkgPath string, skipHooks bool) error {
 	// Check if hooks should be skipped
 	cfg := config.Get()
@@ -36,8 +37,9 @@ func RunPrepare(pkgPath string, skipHooks bool) error {
 		return fmt.Errorf("failed to parse package.json: %w", err)
 	}
 
-	// Try prepare scripts in order of precedence
-	scripts := []string{"prepare", "prepublishOnly", "prepack"}
+	// Run every applicable script, in npm's publish order
+	scripts := []string{"prepublishOnly", "prepare", "prepack"}
+	ran := false
 	for _, scriptName := range scripts {
 		if _, exists := pkgJSON.Scripts[scriptName]; exists {
 			fmt.Printf("Running %s script...\n", scriptName)
@@ -48,12 +50,13 @@ func RunPrepare(pkgPath string, skipHooks bool) error {
 				return fmt.Errorf("%s script failed: %w", scriptName, err)
 			}
 
-			// Only run the first matching script
-			return nil
+			ran = true
 		}
 	}
 
-	debug.Log("hooks: no prepare scripts found")
+	if !ran {
+		debug.Log("hooks: no prepare scripts found")
+	}
 	return nil
 }
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -5,8 +5,29 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 )
+
+// orderLogName is the file each test lifecycle script appends its own name to.
+const orderLogName = "order.log"
+
+// readOrderLog returns the script names recorded in dir's order log, in the
+// order they ran. A missing log means no script ran.
+func readOrderLog(t *testing.T, dir string) []string {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(dir, orderLogName))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("failed to read order log: %v", err)
+	}
+
+	return strings.Fields(string(data))
+}
 
 func TestRunPrepare(t *testing.T) {
 	// RunPrepare shells out to `npm run <script>` for any matched script.
@@ -16,53 +37,62 @@ func TestRunPrepare(t *testing.T) {
 		t.Skip("npm not found in PATH; skipping prepare-hook tests")
 	}
 
-	// sentinelFor returns a script that writes a sentinel file named after the
-	// hook, so the test can prove which script actually ran.
-	sentinelFor := func(name string) string {
-		return "echo ran > " + name + ".sentinel"
+	// logFor returns a script that appends the hook name to one shared log file,
+	// so the test can prove which scripts ran and in which order.
+	logFor := func(name string) string {
+		return "echo " + name + " >> " + orderLogName
 	}
 
 	tests := []struct {
 		name      string
 		scripts   map[string]string
 		skipHooks bool
-		wantRun   string // which script should run (empty if none)
+		wantRun   []string // scripts that should run, in order (nil if none)
 		wantError bool
 	}{
 		{
 			name: "runs prepare script",
 			scripts: map[string]string{
-				"prepare": sentinelFor("prepare"),
+				"prepare": logFor("prepare"),
 			},
-			wantRun: "prepare",
+			wantRun: []string{"prepare"},
 		},
 		{
-			name: "runs prepare over prepublishOnly",
+			name: "runs prepublishOnly before prepare",
 			scripts: map[string]string{
-				"prepare":        sentinelFor("prepare"),
-				"prepublishOnly": sentinelFor("prepublishOnly"),
+				"prepare":        logFor("prepare"),
+				"prepublishOnly": logFor("prepublishOnly"),
 			},
-			wantRun: "prepare", // prepare runs first in precedence
+			wantRun: []string{"prepublishOnly", "prepare"},
+		},
+		{
+			name: "runs every publish script in npm order",
+			scripts: map[string]string{
+				"prepack":        logFor("prepack"),
+				"prepare":        logFor("prepare"),
+				"prepublishOnly": logFor("prepublishOnly"),
+			},
+			wantRun: []string{"prepublishOnly", "prepare", "prepack"},
 		},
 		{
 			name: "runs prepack if no prepare",
 			scripts: map[string]string{
-				"prepack": sentinelFor("prepack"),
+				"prepack": logFor("prepack"),
 			},
-			wantRun: "prepack",
+			wantRun: []string{"prepack"},
 		},
 		{
 			name: "skips when skipHooks=true",
 			scripts: map[string]string{
-				"prepare": sentinelFor("prepare"),
+				"prepare": logFor("prepare"),
 			},
 			skipHooks: true,
-			wantRun:   "",
+			wantRun:   nil,
 		},
 		{
 			name:      "no scripts is ok",
 			scripts:   map[string]string{},
-			wantRun:   "",
+			wantRun:   nil,
 			wantError: false,
 		},
 		{
@@ -71,6 +101,16 @@ func TestRunPrepare(t *testing.T) {
 				"prepare": "exit 1",
 			},
 			wantError: true,
+		},
+		{
+			name: "stops at the first failing script",
+			scripts: map[string]string{
+				"prepublishOnly": "echo prepublishOnly >> " + orderLogName + "; exit 1",
+				"prepare":        logFor("prepare"),
+				"prepack":        logFor("prepack"),
+			},
+			wantError: true,
+			wantRun:   []string{"prepublishOnly"},
 		},
 	}
 
@@ -101,22 +141,14 @@ func TestRunPrepare(t *testing.T) {
 				if err == nil {
 					t.Errorf("expected error but got nil")
 				}
-				return
-			}
-			if err != nil {
+			} else if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			// Verify the expected script ran (and only that one) via sentinel files.
-			ranScript := func(name string) bool {
-				_, statErr := os.Stat(filepath.Join(tmpDir, name+".sentinel"))
-				return statErr == nil
-			}
-			for _, name := range []string{"prepare", "prepublishOnly", "prepack"} {
-				want := name == tt.wantRun
-				if got := ranScript(name); got != want {
-					t.Errorf("script %q ran=%v, want %v", name, got, want)
-				}
+			// The shared log records exactly which scripts ran, in order, so
+			// comparing the whole sequence checks both membership and ordering.
+			if got := readOrderLog(t, tmpDir); !slices.Equal(got, tt.wantRun) {
+				t.Errorf("scripts ran %v, want %v", got, tt.wantRun)
 			}
 		})
 	}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -38,9 +38,17 @@ func TestRunPrepare(t *testing.T) {
 	}
 
 	// logFor returns a script that appends the hook name to one shared log file,
-	// so the test can prove which scripts ran and in which order.
+	// so the test can prove which scripts ran and in which order. It goes
+	// through node rather than shell built-ins because npm runs scripts under
+	// cmd.exe on Windows, where `>>` appends a trailing space and `;` is not a
+	// command separator. node is already required here, so this costs nothing.
 	logFor := func(name string) string {
-		return "echo " + name + " >> " + orderLogName
+		return `node -e "require('fs').appendFileSync('` + orderLogName + `','` + name + `\n')"`
+	}
+
+	// failAfterLog returns a script that logs its own name and then fails.
+	failAfterLog := func(name string) string {
+		return `node -e "require('fs').appendFileSync('` + orderLogName + `','` + name + `\n');process.exit(1)"`
 	}
 
 	tests := []struct {
@@ -58,6 +66,13 @@ func TestRunPrepare(t *testing.T) {
 			wantRun: []string{"prepare"},
 		},
 		{
+			name: "runs prepublishOnly if it is the only script",
+			scripts: map[string]string{
+				"prepublishOnly": logFor("prepublishOnly"),
+			},
+			wantRun: []string{"prepublishOnly"},
+		},
+		{
 			name: "runs prepublishOnly before prepare",
 			scripts: map[string]string{
 				"prepare":        logFor("prepare"),
@@ -66,7 +81,7 @@ func TestRunPrepare(t *testing.T) {
 			wantRun: []string{"prepublishOnly", "prepare"},
 		},
 		{
-			name: "runs every publish script in npm order",
+			name: "runs every publish script in order",
 			scripts: map[string]string{
 				"prepack":        logFor("prepack"),
 				"prepare":        logFor("prepare"),
@@ -105,7 +120,7 @@ func TestRunPrepare(t *testing.T) {
 		{
 			name: "stops at the first failing script",
 			scripts: map[string]string{
-				"prepublishOnly": "echo prepublishOnly >> " + orderLogName + "; exit 1",
+				"prepublishOnly": failAfterLog("prepublishOnly"),
 				"prepare":        logFor("prepare"),
 				"prepack":        logFor("prepack"),
 			},


### PR DESCRIPTION
`RunPrepare` iterated `{"prepare", "prepublishOnly", "prepack"}` and returned as
soon as it found one, so a package with both `prepare` and `prepack` ran only
`prepare`. A `prepack: npm run build` never ran, and `lnpm publish` copied stale
or absent build output into the store and on to every consumer.

## Change

`RunPrepare` now runs every script in the set that `package.json` defines, in
the order `prepublishOnly` → `prepare` → `prepack`, stopping at the first
failure with the existing `%s script failed: %w` wrapping. A `ran` flag keeps
`debug.Log("hooks: no prepare scripts found")` firing only when none exist.

## Tests

`TestRunPrepare`'s table now records the sequence of scripts that ran, not just
which one. Each script appends its name to a shared log via `node -e`, and the
assertion compares the whole sequence — one comparison covering membership,
ordering, and the absence of anything extra.

The case that asserted only the first matching script runs was the guard for
exactly the behavior this issue removes. It is replaced by
`runs prepublishOnly before prepare`, which re-pins the ordering it implicitly
guarded; "no other script ran" is still covered, because sequence equality
fails on any extra entry. Cases added for all three scripts together, for
`prepublishOnly` alone, and for a failing script stopping the rest — that last
one asserts the later scripts' markers are absent, not merely that an error
returned.

Order-sensitivity was verified by mutation: reversing the slice, which changes
only the sequence and not the set, fails exactly the three ordering cases.

Script bodies use `node -e` rather than shell built-ins because npm's default
script-shell on Windows is `cmd /d /s /c`, which has no `;` separator and
appends a trailing space to `echo foo >> file`. CI runs a `windows-latest` job
with Node installed, so the `exec.LookPath("npm")` skip does not fire there.

## Note on ordering

The issue's brief describes `prepublishOnly` → `prepare` → `prepack` as "npm's
publish order". It is not. Probing npm 11.16.0 with all three scripts defined,
`npm publish --dry-run` runs `prepublishOnly` → **`prepack`** → **`prepare`**,
and `npm pack` runs `prepack` → `prepare`.

The acceptance criterion states the order explicitly and is the contract, so
the code implements it as written. What changed here is only the documentation,
which no longer claims npm parity it does not have. Whether lnpm should instead
match real npm is a behavior decision for the maintainer; filed separately.

Closes #164