### PR TITLE
Add `lnpm pull` to sync linked packages from the store

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -331,6 +331,36 @@ lnpm push --skip-hooks
    `node_modules/{package}` never sees an empty or half-written package, and a
    failed or interrupted push leaves the previous package in place.
 
+### `lnpm pull [package...]`
+
+Refresh linked packages from the store. The counterpart to `push`: where `push`
+sends a package out to its consumers, `pull` fetches the store's current
+contents into the consumer that runs it.
+
+```bash
+# Refresh every package in lnpm.lock
+lnpm pull
+
+# Refresh only the named packages
+lnpm pull my-package other-pkg
+```
+
+**Process:**
+1. Read the linked set from `lnpm.lock` (all of it, or just the named packages,
+   which must already be linked here — `pull` refreshes links, it never creates
+   them)
+2. For each package, look it up in the store; skip it when the lock entry
+   already matches the store's version and content hash
+3. Hard link the store's current files into a temporary directory and rename it
+   over `.lnpm/{package}/`, exactly as `add` does
+4. Update the entry in `lnpm.lock`, preserving the original `package.json`
+   specifier recorded by `add`
+
+`package.json` is never touched: the `file:.lnpm/{package}` reference it holds
+is already correct, and only the contents behind it change. Nothing is written
+to bbolt either — publishing updates the package row in place, so the link row
+`add` recorded still points at the right package.
+
 ### `lnpm status`
 
 Show current state of all links.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ lnpm push
 | `lnpm publish` | Publish package to local store |
 | `lnpm add <pkg...>` | Add package(s) from store to project |
 | `lnpm remove <pkg>` | Remove linked package |
+| `lnpm pull [pkg...]` | Sync linked packages with the store (all of them when no name is given) |
 | `lnpm push` | Push changes to all linked projects |
 | `lnpm status` | Show current project's links |
 | `lnpm list` | List this project's linked packages (`--store` lists the store, `--projects` lists consumers) |

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -94,6 +94,31 @@ Examples:
 	},
 }
 
+// pullCmd refreshes linked packages from the store
+var pullCmd = &cobra.Command{
+	Use:   "pull [package...]",
+	Short: "Sync linked packages with the store",
+	Long: `Re-link packages already linked in this project to the version now in
+the store, picking up anything published since they were added.
+
+With no arguments every package in lnpm.lock is refreshed.
+
+This command:
+  1. Finds each package's current version in the store
+  2. Refreshes .lnpm/{package}/
+  3. Updates lnpm.lock
+
+package.json is never modified: its reference already points at .lnpm/{package}.
+
+Examples:
+  lnpm pull              # Refresh every linked package
+  lnpm pull my-package   # Refresh one package`,
+	Args: cobra.ArbitraryArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return RunPull(args)
+	},
+}
+
 // pushCmd pushes updates to all linked projects
 var pushCmd = &cobra.Command{
 	Use:   "push",

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/pedrosousa13/lnpm/internal/db"
+	"github.com/pedrosousa13/lnpm/internal/link"
+	"github.com/pedrosousa13/lnpm/internal/store"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
+)
+
+// RunPull re-links packages already linked in this project to whatever the
+// store now holds for them. With no names it refreshes every package in
+// lnpm.lock.
+//
+// Unlike add, pull never touches package.json: the reference there already
+// points at .lnpm/<pkg>, and only the contents behind it and the lock entry
+// change when the source package is republished.
+func RunPull(packageNames []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	database, err := db.GetDB()
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+
+	lock, err := lockfile.Load(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to load lock file: %w", err)
+	}
+
+	// Named packages must already be linked here - pull refreshes links, it does
+	// not create them. Check them all before any linking so a typo cannot leave
+	// the project half-pulled.
+	names := packageNames
+	if len(names) == 0 {
+		names = lock.List()
+		if len(names) == 0 {
+			fmt.Println("No linked packages to pull")
+			return nil
+		}
+	} else {
+		for _, name := range names {
+			if !lock.Has(name) {
+				return fmt.Errorf("package %s is not linked in this project", name)
+			}
+		}
+	}
+
+	s, err := store.New()
+	if err != nil {
+		return fmt.Errorf("failed to access store: %w", err)
+	}
+
+	linker := link.New(cwd)
+
+	var failed []error
+	pulled := 0
+	lockChanged := false
+	lastVersion := ""
+
+	for _, name := range names {
+		entry, _ := lock.Get(name)
+
+		pkg, err := database.GetPackageByName(name)
+		if err != nil {
+			failed = append(failed, fmt.Errorf("%s: failed to look up package: %w", name, err))
+			continue
+		}
+		if pkg == nil {
+			failed = append(failed, fmt.Errorf("%s: not found in store", name))
+			continue
+		}
+
+		fmt.Printf("Pulling %s... ", name)
+
+		if entry.Version == pkg.Version && entry.Hash == pkg.ContentHash {
+			fmt.Printf("already up to date (%s)\n", pkg.Version)
+			pulled++
+			lastVersion = pkg.Version
+			continue
+		}
+
+		files, err := s.GetFiles(pkg.Name, pkg.ContentHash)
+		if err != nil {
+			fmt.Println()
+			failed = append(failed, fmt.Errorf("%s: failed to get package files: %w", name, err))
+			continue
+		}
+
+		if _, err := linker.Link(pkg.Name, pkg.StorePath, files); err != nil {
+			fmt.Println()
+			failed = append(failed, fmt.Errorf("%s: failed to link package: %w", name, err))
+			continue
+		}
+
+		// Keep the original specifier: it lives only in the lock file once add
+		// has rewritten package.json, and remove/retreat need it to restore the
+		// dependency.
+		lock.Add(name, lockfile.Package{
+			Version:         pkg.Version,
+			Hash:            pkg.ContentHash,
+			Source:          pkg.SourcePath,
+			Linked:          time.Now(),
+			OriginalVersion: entry.OriginalVersion,
+		})
+		lockChanged = true
+
+		fmt.Printf("updated %s -> %s\n", entry.Version, pkg.Version)
+		pulled++
+		lastVersion = pkg.Version
+	}
+
+	if lockChanged {
+		if err := lock.Save(cwd); err != nil {
+			return fmt.Errorf("failed to save lock file: %w", err)
+		}
+	}
+
+	if len(failed) > 0 {
+		fmt.Printf("\n%s Some packages failed:\n", iconWarn())
+		for _, err := range failed {
+			fmt.Printf("  - %v\n", err)
+		}
+	}
+
+	if pulled == 1 && len(packageNames) == 1 {
+		fmt.Printf("%s Pulled %s@%s\n", iconOK(), names[0], lastVersion)
+	} else if pulled > 0 {
+		fmt.Printf("%s Pulled %d package(s)\n", iconOK(), pulled)
+	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("%d of %d package(s) failed to pull", len(failed), len(names))
+	}
+
+	return nil
+}

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/pedrosousa13/lnpm/internal/db"
@@ -44,6 +46,9 @@ func RunPull(packageNames []string) error {
 			fmt.Println("No linked packages to pull")
 			return nil
 		}
+		// lock.List() ranges over a map, so sort to keep the report stable
+		// between runs.
+		sort.Strings(names)
 	} else {
 		for _, name := range names {
 			if !lock.Has(name) {
@@ -60,7 +65,8 @@ func RunPull(packageNames []string) error {
 	linker := link.New(cwd)
 
 	var failed []error
-	pulled := 0
+	refreshed := 0
+	skipped := 0
 	lockChanged := false
 	lastVersion := ""
 
@@ -73,7 +79,7 @@ func RunPull(packageNames []string) error {
 			continue
 		}
 		if pkg == nil {
-			failed = append(failed, fmt.Errorf("%s: not found in store", name))
+			failed = append(failed, fmt.Errorf("%s: not found in store - did you run 'lnpm publish' in the package directory", name))
 			continue
 		}
 
@@ -81,20 +87,26 @@ func RunPull(packageNames []string) error {
 
 		if entry.Version == pkg.Version && entry.Hash == pkg.ContentHash {
 			fmt.Printf("already up to date (%s)\n", pkg.Version)
-			pulled++
-			lastVersion = pkg.Version
+			skipped++
 			continue
 		}
 
+		// Every path out of here closes the "Pulling <name>... " line, so a
+		// failure names itself where it happened instead of leaving the line
+		// dangling until the end-of-run report.
 		files, err := s.GetFiles(pkg.Name, pkg.ContentHash)
 		if err != nil {
-			fmt.Println()
+			fmt.Printf("failed to get package files: %v\n", err)
 			failed = append(failed, fmt.Errorf("%s: failed to get package files: %w", name, err))
 			continue
 		}
 
+		// The link type Link reports is deliberately dropped, and no db link row
+		// is written: publishing updates the existing package row in place, so
+		// the row add recorded still points at the package pull just linked, and
+		// no command surfaces the stored link type.
 		if _, err := linker.Link(pkg.Name, pkg.StorePath, files); err != nil {
-			fmt.Println()
+			fmt.Printf("failed to link package: %v\n", err)
 			failed = append(failed, fmt.Errorf("%s: failed to link package: %w", name, err))
 			continue
 		}
@@ -112,14 +124,27 @@ func RunPull(packageNames []string) error {
 		lockChanged = true
 
 		fmt.Printf("updated %s -> %s\n", entry.Version, pkg.Version)
-		pulled++
+		refreshed++
 		lastVersion = pkg.Version
 	}
 
+	// A failed save must not swallow the per-package failures: both are
+	// reported, and both are returned.
+	var saveErr error
 	if lockChanged {
 		if err := lock.Save(cwd); err != nil {
-			return fmt.Errorf("failed to save lock file: %w", err)
+			saveErr = fmt.Errorf("failed to save lock file: %w", err)
 		}
+	}
+
+	// The success line comes first so a partially failed run ends on the warning
+	// block it exits non-zero for.
+	if refreshed == 1 && len(packageNames) == 1 {
+		fmt.Printf("%s Pulled %s@%s\n", iconOK(), names[0], lastVersion)
+	} else if refreshed > 0 {
+		fmt.Printf("%s Pulled %d package(s)\n", iconOK(), refreshed)
+	} else if skipped > 0 && len(failed) == 0 {
+		fmt.Printf("%s Already up to date\n", iconOK())
 	}
 
 	if len(failed) > 0 {
@@ -128,16 +153,13 @@ func RunPull(packageNames []string) error {
 			fmt.Printf("  - %v\n", err)
 		}
 	}
-
-	if pulled == 1 && len(packageNames) == 1 {
-		fmt.Printf("%s Pulled %s@%s\n", iconOK(), names[0], lastVersion)
-	} else if pulled > 0 {
-		fmt.Printf("%s Pulled %d package(s)\n", iconOK(), pulled)
+	if saveErr != nil {
+		fmt.Printf("\n%s %v\n", iconWarn(), saveErr)
 	}
 
+	var pullErr error
 	if len(failed) > 0 {
-		return fmt.Errorf("%d of %d package(s) failed to pull", len(failed), len(names))
+		pullErr = fmt.Errorf("%d of %d package(s) failed to pull", len(failed), len(names))
 	}
-
-	return nil
+	return errors.Join(pullErr, saveErr)
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -71,6 +71,7 @@ func init() {
 	rootCmd.AddCommand(publishCmd)
 	rootCmd.AddCommand(addCmd)
 	rootCmd.AddCommand(removeCmd)
+	rootCmd.AddCommand(pullCmd)
 	rootCmd.AddCommand(pushCmd)
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.AddCommand(listCmd)

--- a/tests/e2e/pull_test.go
+++ b/tests/e2e/pull_test.go
@@ -1,0 +1,88 @@
+package e2e
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// libManifest renders a publishable package.json at an explicit version, so a
+// lib can be republished as a new version between runs. pkgManifest in
+// depth_test.go always renders 1.0.0, which a pull test cannot move off.
+func libManifest(name, version string) string {
+	return fmt.Sprintf("{\n  \"name\": %s,\n  \"version\": %s,\n  \"main\": \"index.js\"\n}\n",
+		jsString(name), jsString(version))
+}
+
+// TestMultiPackagePull proves the whole point of `lnpm pull` end to end, with
+// the real binary and real node: two libs are published and added to one app,
+// both are then republished WITHOUT --push (so the app keeps resolving the old
+// contents), and a single argument-less `lnpm pull` in the app brings both up
+// to date through the existing node_modules symlinks.
+func TestMultiPackagePull(t *testing.T) {
+	t.Parallel()
+	if !nodeAvailable {
+		t.Skip("node not available; skipping real-resolution e2e test")
+	}
+
+	const pkgA, pkgB = "pull-lib-a", "pull-lib-b"
+	libA := makePkgDir(t, pkgA, `module.exports = "a-v1";`+"\n")
+	libB := makePkgDir(t, pkgB, `module.exports = "b-v1";`+"\n")
+	app := makeAppDir(t, "pull-app")
+	store := newStore(t)
+
+	runLNPM(t, store, libA, "publish")
+	runLNPM(t, store, libB, "publish")
+	runLNPM(t, store, app, "add", pkgA, pkgB)
+
+	for _, pkg := range []string{pkgA, pkgB} {
+		assertSymlink(t, filepath.Join(app, "node_modules", pkg))
+		assertDepValue(t, app, pkg, "file:.lnpm/"+pkg)
+	}
+
+	script := fmt.Sprintf(`process.stdout.write(require(%s)+"|"+require(%s))`, jsString(pkgA), jsString(pkgB))
+	if got := runNode(t, app, script); got != "a-v1|b-v1" {
+		t.Fatalf("expected node to resolve both libs to \"a-v1|b-v1\", got %q", got)
+	}
+
+	// Republish both at 2.0.0 without --push: the app must still see v1.
+	writeFile(t, filepath.Join(libA, "package.json"), libManifest(pkgA, "2.0.0"))
+	writeFile(t, filepath.Join(libA, "index.js"), `module.exports = "a-v2";`+"\n")
+	writeFile(t, filepath.Join(libB, "package.json"), libManifest(pkgB, "2.0.0"))
+	writeFile(t, filepath.Join(libB, "index.js"), `module.exports = "b-v2";`+"\n")
+	runLNPM(t, store, libA, "publish")
+	runLNPM(t, store, libB, "publish")
+
+	if got := runNode(t, app, script); got != "a-v1|b-v1" {
+		t.Fatalf("publish without --push must leave the app stale, but node resolved %q", got)
+	}
+
+	// One pull, no arguments: every linked package moves to the store's version.
+	out := runLNPM(t, store, app, "pull")
+	for _, want := range []string{
+		"Pulling " + pkgA + "... updated 1.0.0 -> 2.0.0",
+		"Pulling " + pkgB + "... updated 1.0.0 -> 2.0.0",
+		"Pulled 2 package(s)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected pull output to contain %q, got:\n%s", want, out)
+		}
+	}
+
+	if got := runNode(t, app, script); got != "a-v2|b-v2" {
+		t.Fatalf("after pull, expected node to resolve both libs to \"a-v2|b-v2\", got %q", got)
+	}
+
+	// The symlinks the app resolves through survived the relink, and
+	// package.json was never touched.
+	for _, pkg := range []string{pkgA, pkgB} {
+		assertSymlink(t, filepath.Join(app, "node_modules", pkg))
+		assertDepValue(t, app, pkg, "file:.lnpm/"+pkg)
+	}
+
+	// A second pull has nothing left to do.
+	if out := runLNPM(t, store, app, "pull"); !strings.Contains(out, "already up to date") {
+		t.Fatalf("expected a second pull to report everything already up to date, got:\n%s", out)
+	}
+}

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -656,6 +656,22 @@ func (te *TestEnvironment) simplePkg(name string) string {
 	})
 }
 
+// republish rewrites an already published package's source with a new version
+// and index.js, then publishes it again WITHOUT --push, so linked projects are
+// deliberately left stale. That stale state is exactly what pull has to fix.
+// pkgDir need not be the directory the package was first published from -
+// passing a different one republishes the same package from a new source path.
+// The cwd is left inside the package directory.
+func (te *TestEnvironment) republish(pkgDir, name, version, indexJS string) {
+	te.t.Helper()
+	te.chdir(pkgDir)
+	te.writeFile(filepath.Join(pkgDir, "package.json"), `{"name":"`+name+`","version":"`+version+`"}`)
+	te.writeFile(filepath.Join(pkgDir, "index.js"), indexJS)
+	if err := cli.RunPublish(false, false, false, false); err != nil {
+		te.t.Fatalf("Failed to republish %s@%s: %v", name, version, err)
+	}
+}
+
 // newProject creates an empty project (package.json only) and chdirs into it.
 func (te *TestEnvironment) newProject(name string) string {
 	te.t.Helper()

--- a/tests/pull_permissions_test.go
+++ b/tests/pull_permissions_test.go
@@ -1,0 +1,68 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
+)
+
+// A pull that both fails on a package and then fails to save the lock file must
+// report both. Returning only the save error would hide which packages could not
+// be pulled, which is the half the user can actually act on.
+func TestPullReportsPackageFailuresWhenLockSaveFails(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("save-fail-pkg")
+	projectDir := env.newProject("test-project")
+	env.addPkg(projectDir, "save-fail-pkg", false, false)
+
+	// A second, unpullable entry, so the run has a per-package failure to lose.
+	lock, err := lockfile.Load(projectDir)
+	if err != nil {
+		t.Fatalf("Failed to load lockfile: %v", err)
+	}
+	lock.Add("ghost-pkg", lockfile.Package{Version: "1.0.0", Hash: "deadbeefdeadbeef", Source: "/nowhere", Linked: time.Now()})
+	if err := lock.Save(projectDir); err != nil {
+		t.Fatalf("Failed to save lockfile: %v", err)
+	}
+
+	env.republish(pkgDir, "save-fail-pkg", "2.0.0", "module.exports = 'v2';")
+
+	// Read-only lock file: loading it and linking the package still work, only
+	// writing the refreshed entries back fails.
+	lockPath := filepath.Join(projectDir, "lnpm.lock")
+	if err := os.Chmod(lockPath, 0444); err != nil {
+		t.Fatalf("Failed to chmod lnpm.lock: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(lockPath, 0644) })
+
+	env.chdir(projectDir)
+	var pullErr error
+	out := captureStdout(t, func() { pullErr = cli.RunPull(nil) })
+
+	if pullErr == nil {
+		t.Fatal("Expected an error when the lock file cannot be saved")
+	}
+	if !strings.Contains(pullErr.Error(), "failed to save lock file") {
+		t.Errorf("Expected the returned error to report the failed save, got: %v", pullErr)
+	}
+	if !strings.Contains(pullErr.Error(), "1 of 2 package(s) failed to pull") {
+		t.Errorf("Expected the returned error to also report the failed package, got: %v", pullErr)
+	}
+	if !strings.Contains(out, "ghost-pkg: not found in store") {
+		t.Errorf("Expected ghost-pkg to still be reported, got:\n%s", out)
+	}
+	if !strings.Contains(out, "failed to save lock file") {
+		t.Errorf("Expected the failed save to be reported, got:\n%s", out)
+	}
+
+	// The save really did fail: the lock file still holds the pre-pull entry.
+	assertLockVersion(t, env, projectDir, "save-fail-pkg", "1.0.0")
+}

--- a/tests/pull_test.go
+++ b/tests/pull_test.go
@@ -11,31 +11,17 @@ import (
 	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
 
-// republish rewrites an already published package's source with a new version
-// and index.js, then publishes it again WITHOUT --push, so linked projects are
-// deliberately left stale. That stale state is exactly what pull has to fix.
-// The cwd is left inside the package directory.
-func (te *TestEnvironment) republish(pkgDir, name, version, indexJS string) {
-	te.t.Helper()
-	te.chdir(pkgDir)
-	te.writeFile(filepath.Join(pkgDir, "package.json"), `{"name":"`+name+`","version":"`+version+`"}`)
-	te.writeFile(filepath.Join(pkgDir, "index.js"), indexJS)
-	if err := cli.RunPublish(false, false, false, false); err != nil {
-		te.t.Fatalf("Failed to republish %s@%s: %v", name, version, err)
-	}
-}
-
 // lockEntry returns a project's lock entry for pkg, failing if it has none.
-func lockEntry(t *testing.T, projectDir, pkg string) lockfile.Package {
+func lockEntry(t *testing.T, env *TestEnvironment, projectDir, pkg string) lockfile.Package {
 	t.Helper()
-	lock, err := lockfile.Load(projectDir)
-	if err != nil {
-		t.Fatalf("Failed to load lockfile: %v", err)
-	}
-	entry, ok := lock.Get(pkg)
-	if !ok {
-		t.Fatalf("Package %s not in lockfile", pkg)
-	}
+	var entry lockfile.Package
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		found, ok := lock.Get(pkg)
+		if !ok {
+			t.Fatalf("Package %s not in lockfile", pkg)
+		}
+		entry = found
+	})
 	return entry
 }
 
@@ -50,9 +36,9 @@ func readBytes(t *testing.T, path string) []byte {
 }
 
 // assertLockVersion checks a package's recorded version in the project's lockfile.
-func assertLockVersion(t *testing.T, projectDir, pkg, want string) {
+func assertLockVersion(t *testing.T, env *TestEnvironment, projectDir, pkg, want string) {
 	t.Helper()
-	if got := lockEntry(t, projectDir, pkg).Version; got != want {
+	if got := lockEntry(t, env, projectDir, pkg).Version; got != want {
 		t.Errorf("Expected %s at version %s in lockfile, got %s", pkg, want, got)
 	}
 }
@@ -78,8 +64,52 @@ func TestPullAllRefreshesEveryLinkedPackage(t *testing.T) {
 
 	env.AssertLinkedFileContent(projectDir, "pull-a", "index.js", "module.exports = 'a-v2';")
 	env.AssertLinkedFileContent(projectDir, "pull-b", "index.js", "module.exports = 'b-v2';")
-	assertLockVersion(t, projectDir, "pull-a", "2.0.0")
-	assertLockVersion(t, projectDir, "pull-b", "3.0.0")
+	assertLockVersion(t, env, projectDir, "pull-a", "2.0.0")
+	assertLockVersion(t, env, projectDir, "pull-b", "3.0.0")
+
+	// The relink must leave the link every consumer resolves through intact:
+	// .lnpm/<pkg> still there, node_modules/<pkg> still a symlink into it.
+	for _, name := range []string{"pull-a", "pull-b"} {
+		env.AssertFilesLinked(projectDir, name)
+		env.AssertSymlinkExists(projectDir, name)
+	}
+}
+
+// TestPullAllReportsInSortedOrder pins that the no-argument form reports
+// packages in name order. The set comes from a map, so an unsorted
+// implementation gets the right order by luck often enough that one run proves
+// nothing - the pull is repeated, and every repeat has to agree.
+func TestPullAllReportsInSortedOrder(t *testing.T) {
+	env := setupTest(t)
+
+	names := []string{"order-delta", "order-bravo", "order-charlie", "order-alpha"}
+	projectDir := env.newProject("test-project")
+	for _, name := range names {
+		env.simplePkg(name)
+		env.addPkg(projectDir, name, false, false)
+	}
+
+	wantOrder := []string{"order-alpha", "order-bravo", "order-charlie", "order-delta"}
+	for run := 0; run < 4; run++ {
+		env.chdir(projectDir)
+		out := captureStdout(t, func() {
+			if err := cli.RunPull(nil); err != nil {
+				t.Errorf("RunPull: %v", err)
+			}
+		})
+
+		at := -1
+		for _, name := range wantOrder {
+			idx := strings.Index(out, "Pulling "+name+"...")
+			if idx < 0 {
+				t.Fatalf("Run %d: expected %s to be reported, got:\n%s", run, name, out)
+			}
+			if idx < at {
+				t.Fatalf("Run %d: expected packages reported in name order %v, got:\n%s", run, wantOrder, out)
+			}
+			at = idx
+		}
+	}
 }
 
 // TestPullNamedPackageLeavesOthersAlone covers `lnpm pull <pkg>`: only the named
@@ -102,11 +132,11 @@ func TestPullNamedPackageLeavesOthersAlone(t *testing.T) {
 	}
 
 	env.AssertLinkedFileContent(projectDir, "named-a", "index.js", "module.exports = 'a-v2';")
-	assertLockVersion(t, projectDir, "named-a", "2.0.0")
+	assertLockVersion(t, env, projectDir, "named-a", "2.0.0")
 
 	// named-b keeps the contents and lock entry it had from `add`.
 	env.AssertLinkedFileContent(projectDir, "named-b", "index.js", "module.exports = 'named-b';")
-	assertLockVersion(t, projectDir, "named-b", "1.0.0")
+	assertLockVersion(t, env, projectDir, "named-b", "1.0.0")
 }
 
 // TestPullUpToDateIsNoOp pins that pulling a package already at the store's
@@ -131,8 +161,14 @@ func TestPullUpToDateIsNoOp(t *testing.T) {
 	if !strings.Contains(out, "already up to date") {
 		t.Errorf("Expected an 'already up to date' notice, got:\n%s", out)
 	}
-	// The linked copy is still the one add produced.
-	env.AssertLinkedFileContent(projectDir, "uptodate-pkg", "index.js", "module.exports = 'uptodate-pkg';")
+	// A package that was skipped was not pulled, and the summary must not claim
+	// otherwise.
+	if strings.Contains(out, "Pulled") {
+		t.Errorf("Expected no 'Pulled' summary when nothing moved, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Already up to date") {
+		t.Errorf("Expected an 'Already up to date' summary line, got:\n%s", out)
+	}
 }
 
 // TestPullUnlinkedPackageErrors pins that naming a package this project has
@@ -204,7 +240,7 @@ func TestPullNeverModifiesPackageJSON(t *testing.T) {
 func TestPullUpdatesLockfileEntry(t *testing.T) {
 	env := setupTest(t)
 
-	pkgDir := env.simplePkg("lock-pull-pkg")
+	env.simplePkg("lock-pull-pkg")
 	projectDir := env.CreateTestPackage("test-project", "1.0.0", nil)
 	env.writePackageJSON(projectDir, map[string]interface{}{
 		"name":         "test-project",
@@ -213,9 +249,13 @@ func TestPullUpdatesLockfileEntry(t *testing.T) {
 	})
 	env.addPkg(projectDir, "lock-pull-pkg", false, false)
 
-	before := lockEntry(t, projectDir, "lock-pull-pkg")
+	before := lockEntry(t, env, projectDir, "lock-pull-pkg")
 
-	env.republish(pkgDir, "lock-pull-pkg", "2.0.0", "module.exports = 'v2';")
+	// Republished from a DIFFERENT directory, so the store's source path really
+	// moves and the Source assertion below can only pass if pull writes the
+	// store's path rather than carrying the old lock entry's over.
+	relocated := env.CreateTestPackage("lock-pull-pkg-relocated", "2.0.0", nil)
+	env.republish(relocated, "lock-pull-pkg", "2.0.0", "module.exports = 'v2';")
 
 	env.chdir(projectDir)
 	if err := cli.RunPull(nil); err != nil {
@@ -227,7 +267,7 @@ func TestPullUpdatesLockfileEntry(t *testing.T) {
 		t.Fatalf("Failed to read lock-pull-pkg from the store: %v", err)
 	}
 
-	after := lockEntry(t, projectDir, "lock-pull-pkg")
+	after := lockEntry(t, env, projectDir, "lock-pull-pkg")
 	if after.Version != "2.0.0" {
 		t.Errorf("Expected lock version 2.0.0, got %s", after.Version)
 	}
@@ -306,10 +346,100 @@ func TestPullReportsPackageMissingFromStore(t *testing.T) {
 	if !strings.Contains(out, "ghost-pkg: not found in store") {
 		t.Errorf("Expected ghost-pkg to be reported as missing from the store, got:\n%s", out)
 	}
+	// Missing from the store is nearly always an unpublished package, so the
+	// report has to say what to do about it - as `add` does.
+	if !strings.Contains(out, "did you run 'lnpm publish' in the package directory") {
+		t.Errorf("Expected the report to hint at 'lnpm publish', got:\n%s", out)
+	}
 
 	// The healthy package beside it was still refreshed.
 	env.AssertLinkedFileContent(projectDir, "present-pkg", "index.js", "module.exports = 'v2';")
-	assertLockVersion(t, projectDir, "present-pkg", "2.0.0")
+	assertLockVersion(t, env, projectDir, "present-pkg", "2.0.0")
+}
+
+// TestPullReportsFailuresAtTheFailingPackage pins where a failure is reported:
+// the "Pulling <pkg>... " line is closed by the failure itself rather than left
+// dangling, and the run ends on the warning block it exits non-zero for, not on
+// the success line for the package that did refresh.
+func TestPullReportsFailuresAtTheFailingPackage(t *testing.T) {
+	env := setupTest(t)
+
+	okDir := env.simplePkg("ok-pkg")
+	brokenDir := env.simplePkg("broken-pkg")
+	projectDir := env.newProject("test-project")
+	env.addPkg(projectDir, "ok-pkg", false, false)
+	env.addPkg(projectDir, "broken-pkg", false, false)
+
+	env.republish(okDir, "ok-pkg", "2.0.0", "module.exports = 'ok-v2';")
+	env.republish(brokenDir, "broken-pkg", "2.0.0", "module.exports = 'broken-v2';")
+
+	// Delete the store contents the new broken-pkg entry points at, so reading
+	// its files fails midway through the pull.
+	broken, err := env.Database.GetPackageByName("broken-pkg")
+	if err != nil || broken == nil {
+		t.Fatalf("Failed to read broken-pkg from the store: %v", err)
+	}
+	if err := os.RemoveAll(broken.StorePath); err != nil {
+		t.Fatalf("Failed to remove the store path: %v", err)
+	}
+
+	env.chdir(projectDir)
+	var pullErr error
+	out := captureStdout(t, func() { pullErr = cli.RunPull(nil) })
+
+	if pullErr == nil {
+		t.Fatal("Expected a non-zero result when a package's store files are unreadable")
+	}
+	if !strings.Contains(out, "Pulling broken-pkg... failed to get package files") {
+		t.Errorf("Expected the failure to close the 'Pulling broken-pkg... ' line, got:\n%s", out)
+	}
+
+	okAt := strings.Index(out, "Pulled 1 package(s)")
+	warnAt := strings.Index(out, "Some packages failed")
+	if okAt < 0 || warnAt < 0 {
+		t.Fatalf("Expected both a success line and a failure block, got:\n%s", out)
+	}
+	if okAt > warnAt {
+		t.Errorf("Expected the success line before the failure block, got:\n%s", out)
+	}
+}
+
+// TestPullPicksUpSameVersionContentChange covers the republish that changes
+// nothing but the files: same version, new contents. The version alone cannot
+// tell pull anything here, so only the content hash can.
+func TestPullPicksUpSameVersionContentChange(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("samever-pkg")
+	projectDir := env.newProject("test-project")
+	env.addPkg(projectDir, "samever-pkg", false, false)
+
+	before := lockEntry(t, env, projectDir, "samever-pkg")
+
+	// Same version 1.0.0, different contents.
+	env.republish(pkgDir, "samever-pkg", "1.0.0", "module.exports = 'samever-pkg-patched';")
+
+	env.chdir(projectDir)
+	if err := cli.RunPull(nil); err != nil {
+		t.Fatalf("RunPull: %v", err)
+	}
+
+	env.AssertLinkedFileContent(projectDir, "samever-pkg", "index.js", "module.exports = 'samever-pkg-patched';")
+
+	after := lockEntry(t, env, projectDir, "samever-pkg")
+	if after.Version != "1.0.0" {
+		t.Errorf("Expected the lock version to stay 1.0.0, got %s", after.Version)
+	}
+	if after.Hash == before.Hash {
+		t.Errorf("Expected the lock hash to change when the contents did, still %s", after.Hash)
+	}
+	stored, err := env.Database.GetPackageByName("samever-pkg")
+	if err != nil || stored == nil {
+		t.Fatalf("Failed to read samever-pkg from the store: %v", err)
+	}
+	if after.Hash != stored.ContentHash {
+		t.Errorf("Expected lock hash %s (the store's current content hash), got %s", stored.ContentHash, after.Hash)
+	}
 }
 
 // TestPullNoLinkedPackages pins that pulling in a project with nothing linked

--- a/tests/pull_test.go
+++ b/tests/pull_test.go
@@ -1,0 +1,333 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
+)
+
+// republish rewrites an already published package's source with a new version
+// and index.js, then publishes it again WITHOUT --push, so linked projects are
+// deliberately left stale. That stale state is exactly what pull has to fix.
+// The cwd is left inside the package directory.
+func (te *TestEnvironment) republish(pkgDir, name, version, indexJS string) {
+	te.t.Helper()
+	te.chdir(pkgDir)
+	te.writeFile(filepath.Join(pkgDir, "package.json"), `{"name":"`+name+`","version":"`+version+`"}`)
+	te.writeFile(filepath.Join(pkgDir, "index.js"), indexJS)
+	if err := cli.RunPublish(false, false, false, false); err != nil {
+		te.t.Fatalf("Failed to republish %s@%s: %v", name, version, err)
+	}
+}
+
+// lockEntry returns a project's lock entry for pkg, failing if it has none.
+func lockEntry(t *testing.T, projectDir, pkg string) lockfile.Package {
+	t.Helper()
+	lock, err := lockfile.Load(projectDir)
+	if err != nil {
+		t.Fatalf("Failed to load lockfile: %v", err)
+	}
+	entry, ok := lock.Get(pkg)
+	if !ok {
+		t.Fatalf("Package %s not in lockfile", pkg)
+	}
+	return entry
+}
+
+// readBytes reads a file, failing the test on error.
+func readBytes(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read %s: %v", path, err)
+	}
+	return data
+}
+
+// assertLockVersion checks a package's recorded version in the project's lockfile.
+func assertLockVersion(t *testing.T, projectDir, pkg, want string) {
+	t.Helper()
+	if got := lockEntry(t, projectDir, pkg).Version; got != want {
+		t.Errorf("Expected %s at version %s in lockfile, got %s", pkg, want, got)
+	}
+}
+
+// TestPullAllRefreshesEveryLinkedPackage covers `lnpm pull` with no arguments:
+// every package in lnpm.lock is refreshed to the version now in the store.
+func TestPullAllRefreshesEveryLinkedPackage(t *testing.T) {
+	env := setupTest(t)
+
+	pkgA := env.simplePkg("pull-a")
+	pkgB := env.simplePkg("pull-b")
+	projectDir := env.newProject("test-project")
+	env.addPkg(projectDir, "pull-a", false, false)
+	env.addPkg(projectDir, "pull-b", false, false)
+
+	env.republish(pkgA, "pull-a", "2.0.0", "module.exports = 'a-v2';")
+	env.republish(pkgB, "pull-b", "3.0.0", "module.exports = 'b-v2';")
+
+	env.chdir(projectDir)
+	if err := cli.RunPull(nil); err != nil {
+		t.Fatalf("RunPull: %v", err)
+	}
+
+	env.AssertLinkedFileContent(projectDir, "pull-a", "index.js", "module.exports = 'a-v2';")
+	env.AssertLinkedFileContent(projectDir, "pull-b", "index.js", "module.exports = 'b-v2';")
+	assertLockVersion(t, projectDir, "pull-a", "2.0.0")
+	assertLockVersion(t, projectDir, "pull-b", "3.0.0")
+}
+
+// TestPullNamedPackageLeavesOthersAlone covers `lnpm pull <pkg>`: only the named
+// package is refreshed, even though a sibling is equally out of date.
+func TestPullNamedPackageLeavesOthersAlone(t *testing.T) {
+	env := setupTest(t)
+
+	pkgA := env.simplePkg("named-a")
+	pkgB := env.simplePkg("named-b")
+	projectDir := env.newProject("test-project")
+	env.addPkg(projectDir, "named-a", false, false)
+	env.addPkg(projectDir, "named-b", false, false)
+
+	env.republish(pkgA, "named-a", "2.0.0", "module.exports = 'a-v2';")
+	env.republish(pkgB, "named-b", "2.0.0", "module.exports = 'b-v2';")
+
+	env.chdir(projectDir)
+	if err := cli.RunPull([]string{"named-a"}); err != nil {
+		t.Fatalf("RunPull: %v", err)
+	}
+
+	env.AssertLinkedFileContent(projectDir, "named-a", "index.js", "module.exports = 'a-v2';")
+	assertLockVersion(t, projectDir, "named-a", "2.0.0")
+
+	// named-b keeps the contents and lock entry it had from `add`.
+	env.AssertLinkedFileContent(projectDir, "named-b", "index.js", "module.exports = 'named-b';")
+	assertLockVersion(t, projectDir, "named-b", "1.0.0")
+}
+
+// TestPullUpToDateIsNoOp pins that pulling a package already at the store's
+// current version neither errors nor touches the lock file.
+func TestPullUpToDateIsNoOp(t *testing.T) {
+	env := setupTest(t)
+
+	_, projectDir := env.publishAndAdd("uptodate-pkg")
+	lockPath := filepath.Join(projectDir, "lnpm.lock")
+	before := readBytes(t, lockPath)
+
+	env.chdir(projectDir)
+	out := captureStdout(t, func() {
+		if err := cli.RunPull(nil); err != nil {
+			t.Errorf("Pulling an up-to-date package must not error, got: %v", err)
+		}
+	})
+
+	if got := readBytes(t, lockPath); string(got) != string(before) {
+		t.Errorf("Expected lnpm.lock to be untouched for an up-to-date pull.\nbefore:\n%s\nafter:\n%s", before, got)
+	}
+	if !strings.Contains(out, "already up to date") {
+		t.Errorf("Expected an 'already up to date' notice, got:\n%s", out)
+	}
+	// The linked copy is still the one add produced.
+	env.AssertLinkedFileContent(projectDir, "uptodate-pkg", "index.js", "module.exports = 'uptodate-pkg';")
+}
+
+// TestPullUnlinkedPackageErrors pins that naming a package this project has
+// never linked fails with a clear error and links nothing, even though the
+// package does exist in the store.
+func TestPullUnlinkedPackageErrors(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("linked-pkg")
+	env.simplePkg("stranger-pkg")
+	projectDir := env.newProject("test-project")
+	env.addPkg(projectDir, "linked-pkg", false, false)
+
+	env.chdir(projectDir)
+	err := cli.RunPull([]string{"stranger-pkg"})
+	if err == nil {
+		t.Fatal("Expected an error when pulling a package that is not linked in this project")
+	}
+	if !strings.Contains(err.Error(), "stranger-pkg") || !strings.Contains(err.Error(), "not linked") {
+		t.Errorf("Expected an error naming stranger-pkg as not linked, got: %v", err)
+	}
+
+	env.AssertDirectoryExists(filepath.Join(projectDir, ".lnpm", "stranger-pkg"), false)
+	env.AssertSymlinkMissing(projectDir, "stranger-pkg")
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		if lock.Has("stranger-pkg") {
+			t.Error("Expected no lockfile entry for a package that was never linked")
+		}
+	})
+}
+
+// TestPullNeverModifiesPackageJSON pins that pull leaves package.json exactly as
+// it found it - byte for byte - even when it does refresh the package.
+func TestPullNeverModifiesPackageJSON(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("pj-pkg")
+	projectDir := env.CreateTestPackage("test-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":         "test-project",
+		"version":      "1.0.0",
+		"dependencies": map[string]interface{}{"pj-pkg": "^1.0.0"},
+	})
+	env.addPkg(projectDir, "pj-pkg", false, false)
+
+	env.republish(pkgDir, "pj-pkg", "2.0.0", "module.exports = 'v2';")
+
+	pkgJSONPath := filepath.Join(projectDir, "package.json")
+	before := readBytes(t, pkgJSONPath)
+
+	env.chdir(projectDir)
+	if err := cli.RunPull(nil); err != nil {
+		t.Fatalf("RunPull: %v", err)
+	}
+
+	if got := readBytes(t, pkgJSONPath); string(got) != string(before) {
+		t.Errorf("Expected package.json to be untouched by pull.\nbefore:\n%s\nafter:\n%s", before, got)
+	}
+	// The reference `add` wrote is still what package.json holds.
+	env.AssertPackageJSON(projectDir, "pj-pkg", "file:.lnpm/pj-pkg")
+	// ...and the pull really did happen.
+	env.AssertLinkedFileContent(projectDir, "pj-pkg", "index.js", "module.exports = 'v2';")
+}
+
+// TestPullUpdatesLockfileEntry pins the whole lock entry a pull writes: the new
+// version, the store's current content hash and source, a Linked timestamp that
+// advanced, and the OriginalVersion carried over from `add` (losing it would
+// make a later remove delete the dependency instead of restoring the specifier).
+func TestPullUpdatesLockfileEntry(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("lock-pull-pkg")
+	projectDir := env.CreateTestPackage("test-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":         "test-project",
+		"version":      "1.0.0",
+		"dependencies": map[string]interface{}{"lock-pull-pkg": "^4.2.0"},
+	})
+	env.addPkg(projectDir, "lock-pull-pkg", false, false)
+
+	before := lockEntry(t, projectDir, "lock-pull-pkg")
+
+	env.republish(pkgDir, "lock-pull-pkg", "2.0.0", "module.exports = 'v2';")
+
+	env.chdir(projectDir)
+	if err := cli.RunPull(nil); err != nil {
+		t.Fatalf("RunPull: %v", err)
+	}
+
+	stored, err := env.Database.GetPackageByName("lock-pull-pkg")
+	if err != nil || stored == nil {
+		t.Fatalf("Failed to read lock-pull-pkg from the store: %v", err)
+	}
+
+	after := lockEntry(t, projectDir, "lock-pull-pkg")
+	if after.Version != "2.0.0" {
+		t.Errorf("Expected lock version 2.0.0, got %s", after.Version)
+	}
+	if after.Hash == before.Hash {
+		t.Errorf("Expected the lock hash to change on pull, still %s", after.Hash)
+	}
+	if after.Hash != stored.ContentHash {
+		t.Errorf("Expected lock hash %s (the store's current content hash), got %s", stored.ContentHash, after.Hash)
+	}
+	if after.Source != stored.SourcePath {
+		t.Errorf("Expected lock source %s, got %s", stored.SourcePath, after.Source)
+	}
+	if !after.Linked.After(before.Linked) {
+		t.Errorf("Expected the Linked timestamp to advance, went %v -> %v", before.Linked, after.Linked)
+	}
+	if after.OriginalVersion != "^4.2.0" {
+		t.Errorf("Expected pull to preserve OriginalVersion ^4.2.0, got %q", after.OriginalVersion)
+	}
+}
+
+// TestPullReportsVersionChange pins the per-package summary: the old and new
+// versions are both named, and the closing line reports what was pulled.
+func TestPullReportsVersionChange(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("report-pkg")
+	projectDir := env.newProject("test-project")
+	env.addPkg(projectDir, "report-pkg", false, false)
+
+	env.republish(pkgDir, "report-pkg", "2.5.0", "module.exports = 'v2';")
+
+	env.chdir(projectDir)
+	out := captureStdout(t, func() {
+		if err := cli.RunPull([]string{"report-pkg"}); err != nil {
+			t.Errorf("RunPull: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Pulling report-pkg... updated 1.0.0 -> 2.5.0") {
+		t.Errorf("Expected the summary to name both versions, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Pulled report-pkg@2.5.0") {
+		t.Errorf("Expected a closing line naming the pulled package, got:\n%s", out)
+	}
+}
+
+// TestPullReportsPackageMissingFromStore covers a lock entry whose package is
+// gone from the store: it is reported and pull exits non-zero, while the
+// packages beside it are still refreshed.
+func TestPullReportsPackageMissingFromStore(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("present-pkg")
+	projectDir := env.newProject("test-project")
+	env.addPkg(projectDir, "present-pkg", false, false)
+
+	// A lock entry for a package this store has never held.
+	lock, err := lockfile.Load(projectDir)
+	if err != nil {
+		t.Fatalf("Failed to load lockfile: %v", err)
+	}
+	lock.Add("ghost-pkg", lockfile.Package{Version: "1.0.0", Hash: "deadbeefdeadbeef", Source: "/nowhere", Linked: time.Now()})
+	if err := lock.Save(projectDir); err != nil {
+		t.Fatalf("Failed to save lockfile: %v", err)
+	}
+
+	env.republish(pkgDir, "present-pkg", "2.0.0", "module.exports = 'v2';")
+
+	env.chdir(projectDir)
+	var pullErr error
+	out := captureStdout(t, func() { pullErr = cli.RunPull(nil) })
+
+	if pullErr == nil {
+		t.Fatal("Expected a non-zero result when a locked package is missing from the store")
+	}
+	if !strings.Contains(out, "ghost-pkg: not found in store") {
+		t.Errorf("Expected ghost-pkg to be reported as missing from the store, got:\n%s", out)
+	}
+
+	// The healthy package beside it was still refreshed.
+	env.AssertLinkedFileContent(projectDir, "present-pkg", "index.js", "module.exports = 'v2';")
+	assertLockVersion(t, projectDir, "present-pkg", "2.0.0")
+}
+
+// TestPullNoLinkedPackages pins that pulling in a project with nothing linked
+// says so instead of failing.
+func TestPullNoLinkedPackages(t *testing.T) {
+	env := setupTest(t)
+
+	projectDir := env.newProject("empty-project")
+	env.chdir(projectDir)
+
+	out := captureStdout(t, func() {
+		if err := cli.RunPull(nil); err != nil {
+			t.Errorf("Pulling with nothing linked must not error, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "No linked packages to pull") {
+		t.Errorf("Expected a 'No linked packages to pull' notice, got:\n%s", out)
+	}
+	env.AssertLockfileExists(projectDir, false)
+}


### PR DESCRIPTION
`lnpm add` copies a package's current store contents into `.lnpm/<pkg>` and points
package.json at it. When the source package is republished — by `lnpm publish`
without `--push`, or by a teammate sharing the same store — the consumer had no
way to pick up the new contents short of re-running `add` from scratch.

`lnpm pull` refreshes the packages already recorded in `lnpm.lock`: every one of
them with no arguments, or just the named ones. For each it resolves the current
store version, re-links `.lnpm/<pkg>`, and rewrites the lock entry with the new
version, hash and `Linked` timestamp — preserving `OriginalVersion`, so `remove`
and `retreat` can still restore the user's original specifier.

package.json is never touched on any path: the `file:.lnpm/<pkg>` reference is
already correct, and only the contents behind it change.

The name sidesteps `lnpm update`, which already means "self-update the binary".

```
$ lnpm pull
Pulling mylib... updated 1.2.0 -> 1.3.0
✓ Pulled 1 package(s)

$ lnpm pull mylib
Pulling mylib... already up to date (1.3.0)
✓ Already up to date
```

## Behavior notes

- An already-up-to-date package is a no-op: the lock file is not rewritten at
  all, so its bytes and mtime are untouched.
- Named packages are all checked against the lock **before** any linking, so a
  typo cannot leave the project half-pulled.
- A package that fails mid-run is reported where it fails and the command exits
  non-zero, while healthy packages are still pulled and saved — matching
  `RunAddMultiple`.
- The no-arg form sorts its package list, so the report is stable between runs.
- No database write: publishing updates the existing package row in place, so
  the link row `add` recorded still points at what `pull` just linked, and no
  command surfaces the stored link type. This is recorded as a comment in
  `pull.go`.

## Tests

Integration tests in `tests/pull_test.go` cover each acceptance criterion, plus
`tests/pull_permissions_test.go` for a failed lock save and `tests/e2e/pull_test.go`
for a multi-package pull resolved through real node. Every assertion was
mutation-tested against the production code it pins.

Closes #188
