### PR TITLE
Add tests for the status, list, and doctor commands

### DIFF
--- a/internal/cli/status_helpers_test.go
+++ b/internal/cli/status_helpers_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+// TestTruncate pins the column-fitting helper the status tables rely on: a
+// truncated value must never exceed its column, must end in an ellipsis when
+// something was dropped, and must never split a multibyte character (the
+// tables print package names and paths, which are not ASCII-only).
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		maxLen int
+		want   string
+	}{
+		{"shorter than the column is unchanged", "hello", 10, "hello"},
+		{"exactly the column width is unchanged", "hello", 5, "hello"},
+		{"empty string is unchanged", "", 5, ""},
+		{"longer than the column ends in an ellipsis", "hello world", 8, "hello..."},
+		{"one over the column drops three characters", "hello", 4, "h..."},
+		{"a column of 4 is the narrowest that keeps a character", "hello world", 4, "h..."},
+		{"a column of 3 is a hard cut with no ellipsis", "hello", 3, "hel"},
+		{"a column of 1 is a hard cut", "hello", 1, "h"},
+		{"a column of 0 drops everything", "hello", 0, ""},
+		{"multibyte shorter than the column is unchanged", "héllo wörld", 11, "héllo wörld"},
+		{"multibyte is cut on rune boundaries", "héllo wörld", 8, "héllo..."},
+		{"multibyte counts runes, not bytes", "hé", 2, "hé"},
+		{"multibyte hard cut stays on a rune boundary", "héllo", 2, "hé"},
+		{"the ellipsis is not counted in bytes", "wörld wörld", 6, "wör..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncate(tt.s, tt.maxLen)
+
+			if got != tt.want {
+				t.Errorf("truncate(%q, %d) = %q, want %q", tt.s, tt.maxLen, got, tt.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("truncate(%q, %d) = %q, which is not valid UTF-8", tt.s, tt.maxLen, got)
+			}
+			if n := utf8.RuneCountInString(got); n > tt.maxLen {
+				t.Errorf("truncate(%q, %d) = %q, which is %d runes wide and overflows the column",
+					tt.s, tt.maxLen, got, n)
+			}
+		})
+	}
+}
+
+// TestFormatTimeAgo pins the humanized age shown in the status tables and the
+// list output, including the singular forms and each unit boundary. Every case
+// is expressed as a duration before the same "now", so the test is independent
+// of when it runs, and the past-a-week fallback is compared against the same
+// time formatted by the test rather than a fixed date string.
+func TestFormatTimeAgo(t *testing.T) {
+	type testCase struct {
+		name string
+		ago  time.Duration
+		want string
+		// wantDate marks the past-a-week cases, whose expectation is the
+		// timestamp itself formatted as a date. Deriving it in the runner from
+		// the very instant passed to the helper keeps the test correct whatever
+		// day it runs on, and keeps the subtest names static.
+		wantDate bool
+	}
+
+	const day = 24 * time.Hour
+
+	tests := []testCase{
+		{name: "under a minute", ago: 30 * time.Second, want: "just now"},
+		{name: "one second under a minute", ago: 59 * time.Second, want: "just now"},
+		{name: "exactly a minute is singular", ago: time.Minute, want: "1 minute ago"},
+		{name: "several minutes are plural", ago: 5 * time.Minute, want: "5 minutes ago"},
+		{name: "one minute under an hour", ago: 59 * time.Minute, want: "59 minutes ago"},
+		{name: "exactly an hour is singular", ago: time.Hour, want: "1 hour ago"},
+		{name: "several hours are plural", ago: 3 * time.Hour, want: "3 hours ago"},
+		{name: "one hour under a day", ago: 23 * time.Hour, want: "23 hours ago"},
+		{name: "exactly a day is singular", ago: day, want: "1 day ago"},
+		{name: "several days are plural", ago: 3 * day, want: "3 days ago"},
+		{name: "one hour under a week", ago: 7*day - time.Hour, want: "6 days ago"},
+		{name: "exactly a week falls back to a date", ago: 7 * day, wantDate: true},
+		{name: "ten days falls back to a date", ago: 10 * day, wantDate: true},
+		{name: "over a year falls back to a date", ago: 400 * day, wantDate: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Built here rather than from a "now" shared by the whole table:
+			// the 59-second case sits one second below a boundary, so any
+			// elapsed time between building the table and running the case
+			// could flip it to "1 minute ago".
+			ts := time.Now().Add(-tt.ago)
+
+			want := tt.want
+			if tt.wantDate {
+				want = ts.Format("Jan 2, 2006")
+			}
+
+			if got := formatTimeAgo(ts); got != want {
+				t.Errorf("formatTimeAgo(%v ago) = %q, want %q", tt.ago, got, want)
+			}
+		})
+	}
+}
+
+// TestFormatTimeAgoFutureTime pins what the helper does with a timestamp in the
+// future: time.Since is negative, which falls into the first branch, so it
+// reads as "just now" rather than producing a negative count.
+func TestFormatTimeAgoFutureTime(t *testing.T) {
+	if got := formatTimeAgo(time.Now().Add(time.Hour)); got != "just now" {
+		t.Errorf("formatTimeAgo(an hour from now) = %q, want %q", got, "just now")
+	}
+}

--- a/tests/doctor_test.go
+++ b/tests/doctor_test.go
@@ -1,0 +1,62 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+)
+
+// TestDoctorHealthyStore is the integration counterpart to the unit tests in
+// internal/cli: doctor run over a real published-and-linked store passes every
+// check. setupTest points LNPM_STORE at a temp dir, and config.GetStorePath
+// consults that variable before the config file or the home directory, so a
+// real ~/.lnpm on the machine running the test is never reached.
+func TestDoctorHealthyStore(t *testing.T) {
+	env := setupTest(t)
+	env.publishAndAdd("doctor-pkg")
+
+	out := captureStdout(t, func() {
+		if err := cli.RunDoctor(); err != nil {
+			t.Errorf("RunDoctor() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "All checks passed!") {
+		t.Errorf("RunDoctor did not pass on a healthy store, output was:\n%s", out)
+	}
+	// The check labels themselves mention orphans, so the assertion keys on the
+	// findings' wording ("N orphaned package(s)") rather than the word alone.
+	for _, unwanted := range []string{"NOT FOUND", "orphaned package(s)", "orphaned link(s)", "missing files"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("RunDoctor reported %q on a healthy store, output was:\n%s", unwanted, out)
+		}
+	}
+}
+
+// TestDoctorReportsOrphanedPackage pins the warning path: a package that was
+// published but never linked is an orphan, and doctor must both count it and
+// point at gc, rather than reporting the store healthy.
+func TestDoctorReportsOrphanedPackage(t *testing.T) {
+	env := setupTest(t)
+	env.simplePkg("doctor-orphan")
+
+	out := captureStdout(t, func() {
+		if err := cli.RunDoctor(); err != nil {
+			t.Errorf("RunDoctor() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "1 orphaned package(s)") {
+		t.Errorf("RunDoctor did not report the orphaned package, output was:\n%s", out)
+	}
+	if !strings.Contains(out, "lnpm gc") {
+		t.Errorf("RunDoctor did not suggest gc for the orphan, output was:\n%s", out)
+	}
+	if !strings.Contains(out, "Found 1 warning(s)") {
+		t.Errorf("RunDoctor did not summarize the orphan as a warning, output was:\n%s", out)
+	}
+	if strings.Contains(out, "All checks passed!") {
+		t.Errorf("RunDoctor reported all checks passed despite an orphan, output was:\n%s", out)
+	}
+}

--- a/tests/status_test.go
+++ b/tests/status_test.go
@@ -1,0 +1,305 @@
+// RunStatus and RunList are exercised from this package, not from package cli,
+// so they do not appear in `go test ./internal/cli/ -cover` — that measures the
+// internal/cli test binary alone. To see their coverage:
+//
+//	go test ./tests/ -coverpkg=./internal/cli/ -coverprofile=cover.out
+//
+// which reports RunStatus and RunList around 90%, against 0% before these tests
+// existed.
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+)
+
+// fieldValue returns the text printed after an indented "Label: value" line,
+// so a test can assert on the value rather than merely on the label.
+func fieldValue(t *testing.T, out, label string) string {
+	t.Helper()
+
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(trimmed, label); ok {
+			return strings.TrimSpace(after)
+		}
+	}
+	t.Fatalf("output has no %q line, output was:\n%s", label, out)
+	return ""
+}
+
+// isShortHash reports whether s looks like the abbreviated store hash RunList
+// prints: non-empty and hexadecimal.
+func isShortHash(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !unicode.Is(unicode.Hex_Digit, r) {
+			return false
+		}
+	}
+	return true
+}
+
+// statusSection returns the body of one RunStatus section: everything printed
+// after the named header up to the blank line that separates it from the next
+// one. Slicing the output this way lets a test say "the package appears under
+// Active Links" rather than "the package appears somewhere", so a status that
+// dropped a whole section would still fail even though the name is printed
+// elsewhere in the report.
+func statusSection(t *testing.T, out, name string) string {
+	t.Helper()
+
+	start := strings.Index(out, name+"\n")
+	if start < 0 {
+		t.Fatalf("status output has no %q section, output was:\n%s", name, out)
+	}
+	body := out[start+len(name)+1:]
+	if end := strings.Index(body, "\n\n"); end >= 0 {
+		return body[:end]
+	}
+	return body
+}
+
+// TestStatusEmptyStore pins what status reports when nothing has been
+// published: both the packages and the links sections render their "(none)"
+// placeholder, and the current-project section is omitted entirely because the
+// cwd has no lockfile.
+func TestStatusEmptyStore(t *testing.T) {
+	env := setupTest(t)
+	env.newProject("empty-status-project") // a cwd with no lnpm.lock
+
+	out := captureStdout(t, func() {
+		if err := cli.RunStatus(); err != nil {
+			t.Errorf("RunStatus() error = %v", err)
+		}
+	})
+
+	if got := statusSection(t, out, "Published Packages"); !strings.Contains(got, "(none)") {
+		t.Errorf("Published Packages section should be empty, got:\n%s", got)
+	}
+	if got := statusSection(t, out, "Active Links"); !strings.Contains(got, "(none)") {
+		t.Errorf("Active Links section should be empty, got:\n%s", got)
+	}
+	if strings.Contains(out, "Current Project") {
+		t.Errorf("status reported a Current Project without a lockfile, output was:\n%s", out)
+	}
+}
+
+// TestStatusWithPackagesAndLinks pins the populated report. The cwd is left
+// inside the linked project, so all three sections run: the package is listed
+// in the store, the project is listed as an active link with its package
+// manager and the package it uses, and the current project's lockfile entry is
+// printed with its version.
+func TestStatusWithPackagesAndLinks(t *testing.T) {
+	env := setupTest(t)
+	_, projectDir := env.publishAndAdd("status-pkg")
+
+	out := captureStdout(t, func() {
+		if err := cli.RunStatus(); err != nil {
+			t.Errorf("RunStatus() error = %v", err)
+		}
+	})
+
+	published := statusSection(t, out, "Published Packages")
+	if !strings.Contains(published, "status-pkg") || !strings.Contains(published, "1.0.0") {
+		t.Errorf("Published Packages section is missing status-pkg@1.0.0, got:\n%s", published)
+	}
+
+	// The project column is truncated to 40 columns, so the assertion keys on
+	// the package manager and the packages column, which are not.
+	links := statusSection(t, out, "Active Links")
+	if strings.Contains(links, "(none)") {
+		t.Errorf("Active Links section reported no links despite an active link, got:\n%s", links)
+	}
+	if !strings.Contains(links, "npm") || !strings.Contains(links, "status-pkg") {
+		t.Errorf("Active Links section is missing the npm project using status-pkg, got:\n%s", links)
+	}
+
+	// The linked package is printed from the lockfile, with the version the
+	// lockfile recorded rather than the one in the store listing.
+	current := statusSection(t, out, "Current Project")
+	if !strings.Contains(current, "status-pkg@1.0.0") {
+		t.Errorf("Current Project section is missing status-pkg@1.0.0, got:\n%s", current)
+	}
+	// Asserted separator-free: the printed cwd may be a resolved form of
+	// projectDir (macOS resolves /var through a symlink), so only the leaf is
+	// stable across platforms.
+	if leaf := filepath.Base(projectDir); !strings.Contains(current, leaf) {
+		t.Errorf("Current Project section does not name the project %q, got:\n%s", leaf, current)
+	}
+}
+
+// TestListStore pins `lnpm list --store` in both states: it names every
+// published package with its version, and reports the empty store rather than
+// printing an empty list.
+func TestListStore(t *testing.T) {
+	t.Run("empty store", func(t *testing.T) {
+		setupTest(t)
+
+		out := captureStdout(t, func() {
+			if err := cli.RunList(true, "", false); err != nil {
+				t.Errorf("RunList(store) error = %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "No packages in store") {
+			t.Errorf("RunList(store) on an empty store printed:\n%s", out)
+		}
+	})
+
+	t.Run("populated store", func(t *testing.T) {
+		env := setupTest(t)
+		env.simplePkg("list-store-a")
+		env.simplePkg("list-store-b")
+
+		out := captureStdout(t, func() {
+			if err := cli.RunList(true, "", false); err != nil {
+				t.Errorf("RunList(store) error = %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "Packages in store:") {
+			t.Errorf("RunList(store) did not print the store listing header, output was:\n%s", out)
+		}
+		for _, want := range []string{"list-store-a@1.0.0", "list-store-b@1.0.0"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("RunList(store) did not list %q, output was:\n%s", want, out)
+			}
+		}
+	})
+}
+
+// TestListProjectsForPackage pins the package+--projects mode: the linked
+// project is named with its package manager, a package nobody links reports
+// that rather than an empty list, and an unknown package is an error.
+func TestListProjectsForPackage(t *testing.T) {
+	t.Run("linked package", func(t *testing.T) {
+		env := setupTest(t)
+		_, projectDir := env.publishAndAdd("list-projects-pkg")
+
+		out := captureStdout(t, func() {
+			if err := cli.RunList(false, "list-projects-pkg", true); err != nil {
+				t.Errorf("RunList(projects) error = %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "Projects using list-projects-pkg:") {
+			t.Errorf("RunList(projects) did not print the projects header, output was:\n%s", out)
+		}
+		if leaf := filepath.Base(projectDir); !strings.Contains(out, leaf) {
+			t.Errorf("RunList(projects) did not name the project %q, output was:\n%s", leaf, out)
+		}
+		if !strings.Contains(out, "(npm)") {
+			t.Errorf("RunList(projects) did not report the project's package manager, output was:\n%s", out)
+		}
+	})
+
+	t.Run("package with no projects", func(t *testing.T) {
+		env := setupTest(t)
+		env.simplePkg("unlinked-pkg")
+
+		out := captureStdout(t, func() {
+			if err := cli.RunList(false, "unlinked-pkg", true); err != nil {
+				t.Errorf("RunList(projects) error = %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "No projects using unlinked-pkg") {
+			t.Errorf("RunList(projects) on an unlinked package printed:\n%s", out)
+		}
+	})
+
+	t.Run("unknown package", func(t *testing.T) {
+		setupTest(t)
+
+		err := cli.RunList(false, "no-such-pkg", true)
+		if err == nil {
+			t.Fatal("RunList(projects) on an unknown package returned nil, want an error")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("RunList(projects) error = %v, want it to say the package was not found", err)
+		}
+		if !strings.Contains(err.Error(), "no-such-pkg") {
+			t.Errorf("RunList(projects) error = %v, want it to name no-such-pkg", err)
+		}
+	})
+
+	t.Run("package name without --projects", func(t *testing.T) {
+		env := setupTest(t)
+		env.simplePkg("needs-projects-flag")
+
+		err := cli.RunList(false, "needs-projects-flag", false)
+		if err == nil {
+			t.Fatal("RunList with a package name but no --projects returned nil, want an error")
+		}
+		if !strings.Contains(err.Error(), "--projects") {
+			t.Errorf("RunList error = %v, want it to point at --projects", err)
+		}
+	})
+}
+
+// TestListCurrentProject pins the no-flags mode, which reads the cwd's
+// lockfile: inside a linked project every recorded field is printed, and a
+// directory without a lockfile reports no linked packages rather than failing
+// (lockfile.Load treats a missing file as an empty lockfile).
+func TestListCurrentProject(t *testing.T) {
+	t.Run("linked project", func(t *testing.T) {
+		env := setupTest(t)
+		env.publishAndAdd("list-current-pkg") // leaves the cwd in the project
+
+		out := captureStdout(t, func() {
+			if err := cli.RunList(false, "", false); err != nil {
+				t.Errorf("RunList(current) error = %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "Linked packages:") {
+			t.Errorf("RunList(current) did not print the linked packages header, output was:\n%s", out)
+		}
+		if !strings.Contains(out, "list-current-pkg@1.0.0") {
+			t.Errorf("RunList(current) did not list list-current-pkg@1.0.0, output was:\n%s", out)
+		}
+		// Assert the field *values*, not just the labels: printing "Source:"
+		// with an empty value is exactly the kind of regression a
+		// label-presence check waves through.
+		for _, field := range []struct{ label, want string }{
+			// The source is the package directory publishAndAdd created, so its
+			// last element is the package name. Compared on the base name only,
+			// which keeps the assertion free of path separators for Windows and
+			// of macOS's /var -> /private/var symlink resolution.
+			{"Source:", "list-current-pkg"},
+			// Nothing else has elapsed, so formatTimeAgo's first branch applies.
+			{"Linked:", "just now"},
+		} {
+			value := fieldValue(t, out, field.label)
+			if !strings.Contains(value, field.want) {
+				t.Errorf("RunList(current) printed %s %q, want it to contain %q, output was:\n%s",
+					field.label, value, field.want, out)
+			}
+		}
+		if hash := fieldValue(t, out, "Hash:"); !isShortHash(hash) {
+			t.Errorf("RunList(current) printed Hash: %q, want a short hex hash, output was:\n%s", hash, out)
+		}
+	})
+
+	t.Run("no lockfile", func(t *testing.T) {
+		env := setupTest(t)
+		env.newProject("unlinked-project")
+
+		out := captureStdout(t, func() {
+			if err := cli.RunList(false, "", false); err != nil {
+				t.Errorf("RunList(current) without a lockfile error = %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "No linked packages in current project") {
+			t.Errorf("RunList(current) without a lockfile printed:\n%s", out)
+		}
+	})
+}


### PR DESCRIPTION
`RunStatus`, `RunList`, `truncate` and `formatTimeAgo` were invoked by no test
at all, so a panic or wrong output in `lnpm status` or `lnpm list` would have
shipped unnoticed. No production code is changed.

## Coverage

| function | before | after |
| --- | --- | --- |
| `RunStatus` | 0.0% | **90.9%** |
| `RunList` | 0.0% | **88.0%** |
| `RunDoctor` | 54.3% | **65.4%** |
| `truncate` | 0.0% | **100%** |
| `formatTimeAgo` | 0.0% | **100%** |

`RunStatus`/`RunList` figures are measured with
`go test ./tests/ -coverpkg=./internal/cli/`.

**On acceptance criterion 5.** It asks that `go test ./internal/cli/ -cover`
show `status.go` and `doctor.go` no longer at 0%. That is satisfiable only at
file granularity — `truncate` and `formatTimeAgo` live in `status.go` and are
now 100% — because the criterion contradicts the issue's own step 1, which says
to put the command tests in `package tests`. Tests in a separate binary cannot
appear in that command's profile without `-coverpkg`. Rather than move the
integration tests somewhere the issue didn't ask for, the `-coverpkg` invocation
is documented at the top of `tests/status_test.go` so the real number is
discoverable. Flagging it rather than quietly satisfying the letter of it.

## Not hollow — verified by mutation

This repo's review has caught three hollow tests before (an assertion-free test,
one that passed on any machine with a real `~/.lnpm`, and a lock test whose two
`GetDB()` calls returned the same singleton). Every test here was checked by
mutating the code it pins and confirming it fails: 16 mutations by the
implementer, plus two re-run independently during review — making `RunList`'s
not-found path return `nil`, and blanking `entry.Source`.

The second of those found a real weakness: `TestListCurrentProject` originally
asserted only that the labels `Hash:`, `Source:` and `Linked:` were printed, so
blanking a value still passed. It now asserts the values — the source contains
the package name, the link age reads `just now`, and the hash is hex.

Assertions read stdout sliced per section (`statusSection`), so a package name
appearing anywhere in the report cannot satisfy a test about a specific section.

## Review fixes also applied

- Dropped a `HOME`/`USERPROFILE` redirect from the doctor tests that was inert
  and whose comment claimed otherwise: `setupTest` sets `LNPM_STORE`, and
  `config.GetStorePath` consults it before the config file or the home
  directory, so `~/.lnpm` is never reached.
- Moved the doctor integration tests to `tests/doctor_test.go`, matching the
  convention that keys integration files to the command.
- Made the `formatTimeAgo` date-fallback subtest names static — they were built
  from `time.Now()`, so `-run` selectors stopped working the next day.
- Each `formatTimeAgo` case now builds its timestamp when it runs, so the case
  one second below the minute boundary cannot drift across it.

## Known gap, not fixed here

Doctor's fifth check (missing store files) still has no test — deleting its
counter increment passes the suite. AC 3 asks only that `RunDoctor` be invoked
by an integration test, so this is left for the Test coverage gaps milestone
rather than expanded into here.

Closes #182