### PR TITLE
Stop concurrent lnpm invocations from failing with a cryptic database timeout

### DIFF
--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -162,9 +162,9 @@
 - Priority: High - silent data corruption possible
 
 **Concurrent access coordination:**
-- Problem: No file locking on database, no inter-process coordination
-- Blocks: Multiple lnpm processes on same machine may corrupt database
-- Priority: High - BoltDB needs exclusive access, concurrent opens at `internal/db/db.go:114` timeout after 1s
+- Problem: bbolt's flock is the only inter-process coordination. It keeps the database from being corrupted, but a process that loses the race just waits, then fails
+- Blocks: Parallel lnpm invocations serialize end to end; nothing queues them or reports progress while they wait
+- Priority: Medium - the wait is `openTimeout` in `internal/db/db.go` (30s, enough to cover an ordinary in-flight command) and exceeding it now reports that another lnpm process holds the database. Multi-process test coverage is still missing (#184)
 
 ## Test Coverage Gaps
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,12 +14,24 @@ import (
 	"github.com/pedrosousa13/lnpm/internal/config"
 	"github.com/pedrosousa13/lnpm/internal/debug"
 	bolt "go.etcd.io/bbolt"
+	bolterrors "go.etcd.io/bbolt/errors"
 )
 
 var (
 	instance *DB
 	once     sync.Once
 )
+
+// openTimeout is how long bolt.Open waits for the bbolt file lock before it
+// gives up. The lock serializes every lnpm process against the shared store,
+// so this has to cover a whole in-flight command (a publish or a push) rather
+// than a single transaction — otherwise parallel invocations from a task
+// runner all die while the first one is still working.
+//
+// It is a var rather than a const purely so tests can shorten it: the
+// production value is long enough that a test which waits it out would stall
+// the suite for half a minute.
+var openTimeout = 30 * time.Second
 
 // Bucket names
 var (
@@ -113,8 +126,13 @@ func initDB() (*DB, error) {
 	debug.Logf("db: opening %s", dbPath)
 
 	// Open bbolt database
-	boltDB, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: 1 * time.Second})
+	boltDB, err := bolt.Open(dbPath, 0600, &bolt.Options{Timeout: openTimeout})
 	if err != nil {
+		// bbolt reports a lost race for the file lock as ErrTimeout. Name the
+		// likely cause, because "timeout" on its own tells the user nothing.
+		if errors.Is(err, bolterrors.ErrTimeout) {
+			return nil, fmt.Errorf("another lnpm process appears to be running (database is locked): %w", err)
+		}
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 

--- a/internal/db/db_permissions_test.go
+++ b/internal/db/db_permissions_test.go
@@ -279,37 +279,6 @@ func TestGetDB_Singleton(t *testing.T) {
 	}
 }
 
-// TestOpen_TimeoutWithLockedDB tests timeout when database is locked
-func TestOpen_TimeoutWithLockedDB(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("LNPM_STORE", tmpDir)
-	defer ResetForTesting()
-
-	// Open first database instance
-	db1, err := GetDB()
-	if err != nil {
-		t.Fatalf("Failed to open first database: %v", err)
-	}
-	defer func() {
-		_ = db1.Close()
-	}()
-
-	// Try to open second instance - should timeout due to lock
-	// (bolt only allows one writer at a time)
-	db2, err := GetDB()
-	if err != nil {
-		t.Logf("Second open timed out as expected: %v", err)
-		return
-	}
-	defer func() {
-		_ = db2.Close()
-	}()
-
-	// If we got here, concurrent access is somehow allowed
-	// This is fine on some platforms/configurations
-	t.Log("Concurrent database access allowed on this platform")
-}
-
 // TestWriteOperations_PreservePermissions tests write operations preserve file permissions
 func TestWriteOperations_PreservePermissions(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,0 +1,107 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+// lockMessage is the phrase users should see when the database is already held
+// by a concurrent lnpm invocation.
+const lockMessage = "another lnpm process"
+
+// shortenOpenTimeout points initDB at a timeout the test can afford to wait
+// out, and restores the production value afterwards.
+func shortenOpenTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	previous := openTimeout
+	openTimeout = d
+	t.Cleanup(func() { openTimeout = previous })
+}
+
+// holdDatabaseLock opens the store's bbolt file directly, standing in for a
+// second lnpm process that already holds the flock. bbolt locks per open file
+// description, so a separate handle in this process conflicts exactly the way
+// a separate process would.
+func holdDatabaseLock(t *testing.T, storeDir string) *bolt.DB {
+	t.Helper()
+	holder, err := bolt.Open(filepath.Join(storeDir, "lnpm.db"), 0600, &bolt.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Failed to take the database lock: %v", err)
+	}
+	t.Cleanup(func() { _ = holder.Close() })
+	return holder
+}
+
+// TestGetDB_LockHeldElsewhere_NamesTheOtherProcess checks that a database the
+// process cannot lock within the timeout is reported as a concurrency problem
+// rather than a bare "timeout".
+func TestGetDB_LockHeldElsewhere_NamesTheOtherProcess(t *testing.T) {
+	ResetForTesting()
+	storeDir := t.TempDir()
+	t.Setenv("LNPM_STORE", storeDir)
+	t.Cleanup(ResetForTesting)
+
+	holdDatabaseLock(t, storeDir)
+	shortenOpenTimeout(t, 200*time.Millisecond)
+
+	_, err := GetDB()
+	if err == nil {
+		t.Fatal("Expected an error opening a database locked by another handle")
+	}
+	if !strings.Contains(err.Error(), lockMessage) {
+		t.Errorf("Expected error to mention %q, got: %v", lockMessage, err)
+	}
+}
+
+// TestGetDB_WaitsOutALockHeldLongerThanASecond checks the production timeout is
+// generous enough that a second lnpm invocation waits for an in-flight one
+// instead of dying almost immediately. It deliberately uses the production
+// openTimeout so that shrinking it back re-breaks this test.
+func TestGetDB_WaitsOutALockHeldLongerThanASecond(t *testing.T) {
+	ResetForTesting()
+	storeDir := t.TempDir()
+	t.Setenv("LNPM_STORE", storeDir)
+	t.Cleanup(ResetForTesting)
+
+	holder := holdDatabaseLock(t, storeDir)
+	time.AfterFunc(1500*time.Millisecond, func() { _ = holder.Close() })
+
+	database, err := GetDB()
+	if err != nil {
+		t.Fatalf("Expected the open to wait for the lock to be released, got: %v", err)
+	}
+	if database == nil {
+		t.Fatal("Expected a database instance")
+	}
+}
+
+// TestGetDB_NonTimeoutFailure_DoesNotBlameAnotherProcess pins the error
+// classification: an open that fails for a reason other than the lock must not
+// be reported as a concurrent lnpm invocation.
+func TestGetDB_NonTimeoutFailure_DoesNotBlameAnotherProcess(t *testing.T) {
+	ResetForTesting()
+	storeDir := t.TempDir()
+	t.Setenv("LNPM_STORE", storeDir)
+	t.Cleanup(ResetForTesting)
+
+	// A non-empty file that is not a bbolt database fails meta-page validation.
+	// Nothing holds the lock, so this cannot be a timeout.
+	dbPath := filepath.Join(storeDir, "lnpm.db")
+	if err := os.WriteFile(dbPath, []byte(strings.Repeat("not a bbolt database", 256)), 0600); err != nil {
+		t.Fatalf("Failed to write invalid database file: %v", err)
+	}
+	shortenOpenTimeout(t, 200*time.Millisecond)
+
+	_, err := GetDB()
+	if err == nil {
+		t.Fatal("Expected an error opening an invalid database file")
+	}
+	if strings.Contains(err.Error(), lockMessage) {
+		t.Errorf("Expected error not to blame another lnpm process, got: %v", err)
+	}
+}


### PR DESCRIPTION
`bolt.Open` used `Timeout: 1 * time.Second`. bbolt's flock is held for a whole
process lifetime, not per transaction, so any second lnpm invocation started
while a `publish` or `push` was in flight died within a second with
`failed to open database: timeout`. Under a task runner invoking lnpm in
parallel across packages, the first invocation wins and the rest crash.

## Change

Timeout raised to 30s, long enough to cover an in-flight command. A lost race
for the lock is now reported as `another lnpm process appears to be running
(database is locked)`, classified with `errors.Is(err, bolterrors.ErrTimeout)`
rather than by matching the message — other open failures keep the original
wrapping.

The flock is untouched. It is the only cross-process guard protecting the store
from concurrent corruption, and weakening it is out of scope.

The timeout is an unexported package var solely so tests can shorten it; a test
that waited out the real value would stall the suite for half a minute.

## Tests

New `internal/db/db_test.go`:

- lock held elsewhere, timeout shortened → asserts the message names another
  lnpm process. Red against the old code with the bare `timeout` text.
- a lock held longer than a second, using the **production** timeout → pins that
  the wait actually happens. Mutating the timeout back to 1s re-breaks it, so
  the value cannot silently regress.
- a non-timeout open failure → asserts it is *not* blamed on another process,
  so the classification branch is pinned rather than assumed.

bbolt's flock is per open-file-description, so a second `bolt.Open` from the
same process conflicts exactly like a second process would. That was verified
rather than assumed, and holds on Windows too, where `LockFileEx` byte-range
locks are per handle. Multi-process coverage stays out of scope (#184).

`internal/db` runs in 1.75s; nothing can stall on the 30s value.

## Removed a hollow test

`TestOpen_TimeoutWithLockedDB` called `GetDB()` twice with no
`ResetForTesting()` between, so the `sync.Once` singleton returned the same
instance and no second open ever happened. Both its branches returned without
failing, so it passed unconditionally on every platform — it completed in 0.00s
where a real second open would have blocked. It is superseded by the new test,
which takes a genuine second handle.

## Filed separately

`GetDB` returns `(nil, nil)` on every call after a failed init, because
`initErr` is a local that only the `once.Do` body assigns. That swallows the new
error message for any caller after the first — #253.

Closes #165