### PR TITLE
Add tests for config subcommands and config persistence

### DIFF
--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,11 +1,15 @@
 package cli
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/config"
+	"gopkg.in/yaml.v3"
 )
 
 func TestEditConfigSupportsEditorWithArguments(t *testing.T) {
@@ -46,5 +50,271 @@ func TestEditConfigSupportsEditorWithArguments(t *testing.T) {
 	}
 	if args[1] != configPath {
 		t.Fatalf("config path arg = %q, want %q", args[1], configPath)
+	}
+}
+
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what it
+// printed. The config subcommand helpers report their results on stdout and
+// only return an error value, so asserting on anything they actually tell the
+// user means reading the pipe.
+//
+// The reader goroutine starts before fn does, so fn can write more than the
+// pipe buffer without deadlocking, and the teardown is deferred so os.Stdout is
+// restored however fn exits.
+func captureStdout(t *testing.T, fn func()) (out string) {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+
+	done := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(r)
+		done <- string(data)
+	}()
+
+	orig := os.Stdout
+	os.Stdout = w
+
+	defer func() {
+		os.Stdout = orig
+		_ = w.Close() // unblocks the reader goroutine
+		out = <-done
+		_ = r.Close()
+	}()
+
+	fn()
+	return
+}
+
+// readSavedConfig parses the config file setConfigKey wrote. It deliberately
+// does not go through config.LoadConfig: that memoizes its first result in a
+// package-level sync.Once for the life of the test binary, so it would not see
+// a file written mid-test.
+//
+// What comes back is therefore the persisted bytes and nothing else — none of
+// the defaults loadConfigFile applies on top. That is the point here: these
+// tests assert what setConfigKey actually wrote, so a value supplied by a
+// default rather than by the write cannot make one pass.
+func readSavedConfig(t *testing.T, path string) *config.Config {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("config file was not written: %v", err)
+	}
+
+	var cfg config.Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse written config %q: %v", string(data), err)
+	}
+	return &cfg
+}
+
+// TestSetThenGetConfigKey walks every key the config subcommand supports:
+// setting it must persist the value to disk, and getting it back — both from
+// the in-memory config and from one re-parsed off disk — must print that value.
+func TestSetThenGetConfigKey(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "some-store")
+
+	tests := []struct {
+		name     string
+		key      string
+		value    string
+		wantYAML string // must appear verbatim in the written file
+		wantGet  string // what getConfigKey prints
+	}{
+		{"store_path", "store_path", storePath, "store_path: " + storePath, storePath},
+		{"link_mode copy", "link_mode", "copy", "link_mode: copy", "copy"},
+		{"link_mode hardlink", "link_mode", "hardlink", "link_mode: hardlink", "hardlink"},
+		{"manage_gitignore true", "manage_gitignore", "true", "manage_gitignore: true", "true"},
+		{"manage_gitignore false", "manage_gitignore", "false", "manage_gitignore: false", "false"},
+		{"hooks.pre_publish", "hooks.pre_publish", "echo pre", "pre_publish: echo pre", "echo pre"},
+		{"hooks.post_publish", "hooks.post_publish", "echo post", "post_publish: echo post", "echo post"},
+		{"hooks.post_add", "hooks.post_add", "npm ci", "post_add: npm ci", "npm ci"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			t.Setenv("LNPM_CONFIG", configPath)
+
+			cfg := &config.Config{}
+			var setErr error
+			setOut := captureStdout(t, func() { setErr = setConfigKey(cfg, tc.key, tc.value) })
+			if setErr != nil {
+				t.Fatalf("setConfigKey(%q, %q) error = %v", tc.key, tc.value, setErr)
+			}
+			if want := "Set " + tc.key + " = " + tc.value; !strings.Contains(setOut, want) {
+				t.Errorf("setConfigKey printed %q, want it to contain %q", setOut, want)
+			}
+
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatalf("config file was not written: %v", err)
+			}
+			if !strings.Contains(string(data), tc.wantYAML) {
+				t.Errorf("written config missing %q\n--- file ---\n%s", tc.wantYAML, string(data))
+			}
+
+			// Once from the config setConfigKey mutated, once from the file it
+			// saved, so a value that never reached disk cannot pass.
+			for _, source := range []struct {
+				label string
+				cfg   *config.Config
+			}{
+				{"in-memory", cfg},
+				{"from disk", readSavedConfig(t, configPath)},
+			} {
+				label, source := source.label, source.cfg
+				var getErr error
+				got := captureStdout(t, func() { getErr = getConfigKey(source, tc.key) })
+				if getErr != nil {
+					t.Fatalf("getConfigKey(%s, %q) error = %v", label, tc.key, getErr)
+				}
+				if strings.TrimSpace(got) != tc.wantGet {
+					t.Errorf("getConfigKey(%s, %q) printed %q, want %q", label, tc.key, strings.TrimSpace(got), tc.wantGet)
+				}
+			}
+		})
+	}
+}
+
+// TestGetConfigKeyStorePathFallsBackToDefault covers the branch where
+// store_path is unset in the config: the resolved store path is printed and
+// marked as a default rather than printing nothing.
+func TestGetConfigKeyStorePathFallsBackToDefault(t *testing.T) {
+	store := t.TempDir()
+	t.Setenv("LNPM_STORE", store) // resolves without touching config.LoadConfig
+
+	var err error
+	got := captureStdout(t, func() { err = getConfigKey(&config.Config{}, "store_path") })
+	if err != nil {
+		t.Fatalf("getConfigKey(store_path) error = %v", err)
+	}
+	if want := store + " (default)"; strings.TrimSpace(got) != want {
+		t.Errorf("getConfigKey(store_path) printed %q, want %q", strings.TrimSpace(got), want)
+	}
+}
+
+// TestSetConfigKeyValidation checks that every rejected input produces an error
+// and, just as importantly, leaves no config file behind: a validation path
+// that fell through to SaveConfig would persist the bad value.
+func TestSetConfigKeyValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		value     string
+		wantErrIn []string
+		check     func(t *testing.T, cfg *config.Config)
+	}{
+		{
+			name:      "link_mode rejects unknown mode",
+			key:       "link_mode",
+			value:     "banana",
+			wantErrIn: []string{"link_mode", "hardlink", "copy"},
+			check: func(t *testing.T, cfg *config.Config) {
+				if cfg.LinkMode != "" {
+					t.Errorf("LinkMode = %q, want it left untouched", cfg.LinkMode)
+				}
+			},
+		},
+		{
+			name:      "manage_gitignore rejects non-boolean",
+			key:       "manage_gitignore",
+			value:     "not-a-bool",
+			wantErrIn: []string{"manage_gitignore", "boolean"},
+			check: func(t *testing.T, cfg *config.Config) {
+				if cfg.ManageGitignore != nil {
+					t.Errorf("ManageGitignore = %v, want it left unset", *cfg.ManageGitignore)
+				}
+			},
+		},
+		{
+			name:      "unknown key",
+			key:       "nonsense",
+			value:     "x",
+			wantErrIn: []string{"unknown config key", "nonsense"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			t.Setenv("LNPM_CONFIG", configPath)
+
+			cfg := &config.Config{}
+			var err error
+			out := captureStdout(t, func() { err = setConfigKey(cfg, tc.key, tc.value) })
+			if err == nil {
+				t.Fatalf("setConfigKey(%q, %q) = nil, want an error", tc.key, tc.value)
+			}
+			for _, want := range tc.wantErrIn {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not mention %q", err.Error(), want)
+				}
+			}
+			if strings.Contains(out, "Set ") {
+				t.Errorf("setConfigKey printed a success line on a rejected value: %q", out)
+			}
+			if _, statErr := os.Stat(configPath); !os.IsNotExist(statErr) {
+				data, _ := os.ReadFile(configPath)
+				t.Errorf("config file was written despite the validation failure (stat err %v)\n--- file ---\n%s", statErr, string(data))
+			}
+			// Nil for the unknown-key case, which mutates no field to check.
+			if tc.check != nil {
+				tc.check(t, cfg)
+			}
+		})
+	}
+}
+
+func TestGetConfigKeyRejectsUnknownKey(t *testing.T) {
+	var err error
+	out := captureStdout(t, func() { err = getConfigKey(&config.Config{}, "nonsense") })
+	if err == nil {
+		t.Fatalf("getConfigKey(nonsense) = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "unknown config key") || !strings.Contains(err.Error(), "nonsense") {
+		t.Errorf("error = %q, want it to mention the unknown config key", err.Error())
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("getConfigKey printed %q for an unknown key, want nothing", out)
+	}
+}
+
+// TestShowConfig checks that the dump actually carries the settings: the config
+// file path plus every value that is set. Asserting only that showConfig
+// returned nil would pass against an empty dump.
+func TestShowConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv("LNPM_CONFIG", configPath)
+
+	manageGitignore := false
+	cfg := &config.Config{
+		StorePath:       filepath.Join(t.TempDir(), "shown-store"),
+		LinkMode:        "copy",
+		ManageGitignore: &manageGitignore,
+		Hooks:           config.HooksConfig{PrePublish: "echo before"},
+	}
+
+	var err error
+	out := captureStdout(t, func() { err = showConfig(cfg) })
+	if err != nil {
+		t.Fatalf("showConfig() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"Config file: " + configPath,
+		"store_path: " + cfg.StorePath,
+		"link_mode: copy",
+		"manage_gitignore: false",
+		"pre_publish: echo before",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("showConfig output missing %q\n--- output ---\n%s", want, out)
+		}
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -102,45 +101,21 @@ func newDoctorStoreConfig(t *testing.T) string {
 	return dir
 }
 
-// captureDoctorStdout runs RunDoctor with os.Stdout redirected to a pipe and
-// returns what it printed. RunDoctor reports every check on stdout rather than
-// through its return value, so the findings are only readable this way.
-//
-// The reader goroutine starts before RunDoctor does, so it can write more than
-// the pipe buffer without deadlocking, and the teardown is deferred so
-// os.Stdout is restored however RunDoctor exits.
+// captureDoctorStdout runs RunDoctor and returns what it printed. RunDoctor
+// reports every check on stdout rather than through its return value, so the
+// findings are only readable this way.
 //
 // RunDoctor opens the database, which is cached for the process and would keep
 // a file handle inside the test's temp dir, so it is released on the way out.
-func captureDoctorStdout(t *testing.T) (out string) {
+func captureDoctorStdout(t *testing.T) string {
 	t.Helper()
 
 	db.ResetForTesting()
 	t.Cleanup(db.ResetForTesting)
 
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("Failed to create pipe: %v", err)
-	}
-
-	done := make(chan string, 1)
-	go func() {
-		data, _ := io.ReadAll(r)
-		done <- string(data)
-	}()
-
-	orig := os.Stdout
-	os.Stdout = w
-
-	defer func() {
-		os.Stdout = orig
-		_ = w.Close() // unblocks the reader goroutine
-		out = <-done
-		_ = r.Close()
-	}()
-
-	if err := RunDoctor(); err != nil {
-		t.Errorf("RunDoctor() error = %v", err)
-	}
-	return
+	return captureStdout(t, func() {
+		if err := RunDoctor(); err != nil {
+			t.Errorf("RunDoctor() error = %v", err)
+		}
+	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -34,5 +35,140 @@ func TestGetStorePathEnvWins(t *testing.T) {
 	}
 	if got != "/tmp/from-env" {
 		t.Errorf("GetStorePath = %q, want /tmp/from-env", got)
+	}
+}
+
+// TestSaveConfigRoundTrip checks that everything SaveConfig writes comes back
+// out of the file unchanged, and that the parent directory is created on the
+// way.
+//
+// The read-back goes through loadConfigFile rather than LoadConfig on purpose:
+// LoadConfig memoizes the first successful load in a package-level sync.Once
+// for the life of the test binary, so it would either return another test's
+// config or pin this one for everyone else. loadConfigFile reads the file every
+// time, which is what a round-trip needs.
+func TestSaveConfigRoundTrip(t *testing.T) {
+	// "nested" does not exist yet, so a SaveConfig that skipped MkdirAll would
+	// fail to write here.
+	configPath := filepath.Join(t.TempDir(), "nested", "config.yaml")
+	t.Setenv("LNPM_CONFIG", configPath)
+
+	manageGitignore := false
+	want := &Config{
+		StorePath:       filepath.Join(t.TempDir(), "custom-store"),
+		LinkMode:        "copy",
+		ManageGitignore: &manageGitignore,
+		Hooks:           HooksConfig{PostAdd: "echo added", SkipPrepare: true},
+	}
+
+	if err := SaveConfig(want); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	got, err := loadConfigFile()
+	if err != nil {
+		t.Fatalf("loadConfigFile: %v", err)
+	}
+
+	if got.StorePath != want.StorePath {
+		t.Errorf("StorePath = %q, want %q", got.StorePath, want.StorePath)
+	}
+	if got.LinkMode != want.LinkMode {
+		t.Errorf("LinkMode = %q, want %q", got.LinkMode, want.LinkMode)
+	}
+	if got.ManageGitignore == nil {
+		t.Errorf("ManageGitignore = nil, want a pointer to false")
+	} else if *got.ManageGitignore {
+		t.Errorf("ManageGitignore = true, want false")
+	}
+	if got.ShouldManageGitignore() {
+		t.Errorf("ShouldManageGitignore() = true, want false (saved value lost, fell back to the default)")
+	}
+	if got.Hooks.PostAdd != want.Hooks.PostAdd {
+		t.Errorf("Hooks.PostAdd = %q, want %q", got.Hooks.PostAdd, want.Hooks.PostAdd)
+	}
+	if !got.Hooks.SkipPrepare {
+		t.Errorf("Hooks.SkipPrepare = false, want true")
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read written config: %v", err)
+	}
+	raw := string(data)
+
+	// The values, not just the keys, have to be on disk: a marshal that emitted
+	// the key with an empty value would still round-trip past a key-only check.
+	for _, line := range []string{
+		"store_path: " + want.StorePath,
+		"link_mode: copy",
+		"manage_gitignore: false",
+		"post_add: echo added",
+		"skip_prepare: true",
+	} {
+		if !strings.Contains(raw, line) {
+			t.Errorf("written config missing %q\n--- file ---\n%s", line, raw)
+		}
+	}
+
+	// omitempty: keys for fields that were never set must not appear at all.
+	for _, absent := range []string{"pre_publish", "post_publish", "skip_post_add"} {
+		if strings.Contains(raw, absent) {
+			t.Errorf("written config contains unset key %q (omitempty lost)\n--- file ---\n%s", absent, raw)
+		}
+	}
+}
+
+// TestSaveConfigOmitsEveryUnsetField pins the omitempty tags on every field: an
+// all-zero Config must serialize to the empty mapping, with no keys at all.
+func TestSaveConfigOmitsEveryUnsetField(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv("LNPM_CONFIG", configPath)
+
+	if err := SaveConfig(&Config{}); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read written config: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "{}" {
+		t.Errorf("empty config serialized to %q, want \"{}\" (a field lost its omitempty)", got)
+	}
+}
+
+func TestGetConfigPathHonorsEnv(t *testing.T) {
+	want := filepath.Join(t.TempDir(), "elsewhere", "lnpm.yaml")
+	t.Setenv("LNPM_CONFIG", want)
+
+	if got := GetConfigPath(); got != want {
+		t.Errorf("GetConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestGetConfigPathDefaultsUnderHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("LNPM_CONFIG", "")   // empty is treated as unset, so the default applies
+	t.Setenv("HOME", home)        // os.UserHomeDir on unix
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir on windows
+
+	want := filepath.Join(home, ".lnpm", "config.yaml")
+	if got := GetConfigPath(); got != want {
+		t.Errorf("GetConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestGetPackageStorePath(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("LNPM_STORE", dir)
+
+	want := filepath.Join(dir, "store")
+	got, err := GetPackageStorePath()
+	if err != nil {
+		t.Fatalf("GetPackageStorePath: %v", err)
+	}
+	if got != want {
+		t.Errorf("GetPackageStorePath() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
`SaveConfig` was at 0%. Nothing verified that what it writes can be read back,
that it creates the parent directory, or that unset fields stay omitted — so a
YAML tag typo would have silently destroyed user settings on the next
`lnpm config <key> <value>`. `showConfig`, `getConfigKey` and `setConfigKey`
were never invoked either, including their user-facing validation errors.

No production code is changed.

## Coverage

| function | before | after |
| --- | --- | --- |
| `config.SaveConfig` | 0.0% | **71.4%** |
| `config.GetConfigPath` | 0.0% | **100%** |
| `config.GetPackageStorePath` | 0.0% | **75.0%** |
| `cli.showConfig` | 0.0% | **83.3%** |
| `cli.getConfigKey` | 0.0% | **100%** |
| `cli.setConfigKey` | 0.0% | **94.1%** |

Package totals: `internal/config` 27.3% → 47.0%, `internal/cli` 20.1% → 22.3%.
Nothing in `internal/cli/config.go` remains at 0%. The residual uncovered lines
are unreachable-in-test error returns (`MkdirAll`/`WriteFile`/`yaml.Marshal`
failures, `os.UserHomeDir` error).

## Not hollow — 20 mutations, all killed

18 by the implementer plus two re-run independently during review. The ones that
matter most, because they are exactly what a fake pass would look like:

- Delete `SaveConfig`'s `MkdirAll` → round-trip test fails (the test writes
  through a genuinely absent nested parent).
- Strip `,omitempty` from one YAML tag → fails. The omitempty assertion reads
  the **raw file bytes**, not a re-unmarshal, which would prove nothing about
  omitted keys.
- Sneak a `SaveConfig` call in before `link_mode`'s rejection → fails on the
  file-non-existence check. That is AC 3's "assert the config file was NOT
  written on validation failures" being a real assertion rather than a
  restatement of the error check.
- Make `link_mode` validation accept anything → fails.
- Blank a value while keeping its label (the hollow shape caught earlier in
  this milestone) → fails.

All six supported keys are covered — `store_path`, `link_mode`,
`manage_gitignore`, `hooks.pre_publish`, `hooks.post_publish`, `hooks.post_add`
— each asserted both in memory and re-read from disk, so a value that never
reached the file cannot pass.

## On acceptance criterion 4

*"Tests never rely on `LoadConfig` re-reading a file mid-process."* Honored: no
new test calls `LoadConfig`, `config.Get()` or `ResetForTesting`. Round-trips go
through `loadConfigFile` or unmarshal the file directly.

Worth recording that the brief's stated *reason* is now out of date —
`config.ResetForTesting()` exists (added by #161, after this issue was filed),
so the `sync.Once` is no longer unresettable. The criterion still stands and is
still the safer pattern, so it was followed as written.

## Review fixes also applied

- The new `captureStdout` made `captureDoctorStdout` a line-for-line duplicate
  in the same package; it now delegates instead. The three pre-existing doctor
  tests pass unchanged through it.
- Corrected a comment that overclaimed: `readSavedConfig` returns the persisted
  bytes only, with none of the defaults `loadConfigFile` layers on — which is
  the point, since it means a default cannot supply a value the write should
  have.
- Replaced a `map` range with a slice (nondeterministic iteration order, against
  the table style used everywhere else), unshadowed a `want` variable, and
  dropped an empty closure in favour of a nil guard.

Closes #183