### PR TITLE
Fix deprecated GoReleaser fields and pin the GoReleaser version

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,11 +28,13 @@ builds:
 
 archives:
   - id: default
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - README.md
       - LICENSE*


### PR DESCRIPTION
`.goreleaser.yaml` used GoReleaser's singular `format:` and
`format_overrides[].format:` fields, deprecated in v2.6 in favour of the plural
`formats:` list, and `.github/workflows/release-please.yaml` installed
`version: latest` — so the GoReleaser version was decided at release time. The
day GoReleaser removes the deprecated fields, the next release would fail
*during the release*, not during a PR.

## Changes

- `.goreleaser.yaml` — `format: tar.gz` → `formats:` and the windows
  `format: zip` override → `formats:`, both block style to match every other
  list in the file (including the already-plural, non-deprecated
  `nfpms.formats`). The `format_overrides:` key itself is not deprecated and is
  unchanged.
- `.github/workflows/release-please.yaml` — `version: latest` →
  `version: "~> v2"`. The quotes are load-bearing: an unquoted leading `~`
  parses as null in YAML.

## Verification

- `goreleaser check` exits 0 with both `DEPRECATED` lines gone (it failed before).
- `goreleaser release --snapshot --clean` still produces `.tar.gz` for
  linux/darwin amd64+arm64 and `.zip` for windows amd64+arm64; the nfpm
  deb/rpm/apk set is unchanged.
- Full `go test ./...`, `go vet ./...` and `golangci-lint run ./...` green
  (no Go code is touched).

## Note

The acceptance criteria specify a major-version constraint (`~> v2`) so patch
and minor updates keep flowing in. That differs from this repo's exact-pin
convention for golangci-lint (`v2.12.2`); filed separately so the maintainer can
decide whether to tighten it, rather than overriding the brief here.

Closes #175