### PR TITLE
Add a real multi-process store-contention e2e test

### DIFF
--- a/tests/add_test.go
+++ b/tests/add_test.go
@@ -153,7 +153,7 @@ func TestAddUpdatesExisting(t *testing.T) {
 
 // TestAddConcurrentSameProject tests concurrent adds to same project.
 func TestAddConcurrentSameProject(t *testing.T) {
-	t.Skip("Skipping: concurrent package.json writes cause race conditions, not realistic usage")
+	t.Skip("Skipping: concurrent in-process package.json writes cause race conditions, not realistic usage. Real concurrent use is covered by TestConcurrentProcessesSharedStore in tests/e2e/contention_test.go, which runs overlapping lnpm processes against one shared store.")
 	env := setupTest(t)
 
 	packages := []string{"pkg-a", "pkg-b", "pkg-c"}
@@ -176,7 +176,7 @@ func TestAddConcurrentSameProject(t *testing.T) {
 
 // TestAddConcurrentDifferentProjects tests concurrent adds to different projects.
 func TestAddConcurrentDifferentProjects(t *testing.T) {
-	t.Skip("Skipping: os.Chdir is not goroutine-safe, test creates artificial race condition")
+	t.Skip("Skipping: os.Chdir is not goroutine-safe, test creates artificial race condition. Real concurrent use is covered by TestConcurrentProcessesSharedStore in tests/e2e/contention_test.go, which runs overlapping lnpm processes against one shared store.")
 	env := setupTest(t)
 
 	env.simplePkg("shared-pkg")

--- a/tests/e2e/contention_test.go
+++ b/tests/e2e/contention_test.go
@@ -1,0 +1,266 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// contentionRounds is how many times each worker launches a real lnpm process
+// against the shared store. The two workers re-synchronize at the start of
+// every round, so a handful of rounds is enough to guarantee genuinely
+// overlapping processes without slowing the suite down.
+const contentionRounds = 6
+
+// invocation records the wall-clock window of one real lnpm process, so the
+// test can prove the two workers' processes actually overlapped rather than
+// assuming the start barrier did its job.
+type invocation struct {
+	worker string
+	round  int
+	start  time.Time
+	end    time.Time
+}
+
+// overlap returns how long two process lifetimes intersected in wall time. A
+// non-positive result means they never coexisted.
+func (i invocation) overlap(o invocation) time.Duration {
+	end := i.end
+	if o.end.Before(end) {
+		end = o.end
+	}
+	start := i.start
+	if o.start.After(start) {
+		start = o.start
+	}
+	return end.Sub(start)
+}
+
+// indicatesLockContention reports whether a failed lnpm run failed *because*
+// another process held the store's bbolt lock.
+//
+// internal/db opens bbolt with a lock timeout and turns bbolt's ErrTimeout into
+// "another lnpm process appears to be running (database is locked): timeout".
+// Anything else — a missing package, a bad manifest, a panic — is deliberately
+// NOT matched: those must fail the test.
+//
+// Deliberately not matching bare "timeout": this classifier decides whether a
+// failure is acceptable, so a marker broad enough to appear in unrelated output
+// would reclassify a real bug as an expected outcome. Erring wide here is the
+// dangerous direction. A reword of the wrapper cannot slip past unnoticed
+// either way — internal/db's own test pins the phrase (lockMessage, "another
+// lnpm process"), so it fails first.
+func indicatesLockContention(out string) bool {
+	lower := strings.ToLower(out)
+	for _, marker := range []string{
+		"another lnpm process appears to be running",
+		"database is locked",
+	} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestConcurrentProcessesSharedStore drives two real lnpm processes at ONE
+// shared store at the same time and proves that:
+//
+//   - every invocation either succeeds or fails with output that clearly names
+//     lock contention (any other failure fails the test),
+//   - the two processes genuinely overlapped in wall time (otherwise the test
+//     measures nothing),
+//   - the store is still usable afterwards and holds exactly the content of the
+//     last successful publish from each worker — i.e. contention did not corrupt
+//     or silently drop state.
+//
+// This test is the deliberate exception to the per-test-store rule described on
+// newStore: every other e2e test takes a private store so parallel binaries
+// never fight over the bbolt file lock, whereas this one shares a store
+// precisely to make them fight. It therefore does NOT call t.Parallel() — it
+// must not compete with the rest of the suite for CPU while it is timing
+// overlapping processes.
+//
+// It needs no node runtime (nothing is require()d here), so it runs everywhere
+// Go runs.
+func TestConcurrentProcessesSharedStore(t *testing.T) {
+	store := newStore(t)
+
+	const pkgA, pkgB = "contend-lib-a", "contend-lib-b"
+	repoA := makePkgDir(t, pkgA, `module.exports = "a-v0";`+"\n")
+	repoB := makePkgDir(t, pkgB, `module.exports = "b-v0";`+"\n")
+	app := makeAppDir(t, "contend-app")
+
+	// Warm-up. Only pkg-a reaches the store here; pkg-b is published solely by
+	// worker B inside the contention phase, so the health check below cannot
+	// pass unless worker B really did work.
+	runLNPM(t, store, repoA, "publish")
+	runLNPM(t, store, app, "add", pkgA)
+
+	body := func(worker string, round int) string {
+		return fmt.Sprintf("module.exports = %q;\n", fmt.Sprintf("%s-v%d", strings.ToLower(worker), round))
+	}
+
+	workers := []struct{ name, dir string }{{"A", repoA}, {"B", repoB}}
+
+	var (
+		mu          sync.Mutex
+		invocations []invocation
+		unexpected  []string
+		contended   int
+		lastOK      = map[string]int{}
+	)
+
+	for round := 1; round <= contentionRounds; round++ {
+		// Each worker republishes its own package with fresh content, so every
+		// round is a real write to the shared database, not a no-op. The files
+		// are written from the test goroutine (writeFile uses t.Fatalf) and
+		// each worker only ever touches its own repo.
+		writeFile(t, filepath.Join(repoA, "index.js"), body("A", round))
+		writeFile(t, filepath.Join(repoB, "index.js"), body("B", round))
+
+		// A per-round barrier: both goroutines block on start, so the two
+		// processes are launched within microseconds of each other and their
+		// lifetimes are forced to overlap. Re-synchronizing every round is what
+		// keeps the overlap deterministic instead of hoping one long-running
+		// loop happens to interleave with the other.
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for _, w := range workers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+
+				begin := time.Now()
+				out, err := runLNPMErr(t, store, w.dir, "publish")
+				rec := invocation{worker: w.name, round: round, start: begin, end: time.Now()}
+
+				mu.Lock()
+				defer mu.Unlock()
+				invocations = append(invocations, rec)
+				switch {
+				case err == nil:
+					lastOK[w.name] = round
+				case indicatesLockContention(out):
+					contended++
+				default:
+					unexpected = append(unexpected,
+						fmt.Sprintf("worker %s, round %d: %v\n%s", w.name, round, err, out))
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+	}
+
+	// AC: any failure that is not lock contention is a bug.
+	if len(unexpected) > 0 {
+		t.Fatalf("%d lnpm invocation(s) failed for reasons other than store lock contention:\n%s",
+			len(unexpected), strings.Join(unexpected, "\n"))
+	}
+
+	// Overlap evidence. Without it the rest of the test proves nothing: two
+	// processes that never coexist never contend.
+	overlapping := 0
+	minOverlap := time.Duration(0)
+	for round := 1; round <= contentionRounds; round++ {
+		a, okA := invocationFor(invocations, "A", round)
+		b, okB := invocationFor(invocations, "B", round)
+		if !okA || !okB {
+			continue
+		}
+		if d := a.overlap(b); d > 0 {
+			if overlapping == 0 || d < minOverlap {
+				minOverlap = d
+			}
+			overlapping++
+		}
+	}
+	if overlapping == 0 {
+		t.Fatalf("no round had overlapping lnpm processes across %d rounds — the workers ran sequentially, so this test exercised no contention at all\n%s",
+			contentionRounds, describeInvocations(invocations))
+	}
+	// The contention count is normally 0: internal/db waits up to openTimeout
+	// (30s) for the lock, and a publish takes milliseconds, so the loser of each
+	// round blocks and then wins rather than failing. That is the behaviour
+	// being pinned — overlapping processes both complete correctly.
+	//
+	// The contention branch above is therefore a regression guard, not dead
+	// code: shortening openTimeout to 1ms makes exactly one invocation per round
+	// report contention and the test still passes, which is what confirms these
+	// processes genuinely fight for the bbolt lock rather than merely coexisting.
+	t.Logf("contention: %d/%d rounds had genuinely overlapping lnpm processes (shortest overlap %v), %d invocation(s) reported lock contention",
+		overlapping, contentionRounds, minOverlap, contended)
+
+	// Both workers must have landed at least one publish, otherwise "no
+	// failures" is vacuously true.
+	for _, w := range workers {
+		if lastOK[w.name] == 0 {
+			t.Fatalf("worker %s never completed a successful publish, so it never touched the shared store", w.name)
+		}
+	}
+
+	// The store must still be usable, and must serve exactly the content of the
+	// last publish that succeeded for each package — proving contention neither
+	// corrupted the database nor lost a committed write.
+	runLNPM(t, store, app, "add", pkgA, pkgB)
+	for _, tc := range []struct {
+		pkg, worker string
+	}{{pkgA, "A"}, {pkgB, "B"}} {
+		assertSymlink(t, filepath.Join(app, "node_modules", tc.pkg))
+		assertDepValue(t, app, tc.pkg, "file:.lnpm/"+tc.pkg)
+
+		linked := filepath.Join(app, ".lnpm", tc.pkg, "index.js")
+		got, err := os.ReadFile(linked)
+		if err != nil {
+			t.Fatalf("failed to read linked %s after contention: %v", linked, err)
+		}
+		if want := body(tc.worker, lastOK[tc.worker]); string(got) != want {
+			t.Fatalf("after contention, %s holds %q, want %q (last successful publish was round %d)",
+				linked, got, want, lastOK[tc.worker])
+		}
+	}
+
+	// A final read-side command must still work against the shared database.
+	status := runLNPM(t, store, app, "status")
+	for _, pkg := range []string{pkgA, pkgB} {
+		if !strings.Contains(status, pkg) {
+			t.Fatalf("expected `lnpm status` to list %s after contention, got:\n%s", pkg, status)
+		}
+	}
+}
+
+// invocationFor returns the recorded process window for a worker in a round.
+func invocationFor(all []invocation, worker string, round int) (invocation, bool) {
+	for _, inv := range all {
+		if inv.worker == worker && inv.round == round {
+			return inv, true
+		}
+	}
+	return invocation{}, false
+}
+
+// describeInvocations renders every recorded process window relative to the
+// earliest start, so a failure message shows why the workers did not overlap.
+func describeInvocations(all []invocation) string {
+	if len(all) == 0 {
+		return "(no invocations recorded)"
+	}
+	base := all[0].start
+	for _, inv := range all {
+		if inv.start.Before(base) {
+			base = inv.start
+		}
+	}
+	var b strings.Builder
+	for _, inv := range all {
+		fmt.Fprintf(&b, "  worker %s round %d: %v -> %v\n",
+			inv.worker, inv.round, inv.start.Sub(base), inv.end.Sub(base))
+	}
+	return b.String()
+}

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -14,10 +14,11 @@ import (
 // newStore returns a fresh, isolated LNPM_STORE directory for a single test.
 //
 // Each test gets its OWN store (and therefore its own bbolt database). lnpm
-// opens the database with an exclusive file lock and only a 1s timeout, so
-// sharing one store across t.Parallel() tests would race two binaries on that
-// lock. A per-test store removes the contention entirely while keeping the
-// store off the real ~/.lnpm.
+// opens the database with an exclusive file lock, so sharing one store across
+// t.Parallel() tests would serialize every binary invocation on that lock. A
+// per-test store removes the contention entirely while keeping the store off
+// the real ~/.lnpm. TestConcurrentProcessesSharedStore is the one deliberate
+// exception — it shares a store precisely to exercise that lock.
 func newStore(t *testing.T) string {
 	t.Helper()
 	return t.TempDir()
@@ -32,6 +33,22 @@ func newStore(t *testing.T) string {
 func runLNPM(t *testing.T, store, dir string, args ...string) string {
 	t.Helper()
 
+	out, err := runLNPMErr(t, store, dir, args...)
+	if err != nil {
+		t.Fatalf("lnpm %s (dir=%s) failed: %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+	return out
+}
+
+// runLNPMErr is runLNPM without the t.Fatalf: it returns the combined output
+// and the exit error so the caller can inspect a failure instead of dying on
+// it. Contention tests need this — a run that loses the store lock is a valid
+// outcome to assert on, not a test failure.
+//
+// It is safe to call from a goroutine: it only uses t for t.Helper().
+func runLNPMErr(t *testing.T, store, dir string, args ...string) (string, error) {
+	t.Helper()
+
 	cmd := exec.Command(lnpmBin, args...)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(),
@@ -40,10 +57,7 @@ func runLNPM(t *testing.T, store, dir string, args ...string) string {
 	)
 
 	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("lnpm %s (dir=%s) failed: %v\n%s", strings.Join(args, " "), dir, err, out)
-	}
-	return string(out)
+	return string(out), err
 }
 
 // runNode runs `node -e <script>` with cmd.Dir=dir and returns trimmed stdout.


### PR DESCRIPTION
Two lnpm processes touching the store at once is ordinary use — `push` in one
terminal while `add` runs in another — and nothing tested it. The in-process
suite *cannot*: it drives working directories through `os.Chdir`, which is
process-global. The e2e suite gives every test its own store precisely to avoid
contention, so it never saw it either. No production code is changed.

## The premise the brief was built on is stale

The brief says the bbolt lock timeout is 1 second and that a losing process
fails with a raw bbolt message. #165 changed that to
`var openTimeout = 30 * time.Second` with an explicit `ErrTimeout` branch naming
the store. So contending processes now **wait and win** rather than failing —
AC 2's first branch. Forcing a real timeout would mean holding the lock 30+
seconds on three CI platforms, which is not a trade worth making; `internal/db`
already unit-tests the timeout message. The brief's step 3 ("file a UX issue if
the loser error is raw") is already resolved, so nothing was filed.

## Why this test isn't hollow

A contention test is unusually easy to fake — if the goroutines don't really
overlap, or the assertion accepts any outcome, it proves nothing while looking
thorough. So:

- **Overlap is measured, not assumed.** Every invocation records its start/end;
  the test computes the intersection per round and **fails if no round
  overlapped**. Observed: 6/6 rounds overlap, shortest ~20 ms against a ~20 ms
  process lifetime. Serializing the workers makes the test fail with a full
  interval dump.
- **The overlap is a real lock fight, not incidental coexistence.** Setting
  `openTimeout = 1ms` makes exactly one invocation per round report contention —
  6 of 12 — with the test still passing. That also exercises the contention
  branch end-to-end, so it is a regression guard rather than dead code.
- **The health check catches stale state, not just liveness.** Rolling the
  database back to a mid-run snapshot — valid, both packages present, only the
  *contents* stale — fails on `holds "a-v2", want "a-v6"`. Garbage over the db
  and a rollback to the warm-up snapshot both fail too.
- **The classifier is load-bearing.** Injecting a genuine non-contention error
  fails the test; widening the matcher to accept any string makes that same
  mutation pass. 10 mutations in total across implementation and review, all
  behaving as expected.

`-count=10`: 10/10 pass, ~0.48 s each, 6/6 overlapping rounds every time. The
test adds ~0.4 s to the suite and needs no node, so it runs everywhere Go does.

## Review fixes also applied

- `runLNPM` now composes onto `runLNPMErr` instead of repeating the
  `LNPM_STORE`/`LNPM_CONFIG` isolation setup in both — the store-isolation
  guarantee documented on `runLNPM` would otherwise have silently stopped
  applying to one of them.
- Narrowed the contention classifier: it matched bare `"timeout"`, so any future
  output containing that substring would have reclassified a real bug as an
  acceptable outcome. Widening what a test accepts is the dangerous direction.
  Verified the narrower matcher still catches all 6 contention failures under
  the 1 ms timeout, since the real message carries "another lnpm process appears
  to be running".
- Corrected `newStore`'s doc comment, which still asserted the 1 s timeout.

## AC 5

The two permanently-skipped in-process concurrency tests now name this test as
the real coverage. The optional working-directory refactor was not attempted —
the brief marks it out of scope for closing this issue.

Closes #184