### PR TITLE
Point `add --link` at the package's live source directory

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -270,6 +270,9 @@ lnpm add my-package --pure
 
 # Add with dev dependency
 lnpm add my-package --dev
+
+# Link to the live source directory instead of a store copy
+lnpm add my-package --link
 ```
 
 **Process:**
@@ -286,6 +289,18 @@ lnpm add my-package --dev
 
 6. Update `package.json` with `file:.lnpm/{package}`
 7. Register link in bbolt
+
+**Live linking (`--link`):** steps 2 and 3 are skipped entirely. `.lnpm/{package}`
+becomes a link to the `source_path` recorded at publish time, `package.json` gets
+`link:.lnpm/{package}`, and the recorded link type is `link`. Nothing is copied,
+so every later edit of the source is visible to the project at once — and so the
+project sees files that were never published or committed, which is exactly the
+isolation the default snapshot gives you. `--link` therefore still requires the
+package to have been published once: that is what records its source path.
+
+Teardown never follows the link: `remove`, `retreat` and a re-`add` all delete
+`.lnpm/{package}` with `os.RemoveAll`, which removes a link without descending
+through it, so the source tree is untouched.
 
 ### `lnpm remove <package>`
 
@@ -322,6 +337,9 @@ lnpm push --skip-hooks
 2. Calculate new content hash
 3. Update store with new version
 4. For each linked project:
+   - Skip it if it is live-linked (`.lnpm/{package}` is a link, not a
+     directory): it already resolves to the source directory being pushed, and
+     relinking would swap its live link for a snapshot copy
    - Create new hard links in a temporary directory alongside `.lnpm/{package}/`
    - Rename it over `.lnpm/{package}/`, then delete the old directory
    - Preserve `node_modules` symlink
@@ -349,11 +367,14 @@ lnpm pull my-package other-pkg
 1. Read the linked set from `lnpm.lock` (all of it, or just the named packages,
    which must already be linked here — `pull` refreshes links, it never creates
    them)
-2. For each package, look it up in the store; skip it when the lock entry
-   already matches the store's version and content hash
-3. Hard link the store's current files into a temporary directory and rename it
+2. Skip any package that is live-linked (`.lnpm/{package}` is a link, not a
+   directory): it resolves to its source, so there is nothing to refresh, and
+   relinking it would silently swap the live link for a snapshot copy
+3. For each remaining package, look it up in the store; skip it when the lock
+   entry already matches the store's version and content hash
+4. Hard link the store's current files into a temporary directory and rename it
    over `.lnpm/{package}/`, exactly as `add` does
-4. Update the entry in `lnpm.lock`, preserving the original `package.json`
+5. Update the entry in `lnpm.lock`, preserving the original `package.json`
    specifier recorded by `add`
 
 `package.json` is never touched: the `file:.lnpm/{package}` reference it holds

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -290,13 +290,18 @@ lnpm add my-package --link
 6. Update `package.json` with `file:.lnpm/{package}`
 7. Register link in bbolt
 
-**Live linking (`--link`):** steps 2 and 3 are skipped entirely. `.lnpm/{package}`
-becomes a link to the `source_path` recorded at publish time, `package.json` gets
-`link:.lnpm/{package}`, and the recorded link type is `link`. Nothing is copied,
+**Live linking (`--link`):** step 3 is skipped entirely, and step 2 creates a
+link rather than a directory. `.lnpm/{package}` becomes a link to the
+`source_path` recorded at publish time — created alongside and renamed into
+place, so replacing a store copy never deletes it before its replacement exists
+— `package.json` gets `link:.lnpm/{package}`, and the recorded link type is
+`link`. Nothing is copied,
 so every later edit of the source is visible to the project at once — and so the
-project sees files that were never published or committed, which is exactly the
-isolation the default snapshot gives you. `--link` therefore still requires the
-package to have been published once: that is what records its source path.
+project builds against whatever is in the source tree right now, including files
+that have never been published and are not even committed. That is the isolation
+the default snapshot gives you and `--link` gives up. `--link` therefore still
+requires the package to have been published once: that is what records its
+source path.
 
 Teardown never follows the link: `remove`, `retreat` and a re-`add` all delete
 `.lnpm/{package}` with `os.RemoveAll`, which removes a link without descending

--- a/README.md
+++ b/README.md
@@ -100,11 +100,32 @@ lnpm publish
 # Add to a project (supports multiple packages)
 lnpm add my-package
 lnpm add pkg-a pkg-b pkg-c
-lnpm add my-package --link   # Use link: protocol instead of file:
+lnpm add my-package --link   # Link to the live source instead of a store copy
 
 # Push updates after making changes
 lnpm push
 ```
+
+### Live Linking (`--link`)
+
+By default `lnpm add` copies the package's published snapshot into
+`.lnpm/{package}/`, so the project only sees changes you deliberately
+`publish` or `push`. With `--link`, `.lnpm/{package}` is instead a link to the
+directory the package was published from, and `package.json` says
+`link:.lnpm/{package}`:
+
+```bash
+lnpm add my-package --link
+# Every edit in the source package is visible to this project immediately,
+# with no publish, push or pull.
+```
+
+The tradeoff is the isolation you give up: the project builds against whatever
+is in the source tree right now, including files that have never been published
+and are not even committed. Prefer the default when you want a reproducible
+snapshot; use `--link` while you iterate. `lnpm pull` and `lnpm push` skip
+live-linked packages rather than replacing them with a snapshot, and
+`lnpm remove` / `lnpm retreat` delete only the link, never the source.
 
 ### Monorepo Support
 

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -105,16 +105,9 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 
 			result.pkg = pkg
 
-			files, err := s.GetFiles(pkg.Name, pkg.ContentHash)
+			linkType, err := linkPackage(linker, s, pkg, useLink)
 			if err != nil {
-				result.err = fmt.Errorf("failed to get package files: %w", err)
-				results <- result
-				return
-			}
-
-			linkType, err := linker.Link(pkg.Name, pkg.StorePath, files)
-			if err != nil {
-				result.err = fmt.Errorf("failed to link package: %w", err)
+				result.err = err
 				results <- result
 				return
 			}
@@ -343,6 +336,39 @@ func rollBack(lock *lockfile.LockFile, linker *link.Linker, r *addResult, reason
 	return lockChanged, fmt.Errorf("%s: %w", r.spec, reason)
 }
 
+// linkTypeLabel renders a link type for the add summary, spelling out that a
+// live link resolves to the package's source directory rather than to a copy.
+func linkTypeLabel(t link.LinkType) string {
+	if t == link.Live {
+		return "link (live source)"
+	}
+	return string(t)
+}
+
+// linkPackage points the project at pkg. With useLink the project resolves to
+// pkg's live source directory, so later source edits reach it with no further
+// command; otherwise the published snapshot is materialised out of the store.
+func linkPackage(linker *link.Linker, s *store.Store, pkg *db.Package, useLink bool) (link.LinkType, error) {
+	if useLink {
+		linkType, err := linker.LinkSource(pkg.Name, pkg.SourcePath)
+		if err != nil {
+			return "", fmt.Errorf("failed to link package source: %w", err)
+		}
+		return linkType, nil
+	}
+
+	files, err := s.GetFiles(pkg.Name, pkg.ContentHash)
+	if err != nil {
+		return "", fmt.Errorf("failed to get package files: %w", err)
+	}
+
+	linkType, err := linker.Link(pkg.Name, pkg.StorePath, files)
+	if err != nil {
+		return "", fmt.Errorf("failed to link package: %w", err)
+	}
+	return linkType, nil
+}
+
 // runAddSingle adds a single package (internal implementation)
 func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useLink bool) error {
 	// Parse package spec (name[@version])
@@ -379,7 +405,11 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useL
 		return fmt.Errorf("version %s of %s not found in store (latest published is %s). Re-publish %s to update.", version, name, pkg.Version, name)
 	}
 
-	fmt.Printf("Adding %s@%s...\n", pkg.Name, pkg.Version)
+	if useLink {
+		fmt.Printf("Adding %s@%s (linked to source)...\n", pkg.Name, pkg.Version)
+	} else {
+		fmt.Printf("Adding %s@%s...\n", pkg.Name, pkg.Version)
+	}
 
 	// Get store
 	s, err := store.New()
@@ -387,17 +417,11 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useL
 		return fmt.Errorf("failed to access store: %w", err)
 	}
 
-	// Get files from store
-	files, err := s.GetFiles(pkg.Name, pkg.ContentHash)
-	if err != nil {
-		return fmt.Errorf("failed to get package files: %w", err)
-	}
-
 	// Link the package
 	linker := link.New(cwd)
-	linkType, err := linker.Link(pkg.Name, pkg.StorePath, files)
+	linkType, err := linkPackage(linker, s, pkg, useLink)
 	if err != nil {
-		return fmt.Errorf("failed to link package: %w", err)
+		return err
 	}
 
 	// Update .gitignore if enabled
@@ -490,7 +514,7 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useL
 	}
 
 	fmt.Printf("%s Added %s@%s\n", iconOK(), pkg.Name, pkg.Version)
-	fmt.Printf("  Link type: %s\n", linkType)
+	fmt.Printf("  Link type: %s\n", linkTypeLabel(linkType))
 	fmt.Printf("  Package manager: %s\n", pm)
 	if !pure {
 		fmt.Printf("  Updated: package.json\n")

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -71,6 +71,14 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 
 	linker := link.New(cwd)
 
+	// Announce live linking for the batch. The single-package path names the
+	// package and version here, which this path cannot: resolution happens
+	// inside the parallel phase below, and printing from those goroutines would
+	// interleave. The per-package link type is reported in the summary instead.
+	if useLink {
+		fmt.Printf("Adding %d packages (linked to source)...\n", len(packageSpecs))
+	}
+
 	// Phase 1: Resolve and link packages in parallel
 	var wg sync.WaitGroup
 	results := make(chan addResult, len(packageSpecs))
@@ -267,7 +275,10 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 			fmt.Printf("  %s Failed to record link for %s: %v\n", iconWarn(), r.pkg.Name, err)
 		}
 
-		fmt.Printf("%s Added %s@%s (%s)\n", iconOK(), r.pkg.Name, r.pkg.Version, r.linkType)
+		// Reported exactly as the single-package path reports it, so a live link
+		// is spelled out rather than shown as the bare type name "link".
+		fmt.Printf("%s Added %s@%s\n", iconOK(), r.pkg.Name, r.pkg.Version)
+		fmt.Printf("  Link type: %s\n", linkTypeLabel(r.linkType))
 	}
 
 	if len(errors) > 0 {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -45,6 +45,12 @@ This command:
   4. Updates package.json with file: dependency
   5. Updates lnpm.lock
 
+With --link the package is not copied at all: .lnpm/{package} is linked straight
+at the source directory it was published from, so every source edit reaches this
+project with no further command, and package.json uses link: instead of file:.
+That trades away the isolation the default gives you - the project then builds
+against files that have not been published, or even committed.
+
 Examples:
   lnpm add my-package            # Add latest version
   lnpm add pkg1 pkg2 pkg3        # Add multiple packages
@@ -52,7 +58,7 @@ Examples:
   lnpm add my-package --dev      # Add as devDependency
   lnpm add my-package --install  # Add and run npm install
   lnpm add my-package --pure     # Don't modify package.json
-  lnpm add my-package --link     # Use link: protocol instead of file:`,
+  lnpm add my-package --link     # Link to the live source instead of a store copy`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dev, _ := cmd.Flags().GetBool("dev")
@@ -275,7 +281,7 @@ func init() {
 	addCmd.Flags().Bool("dev", false, "Add as devDependency")
 	addCmd.Flags().Bool("pure", false, "Don't modify package.json")
 	addCmd.Flags().Bool("install", false, "Run npm install after adding (default: no)")
-	addCmd.Flags().Bool("link", false, "Use link: protocol in package.json instead of file:")
+	addCmd.Flags().Bool("link", false, "Link to the package's live source directory instead of a store copy (the project then sees unpublished, uncommitted files)")
 
 	// remove flags
 	removeCmd.Flags().Bool("all", false, "Remove all linked packages")

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -270,8 +270,9 @@ func pushToLinkedProjects(database *db.DB, pkg *db.Package, s *store.Store) erro
 
 	// Push to all projects in parallel
 	type result struct {
-		path string
-		err  error
+		path    string
+		skipped bool
+		err     error
 	}
 	results := make(chan result, len(projects))
 	var wg sync.WaitGroup
@@ -280,8 +281,8 @@ func pushToLinkedProjects(database *db.DB, pkg *db.Package, s *store.Store) erro
 		wg.Add(1)
 		go func(p *db.Project) {
 			defer wg.Done()
-			err := pushToProject(p, pkg, s)
-			results <- result{path: p.Path, err: err}
+			skipped, err := pushToProject(p, pkg, s)
+			results <- result{path: p.Path, skipped: skipped, err: err}
 		}(proj)
 	}
 
@@ -291,36 +292,57 @@ func pushToLinkedProjects(database *db.DB, pkg *db.Package, s *store.Store) erro
 
 	// Print results
 	successCount := 0
+	skippedCount := 0
+	failedCount := 0
 	for res := range results {
-		if res.err != nil {
+		switch {
+		case res.err != nil:
 			fmt.Printf("  %s %s: %v\n", iconFail(), res.path, res.err)
-		} else {
+			failedCount++
+		case res.skipped:
+			fmt.Printf("  %s %s: skipped (live link to source)\n", iconOK(), res.path)
+			skippedCount++
+		default:
 			fmt.Printf("  %s %s\n", iconOK(), res.path)
 			successCount++
 		}
 	}
 
-	fmt.Printf("\nPushed to %d/%d projects\n", successCount, len(projects))
+	fmt.Printf("\nPushed to %d/%d projects", successCount, len(projects))
+	if skippedCount > 0 {
+		fmt.Printf(" (%d skipped: live link to source)", skippedCount)
+	}
+	fmt.Println()
 
-	if successCount < len(projects) {
-		return fmt.Errorf("push failed for %d of %d project(s)", len(projects)-successCount, len(projects))
+	if failedCount > 0 {
+		return fmt.Errorf("push failed for %d of %d project(s)", failedCount, len(projects))
 	}
 
 	return nil
 }
 
-// pushToProject pushes a package update to a single project
-func pushToProject(proj *db.Project, pkg *db.Package, s *store.Store) error {
+// pushToProject pushes a package update to a single project, reporting whether
+// the project was skipped rather than relinked.
+func pushToProject(proj *db.Project, pkg *db.Package, s *store.Store) (skipped bool, err error) {
+	// A project that added this package with --link already resolves to the
+	// source directory just published. Relinking it from the store would replace
+	// its live link with a snapshot copy and silently end the live updates it
+	// was added for - the same hazard push guards against, reached here by
+	// `publish --push`.
+	linker := link.New(proj.Path)
+	if linker.IsLiveLinked(pkg.Name) {
+		return true, nil
+	}
+
 	// Get files from store
 	files, err := s.GetFiles(pkg.Name, pkg.ContentHash)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	// Re-link the package
-	linker := link.New(proj.Path)
 	_, err = linker.Link(pkg.Name, pkg.StorePath, files)
-	return err
+	return false, err
 }
 
 // shortHash returns the first 8 characters of a hash

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -73,6 +73,16 @@ func RunPull(packageNames []string) error {
 	for _, name := range names {
 		entry, _ := lock.Get(name)
 
+		// A package added with --link resolves to its source directory, so there
+		// is nothing to refresh: relinking it from the store would replace the
+		// live link with a snapshot copy and silently end the live updates the
+		// consumer was relying on.
+		if linker.IsLiveLinked(name) {
+			fmt.Printf("Pulling %s... skipped (live link to source)\n", name)
+			skipped++
+			continue
+		}
+
 		pkg, err := database.GetPackageByName(name)
 		if err != nil {
 			failed = append(failed, fmt.Errorf("%s: failed to look up package: %w", name, err))

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -66,7 +66,8 @@ func RunPull(packageNames []string) error {
 
 	var failed []error
 	refreshed := 0
-	skipped := 0
+	upToDate := 0
+	liveLinked := 0
 	lockChanged := false
 	lastVersion := ""
 
@@ -79,7 +80,7 @@ func RunPull(packageNames []string) error {
 		// consumer was relying on.
 		if linker.IsLiveLinked(name) {
 			fmt.Printf("Pulling %s... skipped (live link to source)\n", name)
-			skipped++
+			liveLinked++
 			continue
 		}
 
@@ -97,7 +98,7 @@ func RunPull(packageNames []string) error {
 
 		if entry.Version == pkg.Version && entry.Hash == pkg.ContentHash {
 			fmt.Printf("already up to date (%s)\n", pkg.Version)
-			skipped++
+			upToDate++
 			continue
 		}
 
@@ -153,8 +154,17 @@ func RunPull(packageNames []string) error {
 		fmt.Printf("%s Pulled %s@%s\n", iconOK(), names[0], lastVersion)
 	} else if refreshed > 0 {
 		fmt.Printf("%s Pulled %d package(s)\n", iconOK(), refreshed)
-	} else if skipped > 0 && len(failed) == 0 {
+	} else if upToDate > 0 && len(failed) == 0 {
 		fmt.Printf("%s Already up to date\n", iconOK())
+	}
+
+	// Live-linked packages are reported apart from the up-to-date ones. Nothing
+	// about them was compared against the store, so folding them into "already
+	// up to date" would claim a store parity that was never checked - a pull
+	// where every package is live-linked said so while the store held a newer
+	// version and the lock still held the old one.
+	if liveLinked > 0 && len(failed) == 0 {
+		fmt.Printf("%s Skipped %d live-linked package(s)\n", iconOK(), liveLinked)
 	}
 
 	if len(failed) > 0 {

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -187,10 +187,12 @@ func RunPush(skipHooks bool) error {
 	// Print results in order received (not deterministic order)
 	successCount := 0
 	skippedCount := 0
+	failedCount := 0
 	for res := range results {
 		switch {
 		case res.err != nil:
 			fmt.Printf("  %s %s: %v\n", iconFail(), res.path, res.err)
+			failedCount++
 		case res.skipped:
 			fmt.Printf("  %s %s: skipped (live link to source)\n", iconOK(), res.path)
 			skippedCount++
@@ -200,13 +202,18 @@ func RunPush(skipHooks bool) error {
 		}
 	}
 
-	// Live-linked projects leave the denominator: there was nothing to push to
-	// them, so counting them as pending would report a failure that isn't one.
-	pushable := len(projects) - skippedCount
-	fmt.Printf("\nPushed to %d/%d projects\n", successCount, pushable)
+	// The denominator is every project considered, matching the count announced
+	// above. Live-linked projects are reported as skipped instead of being taken
+	// out of the total: removing them made the two lines contradict each other,
+	// and an all-live push report "Pushed to 0/0 projects".
+	fmt.Printf("\nPushed to %d/%d projects", successCount, len(projects))
+	if skippedCount > 0 {
+		fmt.Printf(" (%d skipped: live link to source)", skippedCount)
+	}
+	fmt.Println()
 
-	if successCount < pushable {
-		return fmt.Errorf("push failed for %d of %d project(s)", pushable-successCount, pushable)
+	if failedCount > 0 {
+		return fmt.Errorf("push failed for %d of %d project(s)", failedCount, len(projects))
 	}
 
 	return nil

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -155,8 +155,9 @@ func RunPush(skipHooks bool) error {
 
 	// Link to all projects in parallel
 	type result struct {
-		path string
-		err  error
+		path    string
+		skipped bool
+		err     error
 	}
 	results := make(chan result, len(projects))
 	var wg sync.WaitGroup
@@ -166,6 +167,14 @@ func RunPush(skipHooks bool) error {
 		go func(p *db.Project) {
 			defer wg.Done()
 			linker := link.New(p.Path)
+			// A project that added this package with --link already resolves to
+			// the source directory being pushed. Relinking it from the store
+			// would replace its live link with a snapshot copy and silently end
+			// the live updates it was added for.
+			if linker.IsLiveLinked(pkg.Name) {
+				results <- result{path: p.Path, skipped: true}
+				return
+			}
 			_, err := linker.Link(pkg.Name, storePath, storeFiles)
 			results <- result{path: p.Path, err: err}
 		}(proj)
@@ -177,19 +186,27 @@ func RunPush(skipHooks bool) error {
 
 	// Print results in order received (not deterministic order)
 	successCount := 0
+	skippedCount := 0
 	for res := range results {
-		if res.err != nil {
+		switch {
+		case res.err != nil:
 			fmt.Printf("  %s %s: %v\n", iconFail(), res.path, res.err)
-		} else {
+		case res.skipped:
+			fmt.Printf("  %s %s: skipped (live link to source)\n", iconOK(), res.path)
+			skippedCount++
+		default:
 			fmt.Printf("  %s %s\n", iconOK(), res.path)
 			successCount++
 		}
 	}
 
-	fmt.Printf("\nPushed to %d/%d projects\n", successCount, len(projects))
+	// Live-linked projects leave the denominator: there was nothing to push to
+	// them, so counting them as pending would report a failure that isn't one.
+	pushable := len(projects) - skippedCount
+	fmt.Printf("\nPushed to %d/%d projects\n", successCount, pushable)
 
-	if successCount < len(projects) {
-		return fmt.Errorf("push failed for %d of %d project(s)", len(projects)-successCount, len(projects))
+	if successCount < pushable {
+		return fmt.Errorf("push failed for %d of %d project(s)", pushable-successCount, pushable)
 	}
 
 	return nil

--- a/internal/cli/retreat.go
+++ b/internal/cli/retreat.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/pedrosousa13/lnpm/internal/config"
 	"github.com/pedrosousa13/lnpm/internal/db"
@@ -52,8 +51,8 @@ func RunRetreat(force bool, runInstall bool) error {
 			for _, name := range linkedPkgs {
 				pkg, _ := lock.Get(name)
 				originalVersion := pkg.OriginalVersion
-				// Ignore file:.lnpm/ as original version (bug from older versions)
-				if strings.HasPrefix(originalVersion, "file:.lnpm/") {
+				// Ignore lnpm's own reference as original version (bug from older versions)
+				if isLnpmReference(originalVersion) {
 					originalVersion = ""
 				}
 				if originalVersion != "" {
@@ -92,9 +91,9 @@ func RunRetreat(force bool, runInstall bool) error {
 		_ = os.Remove(nodeModulesLink)
 
 		// Restore original package.json dependency
-		// Ignore file:.lnpm/ as original version (bug from older versions)
+		// Ignore lnpm's own reference as original version (bug from older versions)
 		originalVersion := pkg.OriginalVersion
-		if strings.HasPrefix(originalVersion, "file:.lnpm/") {
+		if isLnpmReference(originalVersion) {
 			originalVersion = ""
 		}
 

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -22,6 +22,9 @@ type LinkType string
 const (
 	HardLink LinkType = "hardlink"
 	Copy     LinkType = "copy"
+	// Live is the type recorded when .lnpm/{package} is a link at the package's
+	// source directory rather than a materialised copy of the store entry.
+	Live LinkType = "link"
 )
 
 // Linker handles linking packages to projects
@@ -269,6 +272,57 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	return actualType, nil
 }
 
+// LinkSource points a project at a package's live source directory instead of
+// at a copy of its published snapshot: .lnpm/{package} becomes a link to
+// sourcePath, and node_modules/{package} the usual link into .lnpm.
+//
+// Nothing is materialised, so every later edit of the source is visible to the
+// consumer with no further command. That is the point, and also the tradeoff:
+// the consumer sees files that have not been published, or even committed,
+// unlike the snapshot the default path copies out of the store.
+func (l *Linker) LinkSource(packageName string, sourcePath string) (LinkType, error) {
+	debug.Logf("link: live linking %s to %s", packageName, sourcePath)
+
+	// Guard against path traversal: packageName is joined into .lnpm/<name>
+	// (which we replace) and node_modules/<name>.
+	if err := pack.ValidatePackageName(packageName); err != nil {
+		return "", err
+	}
+
+	// An absolute target is what a Windows junction needs, and what keeps the
+	// link valid however deep .lnpm/{package} sits.
+	absSource, err := filepath.Abs(sourcePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve source path: %w", err)
+	}
+	info, err := os.Stat(absSource)
+	if err != nil {
+		return "", fmt.Errorf("source directory %s is not available: %w", absSource, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("source path %s is not a directory", absSource)
+	}
+
+	lnpmPath := filepath.Join(l.projectPath, ".lnpm", packageName)
+	if err := os.MkdirAll(filepath.Dir(lnpmPath), 0755); err != nil {
+		return "", fmt.Errorf("failed to create .lnpm directory: %w", err)
+	}
+	// RemoveAll deletes a link without following it, so replacing an existing
+	// live link cannot reach into the source tree it points at.
+	if err := os.RemoveAll(lnpmPath); err != nil {
+		return "", fmt.Errorf("failed to remove existing linked package: %w", err)
+	}
+	if err := createDirSymlink(absSource, lnpmPath); err != nil {
+		return "", fmt.Errorf("failed to link source directory: %w", err)
+	}
+
+	if err := l.createNodeModulesSymlink(packageName); err != nil {
+		return "", err
+	}
+
+	return Live, nil
+}
+
 // Unlink removes a linked package from the project
 func (l *Linker) Unlink(packageName string) error {
 	if err := pack.ValidatePackageName(packageName); err != nil {
@@ -388,6 +442,16 @@ func (l *Linker) IsLinked(packageName string) bool {
 	lnpmPath := filepath.Join(l.projectPath, ".lnpm", packageName)
 	_, err := os.Stat(lnpmPath)
 	return err == nil
+}
+
+// IsLiveLinked reports whether .lnpm/{package} is a live link at the package's
+// source directory rather than a materialised copy of the store entry.
+//
+// A copy is always a real directory, and Lstat reports neither a symlink nor a
+// Windows junction as one, so "not a directory" is the whole test.
+func (l *Linker) IsLiveLinked(packageName string) bool {
+	info, err := os.Lstat(filepath.Join(l.projectPath, ".lnpm", packageName))
+	return err == nil && !info.IsDir()
 }
 
 // ListLinked returns all packages linked in the project

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -289,6 +289,15 @@ func (l *Linker) LinkSource(packageName string, sourcePath string) (LinkType, er
 		return "", err
 	}
 
+	// An empty source path is rejected before it is resolved, because
+	// filepath.Abs("") returns the working directory and a working directory
+	// stats as a directory: a package row written without a source path would
+	// otherwise link .lnpm/{package} at the consumer's own project root and
+	// report success.
+	if sourcePath == "" {
+		return "", fmt.Errorf("package %s has no recorded source directory - re-publish it from its source", packageName)
+	}
+
 	// An absolute target is what a Windows junction needs, and what keeps the
 	// link valid however deep .lnpm/{package} sits.
 	absSource, err := filepath.Abs(sourcePath)
@@ -304,16 +313,54 @@ func (l *Linker) LinkSource(packageName string, sourcePath string) (LinkType, er
 	}
 
 	lnpmPath := filepath.Join(l.projectPath, ".lnpm", packageName)
-	if err := os.MkdirAll(filepath.Dir(lnpmPath), 0755); err != nil {
+	parentDir := filepath.Dir(lnpmPath)
+	if err := os.MkdirAll(parentDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create .lnpm directory: %w", err)
 	}
-	// RemoveAll deletes a link without following it, so replacing an existing
-	// live link cannot reach into the source tree it points at.
-	if err := os.RemoveAll(lnpmPath); err != nil {
-		return "", fmt.Errorf("failed to remove existing linked package: %w", err)
-	}
-	if err := createDirSymlink(absSource, lnpmPath); err != nil {
+
+	// Create the link beside .lnpm/{package} and swap it in, for the reason
+	// Link's comment gives. What is being replaced may be a whole store copy —
+	// this is the copy-to-live conversion — and deleting that first would leave
+	// .lnpm/{package} missing for as long as the tree takes to delete, with no
+	// way back if creating the replacement then failed.
+	tempPath, err := newTempLink(parentDir, absSource)
+	if err != nil {
 		return "", fmt.Errorf("failed to link source directory: %w", err)
+	}
+	// Remove the temp link unless it is successfully committed via rename.
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	// Lstat, not Stat, so an existing live link whose source has since moved is
+	// still seen and still renamed aside rather than left in place.
+	retiredPath := tempPath + ".old"
+	hadPrevious := false
+	if _, err := os.Lstat(lnpmPath); err == nil {
+		if err := os.Rename(lnpmPath, retiredPath); err != nil {
+			return "", fmt.Errorf("failed to move aside existing linked package: %w", err)
+		}
+		hadPrevious = true
+	}
+	if err := os.Rename(tempPath, lnpmPath); err != nil {
+		if hadPrevious {
+			// If the rollback fails too, the previous package exists only at
+			// retiredPath. Name it in the error so it can be recovered by hand;
+			// deleting it here would destroy the user's only copy.
+			if rollbackErr := os.Rename(retiredPath, lnpmPath); rollbackErr != nil {
+				return "", fmt.Errorf("failed to finalize linked package: %w (the previous package could not be restored: %v, and is preserved at %s)", err, rollbackErr, retiredPath)
+			}
+		}
+		return "", fmt.Errorf("failed to finalize linked package: %w", err)
+	}
+	committed = true
+	if hadPrevious {
+		// RemoveAll deletes a link without following it, so retiring a previous
+		// live link cannot reach into the source tree it pointed at.
+		_ = os.RemoveAll(retiredPath)
 	}
 
 	if err := l.createNodeModulesSymlink(packageName); err != nil {
@@ -447,11 +494,22 @@ func (l *Linker) IsLinked(packageName string) bool {
 // IsLiveLinked reports whether .lnpm/{package} is a live link at the package's
 // source directory rather than a materialised copy of the store entry.
 //
-// A copy is always a real directory, and Lstat reports neither a symlink nor a
-// Windows junction as one, so "not a directory" is the whole test.
+// The test is positive - the entry must carry a link mode bit - rather than
+// merely "not a directory". Callers skip a live link and report success, so a
+// stray file, fifo or device left at that path must not pass: that is a corrupt
+// project, and reporting it as skipped would report corruption as success.
+//
+// The bits to accept come from os/types_windows.go (Go 1.26). Both
+// IO_REPARSE_TAG_SYMLINK and IO_REPARSE_TAG_MOUNT_POINT (a junction) are
+// reparse-tag name surrogates, and fileStat.mode skips "m |= ModeDir" for those,
+// so neither reads as a directory. Its tag switch then sets ModeSymlink for
+// IO_REPARSE_TAG_SYMLINK and falls through to "default: m |= ModeIrregular" for
+// a junction. Under GODEBUG=winsymlink=0 the retained modePreGo1_23 returns
+// ModeSymlink for both tags instead. Accepting either bit therefore covers a
+// Unix symlink, a Windows symlink and a junction under both settings.
 func (l *Linker) IsLiveLinked(packageName string) bool {
 	info, err := os.Lstat(filepath.Join(l.projectPath, ".lnpm", packageName))
-	return err == nil && !info.IsDir()
+	return err == nil && info.Mode()&(os.ModeSymlink|os.ModeIrregular) != 0
 }
 
 // ListLinked returns all packages linked in the project
@@ -500,6 +558,29 @@ func newTempDir(parent string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("failed to find an unused temp directory name in %s", parent)
+}
+
+// createDirSymlinkFn is createDirSymlink behind a variable so a test can force
+// the link creation to fail and prove that LinkSource leaves the previous
+// .lnpm/{package} intact. Production code never reassigns it.
+var createDirSymlinkFn = createDirSymlink
+
+// newTempLink creates a directory link to target under a uniquely named path
+// inside parent and returns that path. It is newTempDir's counterpart for
+// LinkSource: the name is dot-prefixed for the same reasons, so ListLinked
+// skips it and the retired-path scheme stays inside the same namespace.
+func newTempLink(parent, target string) (string, error) {
+	for attempt := 0; attempt < 1000; attempt++ {
+		path := filepath.Join(parent, fmt.Sprintf(".tmp-%x", rand.Uint64()))
+		err := createDirSymlinkFn(target, path)
+		if err == nil {
+			return path, nil
+		}
+		if !os.IsExist(err) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("failed to find an unused temp link name in %s", parent)
 }
 
 // copyFile copies a file

--- a/internal/link/link_failure_test.go
+++ b/internal/link/link_failure_test.go
@@ -363,6 +363,11 @@ func TestLinkSourceRejectsUnusableSource(t *testing.T) {
 	}{
 		{"missing source", filepath.Join(tmpDir, "deleted-source"), "is not available"},
 		{"source is a file", sourceFile, "is not a directory"},
+		// A package row can carry no source path at all. filepath.Abs("")
+		// resolves to the working directory, which stats as a directory, so
+		// without an explicit guard this links .lnpm/{package} at whatever
+		// directory the consumer happened to run lnpm from.
+		{"empty source", "", "no recorded source directory"},
 	}
 
 	for _, tc := range cases {
@@ -379,6 +384,121 @@ func TestLinkSourceRejectsUnusableSource(t *testing.T) {
 				t.Errorf(".lnpm/my-package exists after a failed LinkSource (Lstat err = %v), want it absent", err)
 			}
 		})
+	}
+}
+
+// TestLinkSourceKeepsPreviousOnFailure pins LinkSource's rollback. The previous
+// .lnpm/{package} is a store copy here - the copy-to-live conversion, which is
+// the case Link's comment names, because deleting a whole package tree is not
+// instantaneous - and it must survive a failure to create the replacement link
+// instead of being cleared up front with nothing left to restore.
+func TestLinkSourceKeepsPreviousOnFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	sourcePath := filepath.Join(tmpDir, "source")
+	for _, dir := range []string{projectPath, sourcePath} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	contents := map[string]string{
+		"package.json":  `{"name":"my-package"}`,
+		"dist/index.js": "index contents",
+	}
+	storePath, files := storeFixture(t, tmpDir, contents)
+
+	linker := New(projectPath)
+	if _, err := linker.Link("my-package", storePath, files); err != nil {
+		t.Fatalf("Link(): %v", err)
+	}
+
+	// Force the replacement link's creation to fail. Nothing else about the
+	// project is disturbed, so the only reason .lnpm/my-package could go missing
+	// is LinkSource having removed it before creating the replacement.
+	forced := errors.New("forced link failure")
+	original := createDirSymlinkFn
+	createDirSymlinkFn = func(string, string) error { return forced }
+	t.Cleanup(func() { createDirSymlinkFn = original })
+
+	if _, err := linker.LinkSource("my-package", sourcePath); !errors.Is(err, forced) {
+		t.Fatalf("LinkSource() error = %v, want one wrapping the forced failure", err)
+	}
+
+	lnpmPath := filepath.Join(projectPath, ".lnpm", "my-package")
+	info, err := os.Lstat(lnpmPath)
+	if err != nil {
+		t.Fatalf(".lnpm/my-package is gone after a failed LinkSource: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf(".lnpm/my-package mode = %v after a failed LinkSource, want the previous store copy", info.Mode())
+	}
+	for rel, want := range contents {
+		got, err := os.ReadFile(filepath.Join(lnpmPath, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Errorf("reading %s from the preserved package: %v", rel, err)
+			continue
+		}
+		if string(got) != want {
+			t.Errorf("preserved %s = %q, want %q", rel, string(got), want)
+		}
+	}
+
+	// No abandoned temp link either.
+	if names := entryNames(t, filepath.Join(projectPath, ".lnpm")); len(names) != 1 || names[0] != "my-package" {
+		t.Errorf(".lnpm entries after a failed LinkSource = %v, want [my-package]", names)
+	}
+}
+
+// TestIsLiveLinkedRejectsNonLinks pins what IsLiveLinked accepts. pull and push
+// skip a live-linked package and report the skip as success, so anything at
+// .lnpm/{package} that is not a link - a stray file left by a crashed tool, say
+// - must not be taken for one: that would report a corrupt project as fine.
+func TestIsLiveLinkedRejectsNonLinks(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	lnpmDir := filepath.Join(projectPath, ".lnpm")
+	sourcePath := filepath.Join(tmpDir, "source")
+	for _, dir := range []string{lnpmDir, sourcePath} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	linker := New(projectPath)
+
+	if linker.IsLiveLinked("absent") {
+		t.Error("IsLiveLinked(absent) = true, want false")
+	}
+
+	if err := os.MkdirAll(filepath.Join(lnpmDir, "a-copy"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if linker.IsLiveLinked("a-copy") {
+		t.Error("IsLiveLinked(a-copy) = true for a store copy, want false")
+	}
+
+	if err := os.WriteFile(filepath.Join(lnpmDir, "a-file"), []byte("stray"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if linker.IsLiveLinked("a-file") {
+		t.Error("IsLiveLinked(a-file) = true for a regular file, want false")
+	}
+
+	if _, err := linker.LinkSource("a-link", sourcePath); err != nil {
+		t.Fatalf("LinkSource(a-link): %v", err)
+	}
+	if !linker.IsLiveLinked("a-link") {
+		t.Error("IsLiveLinked(a-link) = false for a live link, want true")
+	}
+
+	// A live link whose source has since been deleted is still a live link:
+	// relinking it from the store would still end the live updates silently.
+	if err := os.RemoveAll(sourcePath); err != nil {
+		t.Fatal(err)
+	}
+	if !linker.IsLiveLinked("a-link") {
+		t.Error("IsLiveLinked(a-link) = false for a dangling live link, want true")
 	}
 }
 

--- a/internal/link/link_failure_test.go
+++ b/internal/link/link_failure_test.go
@@ -339,3 +339,69 @@ func TestUnlinkRemovesEmptyLnpmDir(t *testing.T) {
 		t.Errorf(".lnpm still exists after unlinking the last package (Stat err = %v), want it removed", err)
 	}
 }
+
+// TestLinkSourceRejectsUnusableSource drives LinkSource's guards on the source
+// directory recorded when the package was published. That directory can have
+// been deleted or replaced since, and linking .lnpm/{package} at it anyway
+// would defer the failure to whatever tool next resolved node_modules.
+func TestLinkSourceRejectsUnusableSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	sourceFile := filepath.Join(tmpDir, "a-file")
+	if err := os.WriteFile(sourceFile, []byte("not a package"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name    string
+		source  string
+		wantErr string
+	}{
+		{"missing source", filepath.Join(tmpDir, "deleted-source"), "is not available"},
+		{"source is a file", sourceFile, "is not a directory"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			linker := New(projectPath)
+
+			_, err := linker.LinkSource("my-package", tc.source)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("LinkSource(%s) error = %v, want one containing %q", tc.source, err, tc.wantErr)
+			}
+
+			assertNoSymlink(t, projectPath, "my-package")
+			if _, err := os.Lstat(filepath.Join(projectPath, ".lnpm", "my-package")); !os.IsNotExist(err) {
+				t.Errorf(".lnpm/my-package exists after a failed LinkSource (Lstat err = %v), want it absent", err)
+			}
+		})
+	}
+}
+
+// TestLinkSourceRejectsTraversingName asserts that LinkSource validates the
+// package name before joining it into .lnpm and node_modules, exactly as Link
+// does: the name reaches both from the store, and a traversing one would place
+// a link outside the project.
+func TestLinkSourceRejectsTraversingName(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	sourcePath := filepath.Join(tmpDir, "source")
+	for _, dir := range []string{projectPath, sourcePath} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	linker := New(projectPath)
+	if _, err := linker.LinkSource("../escaped", sourcePath); err == nil {
+		t.Fatal("LinkSource(../escaped) error = nil, want a validation error")
+	}
+
+	if _, err := os.Lstat(filepath.Join(tmpDir, "escaped")); !os.IsNotExist(err) {
+		t.Errorf("a link was created outside the project (Lstat err = %v), want none", err)
+	}
+}

--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -298,3 +298,36 @@ func TestCopyFile(t *testing.T) {
 		t.Errorf("copied content = %q, want %q", string(data), content)
 	}
 }
+
+// TestLinkSourceResolvesRelativeSource pins that a relative source path is
+// resolved against the working directory, not against .lnpm/. Only an absolute
+// target makes the link valid from where it is created - and a Windows junction
+// accepts nothing else.
+func TestLinkSourceResolvesRelativeSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	sourcePath := filepath.Join(tmpDir, "source")
+	for _, dir := range []string{projectPath, sourcePath} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(sourcePath, "index.js"), []byte("live"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(tmpDir)
+
+	linker := New(projectPath)
+	if _, err := linker.LinkSource("my-package", "source"); err != nil {
+		t.Fatalf("LinkSource(source): %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(projectPath, ".lnpm", "my-package", "index.js"))
+	if err != nil {
+		t.Fatalf("Failed to read through the live link: %v", err)
+	}
+	if string(content) != "live" {
+		t.Errorf("linked index.js = %q, want %q", content, "live")
+	}
+}

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -287,6 +287,42 @@ func (te *TestEnvironment) AssertDatabaseNoLink(packageName, projectPath string)
 	}
 }
 
+// AssertDatabaseLinkType verifies the link between packageName and projectPath
+// exists AND was recorded with the given type. A missing row fails: the type is
+// only meaningful if there is a row carrying it, so a loop that quietly matches
+// nothing would assert nothing at all.
+func (te *TestEnvironment) AssertDatabaseLinkType(projectPath, packageName, wantType string) {
+	te.t.Helper()
+
+	pkg, err := te.Database.GetPackageByName(packageName)
+	if err != nil || pkg == nil {
+		te.t.Fatalf("Package %s not found in database: %v", packageName, err)
+	}
+
+	proj, err := te.Database.GetProjectByPath(projectPath)
+	if err != nil || proj == nil {
+		te.t.Fatalf("Project %s not found in database: %v", projectPath, err)
+	}
+
+	links, err := te.Database.GetLinksForProject(proj.ID)
+	if err != nil {
+		te.t.Fatalf("Failed to get links: %v", err)
+	}
+
+	for _, link := range links {
+		if link.PackageID == pkg.ID {
+			if link.LinkType != wantType {
+				te.t.Errorf("Expected link type %s for %s in %s, got %s",
+					wantType, packageName, projectPath, link.LinkType)
+			}
+			return
+		}
+	}
+
+	te.t.Errorf("Expected a link between %s and %s in database, but found none",
+		packageName, projectPath)
+}
+
 // AssertFilesLinked verifies package files are linked to project
 func (te *TestEnvironment) AssertFilesLinked(projectPath, packageName string) {
 	te.t.Helper()
@@ -742,6 +778,22 @@ func (te *TestEnvironment) AssertStoreCopy(projectDir, pkg string) {
 	}
 }
 
+// AssertFileExists is AssertDirectoryExists for a regular file: same check,
+// honest name and message. AssertDirectoryExists only stats, so calling it on a
+// file passes, but the failure it prints then names the wrong kind of thing.
+func (te *TestEnvironment) AssertFileExists(path string, shouldExist bool) {
+	te.t.Helper()
+
+	_, err := os.Stat(path)
+	if exists := err == nil; exists != shouldExist {
+		if shouldExist {
+			te.t.Errorf("Expected file %s to exist, but it doesn't", path)
+		} else {
+			te.t.Errorf("Expected file %s to NOT exist, but it does", path)
+		}
+	}
+}
+
 // AssertFileContent checks that the file at path holds want.
 func (te *TestEnvironment) AssertFileContent(path, want string) {
 	te.t.Helper()
@@ -766,22 +818,12 @@ func (te *TestEnvironment) publishAndAdd(pkgName string) (pkgDir, projectDir str
 	return pkgDir, projectDir
 }
 
-// linkedFileContent reads .lnpm/<pkg>/<rel> in projectDir, failing on error.
-func (te *TestEnvironment) linkedFileContent(projectDir, pkg, rel string) string {
-	te.t.Helper()
-	data, err := os.ReadFile(filepath.Join(projectDir, ".lnpm", pkg, rel))
-	if err != nil {
-		te.t.Fatalf("Failed to read linked file %s for %s: %v", rel, pkg, err)
-	}
-	return string(data)
-}
-
-// AssertLinkedFileContent checks that .lnpm/<pkg>/<rel> equals want.
+// AssertLinkedFileContent checks that .lnpm/<pkg>/<rel> equals want. It is
+// AssertFileContent addressed the way most of the suite wants it - by project,
+// package and relative path - and reads the same file for the same reason.
 func (te *TestEnvironment) AssertLinkedFileContent(projectDir, pkg, rel, want string) {
 	te.t.Helper()
-	if got := te.linkedFileContent(projectDir, pkg, rel); got != want {
-		te.t.Errorf("linked %s/%s: expected %q, got %q", pkg, rel, want, got)
-	}
+	te.AssertFileContent(filepath.Join(projectDir, ".lnpm", pkg, rel), want)
 }
 
 // writeFile writes content to path (relative to cwd or absolute), failing on error.

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -689,6 +689,72 @@ func (te *TestEnvironment) addPkg(projectDir, spec string, dev, pure bool) {
 	}
 }
 
+// addLinkedPkg chdirs into projectDir and adds spec in live-link mode (--link),
+// failing on error.
+func (te *TestEnvironment) addLinkedPkg(projectDir, spec string) {
+	te.t.Helper()
+	te.chdir(projectDir)
+	if err := cli.RunAddMultiple([]string{spec}, false, false, false, true); err != nil {
+		te.t.Fatalf("Failed to add %s --link: %v", spec, err)
+	}
+}
+
+// AssertLiveLink checks that .lnpm/<pkg> is a link resolving to sourceDir rather
+// than a materialised store copy.
+func (te *TestEnvironment) AssertLiveLink(projectDir, pkg, sourceDir string) {
+	te.t.Helper()
+
+	lnpmPath := filepath.Join(projectDir, ".lnpm", pkg)
+	info, err := os.Lstat(lnpmPath)
+	if err != nil {
+		te.t.Fatalf("Expected .lnpm/%s to exist: %v", pkg, err)
+	}
+	// A store copy is a real directory. A live link is a symlink, or on Windows
+	// possibly a junction, and Lstat reports neither as a directory.
+	if info.IsDir() {
+		te.t.Fatalf("Expected .lnpm/%s to be a live link, but it is a directory", pkg)
+	}
+
+	got, err := filepath.EvalSymlinks(lnpmPath)
+	if err != nil {
+		te.t.Fatalf("Failed to resolve .lnpm/%s: %v", pkg, err)
+	}
+	want, err := filepath.EvalSymlinks(sourceDir)
+	if err != nil {
+		te.t.Fatalf("Failed to resolve source %s: %v", sourceDir, err)
+	}
+	if got != want {
+		te.t.Errorf("Expected .lnpm/%s to resolve to %s, got %s", pkg, want, got)
+	}
+}
+
+// AssertStoreCopy checks that .lnpm/<pkg> is a real directory of copied files,
+// which is what everything but --link produces.
+func (te *TestEnvironment) AssertStoreCopy(projectDir, pkg string) {
+	te.t.Helper()
+
+	info, err := os.Lstat(filepath.Join(projectDir, ".lnpm", pkg))
+	if err != nil {
+		te.t.Fatalf("Expected .lnpm/%s to exist: %v", pkg, err)
+	}
+	if !info.IsDir() {
+		te.t.Errorf("Expected .lnpm/%s to be a store copy, but it is a link", pkg)
+	}
+}
+
+// AssertFileContent checks that the file at path holds want.
+func (te *TestEnvironment) AssertFileContent(path, want string) {
+	te.t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		te.t.Fatalf("Failed to read %s: %v", path, err)
+	}
+	if string(data) != want {
+		te.t.Errorf("%s: expected %q, got %q", path, want, data)
+	}
+}
+
 // publishAndAdd publishes pkgName (single index.js) and adds it to a fresh
 // "test-project", returning (pkgDir, projectDir). The cwd is left inside the
 // project. This is the single most common setup across the suite.

--- a/tests/link_mode_test.go
+++ b/tests/link_mode_test.go
@@ -1,0 +1,280 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
+)
+
+// TestAddLinkPointsAtSource covers the core of live-link mode: `add --link`
+// points .lnpm/<pkg> at the package's source directory instead of filling it
+// with a copy of the store entry.
+func TestAddLinkPointsAtSource(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("live-lib")
+	projectDir := env.newProject("live-project")
+
+	env.addLinkedPkg(projectDir, "live-lib")
+
+	env.AssertLiveLink(projectDir, "live-lib", pkgDir)
+	env.AssertSymlinkExists(projectDir, "live-lib")
+	env.AssertFileContent(filepath.Join(projectDir, "node_modules", "live-lib", "index.js"),
+		"module.exports = 'live-lib';")
+}
+
+// TestAddLinkReportsLiveSource pins how `add --link` reports itself, and the
+// link type it records in the database: a live link is not a hardlink or a
+// copy, and the user is told which they got.
+func TestAddLinkReportsLiveSource(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("report-lib")
+	projectDir := env.newProject("report-project")
+
+	out := captureStdout(t, func() { env.addLinkedPkg(projectDir, "report-lib") })
+
+	if !strings.Contains(out, "Adding report-lib@1.0.0 (linked to source)") {
+		t.Errorf("Expected add to report the live link, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Link type: link (live source)") {
+		t.Errorf("Expected the live source link type, got:\n%s", out)
+	}
+
+	pkg, err := env.Database.GetPackageByName("report-lib")
+	if err != nil || pkg == nil {
+		t.Fatalf("report-lib not in database: %v", err)
+	}
+	proj, err := env.Database.GetProjectByPath(projectDir)
+	if err != nil || proj == nil {
+		t.Fatalf("project not in database: %v", err)
+	}
+	links, err := env.Database.GetLinksForProject(proj.ID)
+	if err != nil {
+		t.Fatalf("Failed to get links: %v", err)
+	}
+	for _, l := range links {
+		if l.PackageID == pkg.ID && l.LinkType != "link" {
+			t.Errorf("Expected recorded link type link, got %s", l.LinkType)
+		}
+	}
+}
+
+// TestLinkedSourceEditsAreVisibleImmediately covers the reason live-link mode
+// exists: an edit to the source package reaches the consumer through
+// node_modules/<pkg> with no publish, push or pull in between.
+func TestLinkedSourceEditsAreVisibleImmediately(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("edit-lib")
+	projectDir := env.newProject("edit-project")
+	env.addLinkedPkg(projectDir, "edit-lib")
+
+	// Edit the source directly. No lnpm command follows.
+	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'edited';")
+	env.writeFile(filepath.Join(pkgDir, "extra.js"), "module.exports = 'new file';")
+
+	consumed := filepath.Join(projectDir, "node_modules", "edit-lib")
+	env.AssertFileContent(filepath.Join(consumed, "index.js"), "module.exports = 'edited';")
+	env.AssertFileContent(filepath.Join(consumed, "extra.js"), "module.exports = 'new file';")
+}
+
+// TestRemoveLinkedPackageKeepsSource covers removal of a live-linked package:
+// it is torn down exactly like a copy-linked one, and - because .lnpm/<pkg> is
+// now a link into the user's real source tree - the teardown must delete the
+// link and nothing behind it.
+func TestRemoveLinkedPackageKeepsSource(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("remove-live-lib")
+	projectDir := env.newProject("remove-live-project")
+	env.addLinkedPkg(projectDir, "remove-live-lib")
+
+	if err := cli.RunRemove("remove-live-lib", false, false); err != nil {
+		t.Fatalf("Failed to remove package: %v", err)
+	}
+
+	env.AssertSymlinkMissing(projectDir, "remove-live-lib")
+	env.AssertDirectoryExists(filepath.Join(projectDir, ".lnpm", "remove-live-lib"), false)
+	env.AssertPackageJSONMissing(projectDir, "remove-live-lib")
+	env.AssertDatabaseNoLink("remove-live-lib", projectDir)
+	env.AssertLockfileExists(projectDir, false)
+
+	// The source package must have survived untouched.
+	env.AssertDirectoryExists(pkgDir, true)
+	env.AssertFileContent(filepath.Join(pkgDir, "index.js"), "module.exports = 'remove-live-lib';")
+	env.AssertDirectoryExists(filepath.Join(pkgDir, "package.json"), true)
+}
+
+// TestRetreatForceRestoresLinkedPackage covers `retreat --force` on a
+// live-linked package: the original specifier comes back, .lnpm/ goes away, and
+// the source tree the removed link pointed at is left alone.
+func TestRetreatForceRestoresLinkedPackage(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("retreat-live-lib")
+	projectDir := env.newProject("retreat-live-project")
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":         "retreat-live-project",
+		"version":      "1.0.0",
+		"dependencies": map[string]interface{}{"retreat-live-lib": "^1.0.0"},
+	})
+	env.addLinkedPkg(projectDir, "retreat-live-lib")
+	env.AssertPackageJSON(projectDir, "retreat-live-lib", "link:.lnpm/retreat-live-lib")
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+
+	env.AssertPackageJSON(projectDir, "retreat-live-lib", "^1.0.0")
+	env.AssertDirectoryExists(filepath.Join(projectDir, ".lnpm"), false)
+	env.AssertLockfileExists(projectDir, false)
+
+	env.AssertDirectoryExists(pkgDir, true)
+	env.AssertFileContent(filepath.Join(pkgDir, "index.js"), "module.exports = 'retreat-live-lib';")
+}
+
+// TestRetreatIgnoresLinkReferenceAsOriginalVersion pins that retreat treats a
+// link:.lnpm/ specifier recorded as an original version the same way it treats
+// file:.lnpm/ - as lnpm's own value, not the user's - so the dependency is
+// dropped rather than restored to a reference that no longer resolves.
+func TestRetreatIgnoresLinkReferenceAsOriginalVersion(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("stale-ref-lib")
+	projectDir := env.newProject("stale-ref-project")
+	env.addLinkedPkg(projectDir, "stale-ref-lib")
+
+	// Rewrite the lock entry the way an older version could have recorded it.
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		entry, ok := lock.Get("stale-ref-lib")
+		if !ok {
+			t.Fatal("stale-ref-lib missing from lockfile")
+		}
+		entry.OriginalVersion = "link:.lnpm/stale-ref-lib"
+		lock.Add("stale-ref-lib", entry)
+		if err := lock.Save(projectDir); err != nil {
+			t.Fatalf("Failed to save lockfile: %v", err)
+		}
+	})
+
+	// The preview must say the same thing the --force run then does.
+	out := captureStdout(t, func() {
+		if err := cli.RunRetreat(false, false); err != nil {
+			t.Fatalf("Failed to preview retreat: %v", err)
+		}
+	})
+	if !strings.Contains(out, "stale-ref-lib: will be removed from package.json") {
+		t.Errorf("Expected the preview to drop the dependency, got:\n%s", out)
+	}
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+
+	env.AssertPackageJSONMissing(projectDir, "stale-ref-lib")
+}
+
+// TestReAddOverLiveLinkKeepsSource covers re-adding on top of an existing live
+// link, in both modes. Each add replaces .lnpm/<pkg>, which is the third place
+// that could delete through the link into the user's source tree.
+func TestReAddOverLiveLinkKeepsSource(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("readd-live-lib")
+	projectDir := env.newProject("readd-live-project")
+	env.addLinkedPkg(projectDir, "readd-live-lib")
+
+	// Re-adding with --link replaces one live link with another.
+	env.addLinkedPkg(projectDir, "readd-live-lib")
+	env.AssertLiveLink(projectDir, "readd-live-lib", pkgDir)
+	env.AssertFileContent(filepath.Join(pkgDir, "index.js"), "module.exports = 'readd-live-lib';")
+
+	// Adding without --link converts the live link back to a store copy.
+	env.addPkg(projectDir, "readd-live-lib", false, false)
+	env.AssertStoreCopy(projectDir, "readd-live-lib")
+	env.AssertPackageJSON(projectDir, "readd-live-lib", "file:.lnpm/readd-live-lib")
+	env.AssertDirectoryExists(pkgDir, true)
+	env.AssertFileContent(filepath.Join(pkgDir, "index.js"), "module.exports = 'readd-live-lib';")
+
+	// And back again, over the copy.
+	env.addLinkedPkg(projectDir, "readd-live-lib")
+	env.AssertLiveLink(projectDir, "readd-live-lib", pkgDir)
+	env.AssertFileContent(filepath.Join(pkgDir, "index.js"), "module.exports = 'readd-live-lib';")
+}
+
+// TestPullSkipsLiveLinkedPackage covers pull against a live-linked package.
+// Relinking it from the store would silently swap the live link for a snapshot
+// copy - the consumer would stop seeing source edits with nothing said about it
+// - so pull leaves it alone and says so, in both the all and the named form.
+func TestPullSkipsLiveLinkedPackage(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("pull-live-lib")
+	projectDir := env.newProject("pull-live-project")
+	env.addLinkedPkg(projectDir, "pull-live-lib")
+
+	env.republish(pkgDir, "pull-live-lib", "2.0.0", "module.exports = 'v2';")
+
+	env.chdir(projectDir)
+	out := captureStdout(t, func() {
+		if err := cli.RunPull(nil); err != nil {
+			t.Fatalf("RunPull: %v", err)
+		}
+		if err := cli.RunPull([]string{"pull-live-lib"}); err != nil {
+			t.Fatalf("RunPull by name: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "live link") {
+		t.Errorf("Expected pull to report the live link, got:\n%s", out)
+	}
+	env.AssertLiveLink(projectDir, "pull-live-lib", pkgDir)
+	assertLockVersion(t, env, projectDir, "pull-live-lib", "1.0.0")
+	env.AssertFileContent(filepath.Join(projectDir, "node_modules", "pull-live-lib", "index.js"),
+		"module.exports = 'v2';")
+}
+
+// TestPushSkipsLiveLinkedConsumer covers push from the other side of the same
+// hazard pull has: pushing relinks every consumer from the store, which for a
+// live-linked consumer would quietly replace its link with a snapshot copy and
+// end the live updates it was added for.
+func TestPushSkipsLiveLinkedConsumer(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("push-live-lib")
+	projectDir := env.newProject("push-live-project")
+	env.addLinkedPkg(projectDir, "push-live-lib")
+
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'pushed';")
+	out := captureStdout(t, func() {
+		if err := cli.RunPush(false); err != nil {
+			t.Fatalf("RunPush: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "live link") {
+		t.Errorf("Expected push to report the live link, got:\n%s", out)
+	}
+	env.AssertLiveLink(projectDir, "push-live-lib", pkgDir)
+	env.AssertFileContent(filepath.Join(projectDir, "node_modules", "push-live-lib", "index.js"),
+		"module.exports = 'pushed';")
+}
+
+// TestAddDefaultStillCopiesFromStore pins that the default path is untouched:
+// without --link, .lnpm/<pkg> is still a real directory of copied files.
+func TestAddDefaultStillCopiesFromStore(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("copy-lib")
+	projectDir := env.newProject("copy-project")
+
+	env.addPkg(projectDir, "copy-lib", false, false)
+
+	env.AssertStoreCopy(projectDir, "copy-lib")
+}
+

--- a/tests/link_mode_test.go
+++ b/tests/link_mode_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
-	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
 
 // TestAddLinkPointsAtSource covers the core of live-link mode: `add --link`
@@ -44,23 +43,46 @@ func TestAddLinkReportsLiveSource(t *testing.T) {
 		t.Errorf("Expected the live source link type, got:\n%s", out)
 	}
 
-	pkg, err := env.Database.GetPackageByName("report-lib")
-	if err != nil || pkg == nil {
-		t.Fatalf("report-lib not in database: %v", err)
+	env.AssertDatabaseLinkType(projectDir, "report-lib", "link")
+}
+
+// TestAddMultipleLinkReportsLiveSource covers the multi-package path, which
+// resolves and links in parallel and reports separately from the single-package
+// one. It must say the same things: that the packages are linked to their
+// sources, and that each got a live link rather than a copy.
+func TestAddMultipleLinkReportsLiveSource(t *testing.T) {
+	env := setupTest(t)
+
+	libA := env.simplePkg("multi-live-a")
+	libB := env.simplePkg("multi-live-b")
+	projectDir := env.newProject("multi-live-project")
+
+	out := captureStdout(t, func() {
+		env.chdir(projectDir)
+		if err := cli.RunAddMultiple([]string{"multi-live-a", "multi-live-b"}, false, false, false, true); err != nil {
+			t.Fatalf("add --link failed: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "(linked to source)") {
+		t.Errorf("Expected the multi-package add to report linking to source, got:\n%s", out)
 	}
-	proj, err := env.Database.GetProjectByPath(projectDir)
-	if err != nil || proj == nil {
-		t.Fatalf("project not in database: %v", err)
-	}
-	links, err := env.Database.GetLinksForProject(proj.ID)
-	if err != nil {
-		t.Fatalf("Failed to get links: %v", err)
-	}
-	for _, l := range links {
-		if l.PackageID == pkg.ID && l.LinkType != "link" {
-			t.Errorf("Expected recorded link type link, got %s", l.LinkType)
+	for _, name := range []string{"multi-live-a", "multi-live-b"} {
+		if !strings.Contains(out, "Added "+name+"@1.0.0") {
+			t.Errorf("Expected %s in the summary, got:\n%s", name, out)
 		}
 	}
+	// One "Link type" line per package, both naming the live source link. The
+	// bare type name "link" - which is what this path used to print - would not
+	// match.
+	if got := strings.Count(out, "Link type: link (live source)"); got != 2 {
+		t.Errorf("Expected 2 live source link type lines, got %d in:\n%s", got, out)
+	}
+
+	env.AssertLiveLink(projectDir, "multi-live-a", libA)
+	env.AssertLiveLink(projectDir, "multi-live-b", libB)
+	env.AssertDatabaseLinkType(projectDir, "multi-live-a", "link")
+	env.AssertDatabaseLinkType(projectDir, "multi-live-b", "link")
 }
 
 // TestLinkedSourceEditsAreVisibleImmediately covers the reason live-link mode
@@ -106,76 +128,7 @@ func TestRemoveLinkedPackageKeepsSource(t *testing.T) {
 	// The source package must have survived untouched.
 	env.AssertDirectoryExists(pkgDir, true)
 	env.AssertFileContent(filepath.Join(pkgDir, "index.js"), "module.exports = 'remove-live-lib';")
-	env.AssertDirectoryExists(filepath.Join(pkgDir, "package.json"), true)
-}
-
-// TestRetreatForceRestoresLinkedPackage covers `retreat --force` on a
-// live-linked package: the original specifier comes back, .lnpm/ goes away, and
-// the source tree the removed link pointed at is left alone.
-func TestRetreatForceRestoresLinkedPackage(t *testing.T) {
-	env := setupTest(t)
-
-	pkgDir := env.simplePkg("retreat-live-lib")
-	projectDir := env.newProject("retreat-live-project")
-	env.writePackageJSON(projectDir, map[string]interface{}{
-		"name":         "retreat-live-project",
-		"version":      "1.0.0",
-		"dependencies": map[string]interface{}{"retreat-live-lib": "^1.0.0"},
-	})
-	env.addLinkedPkg(projectDir, "retreat-live-lib")
-	env.AssertPackageJSON(projectDir, "retreat-live-lib", "link:.lnpm/retreat-live-lib")
-
-	if err := cli.RunRetreat(true, false); err != nil {
-		t.Fatalf("Failed to retreat: %v", err)
-	}
-
-	env.AssertPackageJSON(projectDir, "retreat-live-lib", "^1.0.0")
-	env.AssertDirectoryExists(filepath.Join(projectDir, ".lnpm"), false)
-	env.AssertLockfileExists(projectDir, false)
-
-	env.AssertDirectoryExists(pkgDir, true)
-	env.AssertFileContent(filepath.Join(pkgDir, "index.js"), "module.exports = 'retreat-live-lib';")
-}
-
-// TestRetreatIgnoresLinkReferenceAsOriginalVersion pins that retreat treats a
-// link:.lnpm/ specifier recorded as an original version the same way it treats
-// file:.lnpm/ - as lnpm's own value, not the user's - so the dependency is
-// dropped rather than restored to a reference that no longer resolves.
-func TestRetreatIgnoresLinkReferenceAsOriginalVersion(t *testing.T) {
-	env := setupTest(t)
-
-	env.simplePkg("stale-ref-lib")
-	projectDir := env.newProject("stale-ref-project")
-	env.addLinkedPkg(projectDir, "stale-ref-lib")
-
-	// Rewrite the lock entry the way an older version could have recorded it.
-	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
-		entry, ok := lock.Get("stale-ref-lib")
-		if !ok {
-			t.Fatal("stale-ref-lib missing from lockfile")
-		}
-		entry.OriginalVersion = "link:.lnpm/stale-ref-lib"
-		lock.Add("stale-ref-lib", entry)
-		if err := lock.Save(projectDir); err != nil {
-			t.Fatalf("Failed to save lockfile: %v", err)
-		}
-	})
-
-	// The preview must say the same thing the --force run then does.
-	out := captureStdout(t, func() {
-		if err := cli.RunRetreat(false, false); err != nil {
-			t.Fatalf("Failed to preview retreat: %v", err)
-		}
-	})
-	if !strings.Contains(out, "stale-ref-lib: will be removed from package.json") {
-		t.Errorf("Expected the preview to drop the dependency, got:\n%s", out)
-	}
-
-	if err := cli.RunRetreat(true, false); err != nil {
-		t.Fatalf("Failed to retreat: %v", err)
-	}
-
-	env.AssertPackageJSONMissing(projectDir, "stale-ref-lib")
+	env.AssertFileExists(filepath.Join(pkgDir, "package.json"), true)
 }
 
 // TestReAddOverLiveLinkKeepsSource covers re-adding on top of an existing live
@@ -206,67 +159,14 @@ func TestReAddOverLiveLinkKeepsSource(t *testing.T) {
 	env.AssertFileContent(filepath.Join(pkgDir, "index.js"), "module.exports = 'readd-live-lib';")
 }
 
-// TestPullSkipsLiveLinkedPackage covers pull against a live-linked package.
-// Relinking it from the store would silently swap the live link for a snapshot
-// copy - the consumer would stop seeing source edits with nothing said about it
-// - so pull leaves it alone and says so, in both the all and the named form.
-func TestPullSkipsLiveLinkedPackage(t *testing.T) {
-	env := setupTest(t)
-
-	pkgDir := env.simplePkg("pull-live-lib")
-	projectDir := env.newProject("pull-live-project")
-	env.addLinkedPkg(projectDir, "pull-live-lib")
-
-	env.republish(pkgDir, "pull-live-lib", "2.0.0", "module.exports = 'v2';")
-
-	env.chdir(projectDir)
-	out := captureStdout(t, func() {
-		if err := cli.RunPull(nil); err != nil {
-			t.Fatalf("RunPull: %v", err)
-		}
-		if err := cli.RunPull([]string{"pull-live-lib"}); err != nil {
-			t.Fatalf("RunPull by name: %v", err)
-		}
-	})
-
-	if !strings.Contains(out, "live link") {
-		t.Errorf("Expected pull to report the live link, got:\n%s", out)
-	}
-	env.AssertLiveLink(projectDir, "pull-live-lib", pkgDir)
-	assertLockVersion(t, env, projectDir, "pull-live-lib", "1.0.0")
-	env.AssertFileContent(filepath.Join(projectDir, "node_modules", "pull-live-lib", "index.js"),
-		"module.exports = 'v2';")
-}
-
-// TestPushSkipsLiveLinkedConsumer covers push from the other side of the same
-// hazard pull has: pushing relinks every consumer from the store, which for a
-// live-linked consumer would quietly replace its link with a snapshot copy and
-// end the live updates it was added for.
-func TestPushSkipsLiveLinkedConsumer(t *testing.T) {
-	env := setupTest(t)
-
-	pkgDir := env.simplePkg("push-live-lib")
-	projectDir := env.newProject("push-live-project")
-	env.addLinkedPkg(projectDir, "push-live-lib")
-
-	env.chdir(pkgDir)
-	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'pushed';")
-	out := captureStdout(t, func() {
-		if err := cli.RunPush(false); err != nil {
-			t.Fatalf("RunPush: %v", err)
-		}
-	})
-
-	if !strings.Contains(out, "live link") {
-		t.Errorf("Expected push to report the live link, got:\n%s", out)
-	}
-	env.AssertLiveLink(projectDir, "push-live-lib", pkgDir)
-	env.AssertFileContent(filepath.Join(projectDir, "node_modules", "push-live-lib", "index.js"),
-		"module.exports = 'pushed';")
-}
-
 // TestAddDefaultStillCopiesFromStore pins that the default path is untouched:
 // without --link, .lnpm/<pkg> is still a real directory of copied files.
+//
+// This is the guarantee TestAddDefaultProtocolUnchanged (link_protocol_test.go)
+// cannot express. That test reads package.json, and the protocol string there
+// was already correct before --link pointed at the source at all: it stayed
+// "file:.lnpm/<pkg>" whether .lnpm/<pkg> held a copy or a link. Only looking at
+// .lnpm/<pkg> itself distinguishes the two.
 func TestAddDefaultStillCopiesFromStore(t *testing.T) {
 	env := setupTest(t)
 
@@ -277,4 +177,3 @@ func TestAddDefaultStillCopiesFromStore(t *testing.T) {
 
 	env.AssertStoreCopy(projectDir, "copy-lib")
 }
-

--- a/tests/publish_test.go
+++ b/tests/publish_test.go
@@ -151,6 +151,44 @@ func TestPublishWithPushReportsFailedProjects(t *testing.T) {
 	env.AssertLinkedFileContent(projectA, "push-fail-pkg", "index.js", "module.exports = 'v2';")
 }
 
+// TestPublishWithPushSkipsLiveLinkedConsumer covers the relink loop reached by
+// `publish --push`, which is a separate one from `push`'s. It has the same
+// hazard: relinking a live-linked consumer from the store turns its link into a
+// snapshot copy, and the source edits it was added for stop arriving with
+// nothing said about it.
+func TestPublishWithPushSkipsLiveLinkedConsumer(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("pub-live-lib")
+	copyProject := env.newProject("pub-copy-project")
+	env.addPkg(copyProject, "pub-live-lib", false, false)
+	liveProject := env.newProject("pub-live-project")
+	env.addLinkedPkg(liveProject, "pub-live-lib")
+
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'v2';")
+	out := captureStdout(t, func() {
+		if err := cli.RunPublish(true, false, false, false); err != nil {
+			t.Fatalf("Failed to publish with push: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Pushed to 1/2 projects (1 skipped: live link to source)") {
+		t.Errorf("Expected a coherent 1/2 summary naming the skip, got:\n%s", out)
+	}
+
+	// The copy-linked project got the snapshot, as always.
+	env.AssertLinkedFileContent(copyProject, "pub-live-lib", "index.js", "module.exports = 'v2';")
+
+	// The live-linked one is still a link, and a later edit still reaches it
+	// with no lnpm command - which is the acceptance criterion a clobbered link
+	// silently breaks.
+	env.AssertLiveLink(liveProject, "pub-live-lib", pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'v3';")
+	env.AssertFileContent(filepath.Join(liveProject, "node_modules", "pub-live-lib", "index.js"),
+		"module.exports = 'v3';")
+}
+
 // TestPublishConcurrentSamePackage tests concurrent publishes of same package.
 func TestPublishConcurrentSamePackage(t *testing.T) {
 	env := setupTest(t)

--- a/tests/pull_test.go
+++ b/tests/pull_test.go
@@ -461,3 +461,66 @@ func TestPullNoLinkedPackages(t *testing.T) {
 	}
 	env.AssertLockfileExists(projectDir, false)
 }
+
+// TestPullSkipsLiveLinkedPackage covers pull against a live-linked package.
+// Relinking it from the store would silently swap the live link for a snapshot
+// copy - the consumer would stop seeing source edits with nothing said about it
+// - so pull leaves it alone and says so, in both the all and the named form.
+func TestPullSkipsLiveLinkedPackage(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("pull-live-lib")
+	projectDir := env.newProject("pull-live-project")
+	env.addLinkedPkg(projectDir, "pull-live-lib")
+
+	env.republish(pkgDir, "pull-live-lib", "2.0.0", "module.exports = 'v2';")
+
+	env.chdir(projectDir)
+	out := captureStdout(t, func() {
+		if err := cli.RunPull(nil); err != nil {
+			t.Fatalf("RunPull: %v", err)
+		}
+		if err := cli.RunPull([]string{"pull-live-lib"}); err != nil {
+			t.Fatalf("RunPull by name: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "live link") {
+		t.Errorf("Expected pull to report the live link, got:\n%s", out)
+	}
+	env.AssertLiveLink(projectDir, "pull-live-lib", pkgDir)
+	assertLockVersion(t, env, projectDir, "pull-live-lib", "1.0.0")
+	env.AssertFileContent(filepath.Join(projectDir, "node_modules", "pull-live-lib", "index.js"),
+		"module.exports = 'v2';")
+}
+
+// TestPullAllLiveLinkedDoesNotClaimUpToDate pins the summary line for a pull
+// where every package was skipped as live-linked. Nothing was compared against
+// the store, so the run must not claim parity with it: here the store holds
+// 2.0.0 and the lock still holds 1.0.0, and "Already up to date" would be a
+// statement about a comparison that never happened.
+func TestPullAllLiveLinkedDoesNotClaimUpToDate(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("all-live-lib")
+	projectDir := env.newProject("all-live-project")
+	env.addLinkedPkg(projectDir, "all-live-lib")
+
+	env.republish(pkgDir, "all-live-lib", "2.0.0", "module.exports = 'v2';")
+
+	env.chdir(projectDir)
+	out := captureStdout(t, func() {
+		if err := cli.RunPull(nil); err != nil {
+			t.Fatalf("RunPull: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "Already up to date") {
+		t.Errorf("Expected no up-to-date claim when every package was skipped, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Skipped 1 live-linked package(s)") {
+		t.Errorf("Expected the skipped live-linked packages to be reported, got:\n%s", out)
+	}
+	// The claim would have been false: the lock is still a version behind.
+	assertLockVersion(t, env, projectDir, "all-live-lib", "1.0.0")
+}

--- a/tests/push_test.go
+++ b/tests/push_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
@@ -221,4 +222,64 @@ func TestPushConcurrentSafe(t *testing.T) {
 	for _, dir := range projectDirs {
 		env.AssertLinkedFileContent(dir, "concurrent-pkg", "index.js", "module.exports = 'v2';")
 	}
+}
+
+// TestPushSkipsLiveLinkedConsumer covers push from the other side of the same
+// hazard pull has: pushing relinks every consumer from the store, which for a
+// live-linked consumer would quietly replace its link with a snapshot copy and
+// end the live updates it was added for.
+func TestPushSkipsLiveLinkedConsumer(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("push-live-lib")
+	projectDir := env.newProject("push-live-project")
+	env.addLinkedPkg(projectDir, "push-live-lib")
+
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'pushed';")
+	out := captureStdout(t, func() {
+		if err := cli.RunPush(false); err != nil {
+			t.Fatalf("RunPush: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "live link") {
+		t.Errorf("Expected push to report the live link, got:\n%s", out)
+	}
+	env.AssertLiveLink(projectDir, "push-live-lib", pkgDir)
+	env.AssertFileContent(filepath.Join(projectDir, "node_modules", "push-live-lib", "index.js"),
+		"module.exports = 'pushed';")
+}
+
+// TestPushReportsCoherentProjectCounts pins push's summary line against the
+// count it announced: the denominator stays every project considered, and a
+// live-linked project is reported as a skip rather than removed from the total.
+// The two lines used to contradict each other - "Updating 2 linked projects"
+// then "Pushed to 1/1 projects" - and an all-live push reported "0/0".
+func TestPushReportsCoherentProjectCounts(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("count-lib")
+	copyProject := env.newProject("count-copy-project")
+	env.addPkg(copyProject, "count-lib", false, false)
+	liveProject := env.newProject("count-live-project")
+	env.addLinkedPkg(liveProject, "count-lib")
+
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'v2';")
+	out := captureStdout(t, func() {
+		if err := cli.RunPush(false); err != nil {
+			t.Fatalf("RunPush: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Updating 2 linked projects") {
+		t.Errorf("Expected 2 projects to be announced, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Pushed to 1/2 projects (1 skipped: live link to source)") {
+		t.Errorf("Expected a coherent 1/2 summary naming the skip, got:\n%s", out)
+	}
+
+	env.AssertLinkedFileContent(copyProject, "count-lib", "index.js", "module.exports = 'v2';")
+	env.AssertLiveLink(liveProject, "count-lib", pkgDir)
 }

--- a/tests/retreat_test.go
+++ b/tests/retreat_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
 
 // retreatLeavesClean asserts the full post-retreat clean state for projectDir:
@@ -207,4 +208,85 @@ func TestRetreatCleansGitignore(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(projectDir, ".gitignore")); err == nil {
 		env.AssertGitignore(projectDir, ".lnpm/", false)
 	}
+}
+
+// TestRetreatForceRestoresLinkedPackage covers `retreat --force` on a package
+// added with --link: the original specifier comes back, .lnpm/ goes away, and
+// the source tree the removed link pointed at is left alone.
+//
+// It is the teardown half of the story, not the isLnpmReference half. The
+// original version this restores is a real one the user wrote, so it exercises
+// the same branch a copy-linked package does; what is specific to --link here is
+// that .lnpm/<pkg> was a link into a real source tree when retreat deleted it.
+// TestRetreatIgnoresLinkReferenceAsOriginalVersion is what pins retreat's
+// handling of a link:.lnpm/ specifier.
+func TestRetreatForceRestoresLinkedPackage(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("retreat-live-lib")
+	projectDir := env.newProject("retreat-live-project")
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":         "retreat-live-project",
+		"version":      "1.0.0",
+		"dependencies": map[string]interface{}{"retreat-live-lib": "^1.0.0"},
+	})
+	env.addLinkedPkg(projectDir, "retreat-live-lib")
+	env.AssertPackageJSON(projectDir, "retreat-live-lib", "link:.lnpm/retreat-live-lib")
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+
+	env.AssertPackageJSON(projectDir, "retreat-live-lib", "^1.0.0")
+	env.AssertDirectoryExists(filepath.Join(projectDir, ".lnpm"), false)
+	env.AssertLockfileExists(projectDir, false)
+
+	env.AssertDirectoryExists(pkgDir, true)
+	env.AssertFileContent(filepath.Join(pkgDir, "index.js"), "module.exports = 'retreat-live-lib';")
+	env.AssertFileExists(filepath.Join(pkgDir, "package.json"), true)
+}
+
+// TestRetreatIgnoresLinkReferenceAsOriginalVersion pins that retreat treats a
+// link:.lnpm/ specifier recorded as an original version the same way it treats
+// file:.lnpm/ - as lnpm's own value, not the user's - so the dependency is
+// dropped rather than restored to a reference that no longer resolves.
+//
+// This is the test that carries retreat's --link change: with the recorded
+// original version left alone, retreat writes link:.lnpm/stale-ref-lib straight
+// back into package.json.
+func TestRetreatIgnoresLinkReferenceAsOriginalVersion(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("stale-ref-lib")
+	projectDir := env.newProject("stale-ref-project")
+	env.addLinkedPkg(projectDir, "stale-ref-lib")
+
+	// Rewrite the lock entry the way an older version could have recorded it.
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		entry, ok := lock.Get("stale-ref-lib")
+		if !ok {
+			t.Fatal("stale-ref-lib missing from lockfile")
+		}
+		entry.OriginalVersion = "link:.lnpm/stale-ref-lib"
+		lock.Add("stale-ref-lib", entry)
+		if err := lock.Save(projectDir); err != nil {
+			t.Fatalf("Failed to save lockfile: %v", err)
+		}
+	})
+
+	// The preview must say the same thing the --force run then does.
+	out := captureStdout(t, func() {
+		if err := cli.RunRetreat(false, false); err != nil {
+			t.Fatalf("Failed to preview retreat: %v", err)
+		}
+	})
+	if !strings.Contains(out, "stale-ref-lib: will be removed from package.json") {
+		t.Errorf("Expected the preview to drop the dependency, got:\n%s", out)
+	}
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+
+	env.AssertPackageJSONMissing(projectDir, "stale-ref-lib")
 }


### PR DESCRIPTION
`--link` and the `link:.lnpm/<pkg>` protocol string already existed, but they
only changed what package.json said. `.lnpm/<pkg>` still received a store copy,
so nothing was actually live — `db.Package.SourcePath` was recorded on every
publish and read by nothing except the lock file's `Source` field.

Now `add --link` points `.lnpm/<pkg>` at that source directory. Source edits, and
newly created source files, are visible through the consumer's
`node_modules/<pkg>` with no further lnpm command.

```
$ lnpm add mylib --link
Adding mylib@1.3.0 (linked to source)...
✓ Added mylib@1.3.0
  Link type: link (live source)
```

`retreat` now recognises lnpm's own reference through the existing
`isLnpmReference` helper instead of two inline `file:.lnpm/` prefix tests, so a
`--link`-added dependency is restored correctly and the two tests cannot drift
apart again. (Folded in from #208.)

## Not deleting your source tree

Once `.lnpm/<pkg>` is a link at real source, every teardown path that deletes it
can in principle delete the user's code. `os.RemoveAll` is documented not to
follow links, but that is asserted here rather than assumed: `remove`,
`retreat --force`, and re-adding over an existing live link (live→live,
live→copy, copy→live) each have a test that checks the source directory and its
files still exist afterwards. Each of the four delete sites was then mutated to
delete *through* the link, and every mutant was killed.

`LinkSource` follows `Link`'s existing rename-aside discipline rather than
clearing the destination first, so a failed swap rolls back to the previous
package instead of losing it.

## Commands that would have silently killed liveness

Three commands relink consumers from the store, which would replace a live link
with a snapshot and quietly end the live updates the consumer was relying on.
All three now skip live-linked packages and say so: `pull`, `push`, and
`publish --push`. This is beyond the issue's literal scope, but without it the
feature dies on the first push — and `publish --push` is the common case.

An empty `SourcePath` (possible on legacy database rows) is now rejected
explicitly: `filepath.Abs("")` returns the working directory, so it would
otherwise have linked the consumer's own project root and reported success.

## Tests

`tests/link_mode_test.go` covers add/remove/re-add; the cross-command skips live
in `pull_test.go`, `push_test.go` and `retreat_test.go` alongside the commands
they belong to. `LinkSource`'s guards, its rollback, and `IsLiveLinked`'s
predicate are unit-tested in `internal/link/`. Every assertion was
mutation-tested against the production code it pins.

`IsLiveLinked` accepts `ModeSymlink|ModeIrregular` rather than "not a directory",
so a stray regular file at `.lnpm/<pkg>` is no longer reported as a live link and
silently skipped. Windows junctions are `ModeIrregular` under current Go and
`ModeSymlink` under `GODEBUG=winsymlink=0`; neither ever carries `ModeDir`, so
both are covered.

Closes #191
