### PR TITLE
Resolve `workspace:` dependency specifiers when publishing

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -41,7 +41,8 @@
 - Location: `internal/workspace/`
 - Contains: Detection and parsing of npm/yarn/pnpm/bun workspaces
 - Depends on: YAML parser (gopkg.in/yaml.v3)
-- Used by: Publish command for `--all` flag
+- Used by: Publish command for `--all` flag, and `internal/pack` to resolve
+  `workspace:` dependency specifiers against sibling versions
 
 **Utilities Layer:**
 - Purpose: Cross-cutting concerns

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -60,11 +60,15 @@ lnpm/
 - Key files: `db.go` (Package, Project, Link, FileEntry models)
 
 **internal/pack:**
-- Purpose: Package file discovery and filtering
-- Contains: File scanning, .npmignore/.gitignore parsing, content hashing
+- Purpose: Package file discovery, filtering, and manifest resolution
+- Contains: File scanning, .npmignore/.gitignore parsing, content hashing,
+  `workspace:` dependency rewriting (depends on `internal/pkgjson` and
+  `internal/workspace`)
 - Key files:
   - `pack.go`: Main packing logic, incremental hashing
   - `git_filter.go`: Safety filter for .git files
+  - `workspacedeps.go`: Resolves `workspace:` specifiers into the published
+    package.json, without touching the source one
 
 **internal/store:**
 - Purpose: Package store management

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -122,6 +122,9 @@ workspaceDir := env.CopyFixture("npm-workspace")
 - `yarn-workspace/`: Yarn workspace setup
 - `turborepo/`: Turborepo monorepo structure
 - `nx/`: Nx workspace example
+- `workspace-deps/`: PNPM workspace whose lib depends on its sibling util with
+  `workspace:*`; the only fixture carrying a `workspace:` specifier, so the
+  other workspace fixtures stay independent of the publish-time rewrite
 
 ## Coverage
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,24 @@ lnpm publish --all
 lnpm push
 ```
 
+**`workspace:` specifiers are resolved on publish.** A sibling dependency written
+with the `workspace:` protocol means nothing outside the workspace it came from,
+so lnpm resolves it in the *stored* package.json — your own package.json is left
+byte-for-byte as you wrote it. All four dependency maps are covered:
+`dependencies`, `devDependencies`, `peerDependencies` and `optionalDependencies`.
+
+| Specifier | Stored as (sibling at 2.3.0) |
+|-----------|------------------------------|
+| `workspace:*` | `2.3.0` |
+| `workspace:latest` | `2.3.0` |
+| `workspace:^` | `^2.3.0` |
+| `workspace:~` | `~2.3.0` |
+| `workspace:^1.2.3`, `workspace:1.2.3`, any explicit range | the range itself: `^1.2.3`, `1.2.3`, … |
+
+Publishing fails instead if the sibling is not a package of the workspace, if the
+package is not in a workspace at all, or on a bare `workspace:` — shipping the
+literal specifier would only break the consumer's `npm install` later.
+
 **📖 See [MONOREPO.md](MONOREPO.md) for complete guides on:**
 - Turborepo integration
 - Nx integration
@@ -345,7 +363,7 @@ Debug output goes to stderr with timestamps, useful for diagnosing slow operatio
 
 ## How It Works
 
-1. **Publish** — Uses `npm pack` rules to determine files, strips lifecycle scripts (`prepare`/`prepublish`), then reflinks or copies to `~/.lnpm/store/{name}/{hash}/`
+1. **Publish** — Uses `npm pack` rules to determine files, strips lifecycle scripts (`prepare`/`prepublish`), resolves `workspace:` dependency specifiers to versions npm can install (see [Monorepo Support](#monorepo-support)), then reflinks or copies to `~/.lnpm/store/{name}/{hash}/`
 2. **Add** — Creates reflinks or hard links from store to `project/.lnpm/{package}/`, updates package.json to `file:.lnpm/{package}`
 3. **Symlink** — Links `node_modules/{package}` → `.lnpm/{package}`
 4. **Push** — Updates store and re-links changed files

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -156,6 +156,10 @@ func publishSingle(pkgPath string, push bool, skipHooks bool, skipValidation boo
 	cleanup, err := pack.RewriteWorkspaceDeps(pkgPath, files)
 	defer cleanup()
 	if err != nil {
+		// Deliberately unwrapped, against the "always wrap" convention: every
+		// error out of RewriteWorkspaceDeps already names the specifier, the
+		// dependency and the workspace, so a "failed to resolve workspace
+		// dependencies:" prefix would only stutter in front of it.
 		return err
 	}
 

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -149,6 +149,16 @@ func publishSingle(pkgPath string, push bool, skipHooks bool, skipValidation boo
 		return fmt.Errorf("failed to pack: %w", err)
 	}
 
+	// Resolve any workspace: dependency specifiers before the content hash is
+	// taken, so the hash covers the bytes consumers actually install. The
+	// cleanup must outlive the store copy, so it is deferred to the end of the
+	// publish rather than released here.
+	cleanup, err := pack.RewriteWorkspaceDeps(pkgPath, files)
+	defer cleanup()
+	if err != nil {
+		return err
+	}
+
 	// Check if already published with same hash
 	database, err := db.GetDB()
 	if err != nil {

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -51,6 +51,11 @@ func RunPush(skipHooks bool) error {
 		if err != nil {
 			return fmt.Errorf("failed to pack: %w", err)
 		}
+		cleanup, err := pack.RewriteWorkspaceDeps(cwd, files)
+		defer cleanup()
+		if err != nil {
+			return err
+		}
 		return finishPublish(cwd, pkgJSON, files, database, false)
 	}
 
@@ -63,6 +68,14 @@ func RunPush(skipHooks bool) error {
 	_, files, err := pack.Pack(cwd)
 	if err != nil {
 		return fmt.Errorf("failed to pack: %w", err)
+	}
+
+	// Resolve any workspace: dependency specifiers before hashing, so a push
+	// stores the same resolved package.json a publish would.
+	cleanup, err := pack.RewriteWorkspaceDeps(cwd, files)
+	defer cleanup()
+	if err != nil {
+		return err
 	}
 
 	// Calculate content hash

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -54,6 +54,8 @@ func RunPush(skipHooks bool) error {
 		cleanup, err := pack.RewriteWorkspaceDeps(cwd, files)
 		defer cleanup()
 		if err != nil {
+			// Deliberately unwrapped: RewriteWorkspaceDeps' errors are already
+			// self-contained, so wrapping them here would only stutter.
 			return err
 		}
 		return finishPublish(cwd, pkgJSON, files, database, false)
@@ -75,6 +77,7 @@ func RunPush(skipHooks bool) error {
 	cleanup, err := pack.RewriteWorkspaceDeps(cwd, files)
 	defer cleanup()
 	if err != nil {
+		// Deliberately unwrapped, as above.
 		return err
 	}
 

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -236,7 +236,7 @@ func collectFiles(packageDir string, filesField []string) ([]*FileInfo, error) {
 		pool, err := ants.NewPoolWithFunc(runtime.NumCPU()*2, func(i interface{}) {
 			defer wg.Done()
 			file := i.(*FileInfo)
-			hash, err := hashFile(file.Path)
+			hash, err := HashFile(file.Path)
 			if err != nil {
 				hashErrMu.Lock()
 				if hashErr == nil {
@@ -472,8 +472,8 @@ func isDefaultInclude(relPath string) bool {
 	return false
 }
 
-// hashFile calculates the xxhash of a file's contents
-func hashFile(path string) (string, error) {
+// HashFile calculates the xxhash of a file's contents
+func HashFile(path string) (string, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return "", err

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -694,17 +694,17 @@ func TestHashFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hash1, err := hashFile(file1)
+	hash1, err := HashFile(file1)
 	if err != nil {
-		t.Fatalf("hashFile(file1) error: %v", err)
+		t.Fatalf("HashFile(file1) error: %v", err)
 	}
-	hash2, err := hashFile(file2)
+	hash2, err := HashFile(file2)
 	if err != nil {
-		t.Fatalf("hashFile(file2) error: %v", err)
+		t.Fatalf("HashFile(file2) error: %v", err)
 	}
-	hash3, err := hashFile(file3)
+	hash3, err := HashFile(file3)
 	if err != nil {
-		t.Fatalf("hashFile(file3) error: %v", err)
+		t.Fatalf("HashFile(file3) error: %v", err)
 	}
 
 	// Same content should have same hash

--- a/internal/pack/workspacedeps.go
+++ b/internal/pack/workspacedeps.go
@@ -18,8 +18,11 @@ import (
 // workspace, so it must never reach a consumer's package.json.
 const workspaceProtocol = "workspace:"
 
-// depFields are the package.json fields whose specifiers get resolved.
-var depFields = []string{"dependencies", "devDependencies"}
+// depFields are the package.json fields whose specifiers get resolved. Issue
+// #192 named only dependencies and devDependencies, but pnpm accepts the
+// workspace: protocol in all four dependency maps and every one of them reaches
+// consumers through the same stored package.json, so all four are resolved.
+var depFields = []string{"dependencies", "devDependencies", "peerDependencies", "optionalDependencies"}
 
 // workspaceDep is one dependency entry carrying a workspace: specifier.
 type workspaceDep struct {
@@ -96,16 +99,20 @@ func RewriteWorkspaceDeps(pkgDir string, files []*FileInfo) (func(), error) {
 // to find the names would reformat everything the splice exists to preserve.
 func findWorkspaceDeps(src []byte) ([]workspaceDep, error) {
 	var manifest struct {
-		Dependencies    map[string]any `json:"dependencies"`
-		DevDependencies map[string]any `json:"devDependencies"`
+		Dependencies         map[string]any `json:"dependencies"`
+		DevDependencies      map[string]any `json:"devDependencies"`
+		PeerDependencies     map[string]any `json:"peerDependencies"`
+		OptionalDependencies map[string]any `json:"optionalDependencies"`
 	}
 	if err := json.Unmarshal(src, &manifest); err != nil {
 		return nil, fmt.Errorf("failed to parse package.json: %w", err)
 	}
 
 	byField := map[string]map[string]any{
-		"dependencies":    manifest.Dependencies,
-		"devDependencies": manifest.DevDependencies,
+		"dependencies":         manifest.Dependencies,
+		"devDependencies":      manifest.DevDependencies,
+		"peerDependencies":     manifest.PeerDependencies,
+		"optionalDependencies": manifest.OptionalDependencies,
 	}
 
 	var deps []workspaceDep
@@ -157,9 +164,12 @@ func indexWorkspace(pkgDir string, first workspaceDep) (*workspaceIndex, error) 
 }
 
 // resolveWorkspaceSpec turns a workspace: specifier into the version range a
-// consumer outside the workspace can install, matching pnpm and yalc. A form it
-// cannot resolve is an error rather than a pass-through: shipping the literal
-// specifier is exactly the breakage this rewrite exists to prevent.
+// consumer outside the workspace can install, matching pnpm and yalc: "*" and
+// "latest" become the sibling's exact version, "^" and "~" that version behind
+// the matching range operator, and every other form is the protocol prefix
+// stripped off - "workspace:^1.2.3" installs as "^1.2.3". A bare "workspace:"
+// names no range to fall back on and is the one error, alongside a sibling the
+// workspace does not contain, whose version is simply not knowable.
 func resolveWorkspaceSpec(dep workspaceDep, index *workspaceIndex) (string, error) {
 	version, ok := index.versions[dep.name]
 	if !ok {
@@ -167,16 +177,17 @@ func resolveWorkspaceSpec(dep workspaceDep, index *workspaceIndex) (string, erro
 			dep.spec, dep.name, index.root)
 	}
 
-	switch strings.TrimPrefix(dep.spec, workspaceProtocol) {
+	switch rest := strings.TrimPrefix(dep.spec, workspaceProtocol); rest {
+	case "":
+		return "", fmt.Errorf("cannot resolve %q for dependency %s: the workspace: protocol carries no version",
+			dep.spec, dep.name)
 	case "*", "latest":
 		return version, nil
-	case "^":
-		return "^" + version, nil
-	case "~":
-		return "~" + version, nil
+	case "^", "~":
+		return rest + version, nil
+	default:
+		return rest, nil
 	}
-
-	return "", fmt.Errorf("unsupported workspace specifier %q for dependency %s", dep.spec, dep.name)
 }
 
 // packedPackageJSON returns the package.json entry of files, or nil.
@@ -197,6 +208,12 @@ func packedPackageJSON(files []*FileInfo) *FileInfo {
 func materializePackageJSON(entry *FileInfo, out []byte) (func(), error) {
 	noop := func() {}
 
+	// The system temp dir, rather than a location beside the destination the way
+	// link.newTempDir and store's MkdirTemp keep theirs: the store path is not
+	// known here and the source tree must not be written to. The consequence is
+	// that /tmp is usually a different filesystem, so fsutil.Reflink cannot
+	// clone this file into the store and store falls back to copyFile - one
+	// small file, so the cost is negligible.
 	tmp, err := os.CreateTemp("", "lnpm-package-json-")
 	if err != nil {
 		return noop, fmt.Errorf("failed to create temporary package.json: %w", err)
@@ -209,7 +226,7 @@ func materializePackageJSON(entry *FileInfo, out []byte) (func(), error) {
 		return noop, err
 	}
 
-	hash, err := hashFile(tmpPath)
+	hash, err := HashFile(tmpPath)
 	if err != nil {
 		cleanup()
 		return noop, fmt.Errorf("failed to hash rewritten package.json: %w", err)

--- a/internal/pack/workspacedeps.go
+++ b/internal/pack/workspacedeps.go
@@ -1,0 +1,239 @@
+package pack
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/pedrosousa13/lnpm/internal/debug"
+	"github.com/pedrosousa13/lnpm/internal/pkgjson"
+	"github.com/pedrosousa13/lnpm/internal/workspace"
+)
+
+// workspaceProtocol is the specifier prefix a monorepo uses to point a package
+// at a sibling of the same workspace. npm has no idea what it means outside that
+// workspace, so it must never reach a consumer's package.json.
+const workspaceProtocol = "workspace:"
+
+// depFields are the package.json fields whose specifiers get resolved.
+var depFields = []string{"dependencies", "devDependencies"}
+
+// workspaceDep is one dependency entry carrying a workspace: specifier.
+type workspaceDep struct {
+	field string
+	name  string
+	spec  string
+}
+
+// workspaceIndex is the version of every package in a workspace, keyed by name.
+type workspaceIndex struct {
+	root     string
+	versions map[string]string
+}
+
+// RewriteWorkspaceDeps resolves the workspace: dependency specifiers of the
+// package at pkgDir against the other packages of its workspace, so consumers
+// receive a specifier npm can install.
+//
+// The developer's own package.json is never modified. The rewritten document is
+// written to a temporary file outside the source tree and the package.json entry
+// of files is repointed at it, with its hash and size recomputed - store.Store
+// copies from FileInfo.Path, and HashFiles must cover the bytes that reach the
+// store rather than the ones still on disk in the workspace.
+//
+// The returned cleanup removes that temporary file. It is never nil, so it can
+// be deferred before the error is checked, and it must not run until the files
+// have been stored.
+func RewriteWorkspaceDeps(pkgDir string, files []*FileInfo) (func(), error) {
+	noop := func() {}
+
+	src, err := os.ReadFile(filepath.Join(pkgDir, "package.json"))
+	if err != nil {
+		return noop, fmt.Errorf("failed to read package.json: %w", err)
+	}
+
+	deps, err := findWorkspaceDeps(src)
+	if err != nil {
+		return noop, err
+	}
+	if len(deps) == 0 {
+		return noop, nil
+	}
+
+	index, err := indexWorkspace(pkgDir, deps[0])
+	if err != nil {
+		return noop, err
+	}
+
+	entry := packedPackageJSON(files)
+	if entry == nil {
+		return noop, fmt.Errorf("cannot resolve workspace dependencies: package.json is excluded from the published files")
+	}
+
+	out := src
+	for _, dep := range deps {
+		resolved, err := resolveWorkspaceSpec(dep, index)
+		if err != nil {
+			return noop, err
+		}
+		if out, err = pkgjson.SetDep(out, dep.field, dep.name, resolved); err != nil {
+			return noop, fmt.Errorf("failed to rewrite %s in package.json: %w", dep.name, err)
+		}
+		debug.Logf("pack: resolved %s %s -> %s", dep.name, dep.spec, resolved)
+	}
+
+	return materializePackageJSON(entry, out)
+}
+
+// findWorkspaceDeps returns the workspace: entries of src, sorted by field and
+// name so errors and debug output do not depend on Go's map iteration order.
+//
+// It reads the dependency maps rather than editing them: pkgjson can set a named
+// entry but cannot enumerate one, and round-tripping the document through a map
+// to find the names would reformat everything the splice exists to preserve.
+func findWorkspaceDeps(src []byte) ([]workspaceDep, error) {
+	var manifest struct {
+		Dependencies    map[string]any `json:"dependencies"`
+		DevDependencies map[string]any `json:"devDependencies"`
+	}
+	if err := json.Unmarshal(src, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to parse package.json: %w", err)
+	}
+
+	byField := map[string]map[string]any{
+		"dependencies":    manifest.Dependencies,
+		"devDependencies": manifest.DevDependencies,
+	}
+
+	var deps []workspaceDep
+	for _, field := range depFields {
+		for name, value := range byField[field] {
+			spec, ok := value.(string)
+			if !ok || !strings.HasPrefix(spec, workspaceProtocol) {
+				continue
+			}
+			deps = append(deps, workspaceDep{field: field, name: name, spec: spec})
+		}
+	}
+
+	sort.Slice(deps, func(i, j int) bool {
+		if deps[i].field != deps[j].field {
+			return deps[i].field < deps[j].field
+		}
+		return deps[i].name < deps[j].name
+	})
+
+	return deps, nil
+}
+
+// indexWorkspace lists the packages of pkgDir's workspace. Detect reports "no
+// workspace here" as (nil, nil), which is its own failure in this context: the
+// package names a sibling but has no workspace to resolve it against. first is
+// only used to name a dependency in that error.
+func indexWorkspace(pkgDir string, first workspaceDep) (*workspaceIndex, error) {
+	ws, err := workspace.Detect(pkgDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect workspace: %w", err)
+	}
+	if ws == nil {
+		return nil, fmt.Errorf("cannot resolve %q for dependency %s: %s is not part of a workspace",
+			first.spec, first.name, pkgDir)
+	}
+
+	packages, err := ws.ListPackages()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list workspace packages: %w", err)
+	}
+
+	versions := make(map[string]string, len(packages))
+	for _, pkg := range packages {
+		versions[pkg.Name] = pkg.Version
+	}
+
+	return &workspaceIndex{root: ws.Root, versions: versions}, nil
+}
+
+// resolveWorkspaceSpec turns a workspace: specifier into the version range a
+// consumer outside the workspace can install, matching pnpm and yalc. A form it
+// cannot resolve is an error rather than a pass-through: shipping the literal
+// specifier is exactly the breakage this rewrite exists to prevent.
+func resolveWorkspaceSpec(dep workspaceDep, index *workspaceIndex) (string, error) {
+	version, ok := index.versions[dep.name]
+	if !ok {
+		return "", fmt.Errorf("cannot resolve %q for dependency %s: no such package in the workspace at %s",
+			dep.spec, dep.name, index.root)
+	}
+
+	switch strings.TrimPrefix(dep.spec, workspaceProtocol) {
+	case "*", "latest":
+		return version, nil
+	case "^":
+		return "^" + version, nil
+	case "~":
+		return "~" + version, nil
+	}
+
+	return "", fmt.Errorf("unsupported workspace specifier %q for dependency %s", dep.spec, dep.name)
+}
+
+// packedPackageJSON returns the package.json entry of files, or nil.
+func packedPackageJSON(files []*FileInfo) *FileInfo {
+	for _, f := range files {
+		if f.RelPath == "package.json" {
+			return f
+		}
+	}
+	return nil
+}
+
+// materializePackageJSON writes out to a temporary file and repoints entry at
+// it, recomputing the hash and size the store and the file manifest are built
+// from. The temporary file carries entry's mode because a reflinked store copy
+// inherits the permissions of the file it clones, and the content hash folds
+// those permissions in.
+func materializePackageJSON(entry *FileInfo, out []byte) (func(), error) {
+	noop := func() {}
+
+	tmp, err := os.CreateTemp("", "lnpm-package-json-")
+	if err != nil {
+		return noop, fmt.Errorf("failed to create temporary package.json: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+
+	if err := writeTempPackageJSON(tmp, out, entry.Mode); err != nil {
+		cleanup()
+		return noop, err
+	}
+
+	hash, err := hashFile(tmpPath)
+	if err != nil {
+		cleanup()
+		return noop, fmt.Errorf("failed to hash rewritten package.json: %w", err)
+	}
+
+	entry.Path = tmpPath
+	entry.ContentHash = hash
+	entry.Size = int64(len(out))
+
+	return cleanup, nil
+}
+
+// writeTempPackageJSON fills and closes an already created temporary file.
+func writeTempPackageJSON(tmp *os.File, out []byte, mode os.FileMode) error {
+	if _, err := tmp.Write(out); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to write rewritten package.json: %w", err)
+	}
+	if err := tmp.Chmod(mode.Perm()); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to set rewritten package.json permissions: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to write rewritten package.json: %w", err)
+	}
+	return nil
+}

--- a/internal/pack/workspacedeps_test.go
+++ b/internal/pack/workspacedeps_test.go
@@ -1,0 +1,455 @@
+package pack
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newTestWorkspace creates an empty pnpm workspace whose packages live under
+// packages/ and returns its root.
+func newTestWorkspace(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n")
+	return root
+}
+
+// addTestPackage writes packages/<dir>/package.json under root and returns the
+// package directory.
+func addTestPackage(t *testing.T, root, dir, manifest string) string {
+	t.Helper()
+
+	pkgDir := filepath.Join(root, "packages", dir)
+	writeTestFile(t, filepath.Join(pkgDir, "package.json"), manifest)
+	return pkgDir
+}
+
+// writeTestFile writes content to path, creating parent directories.
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("Failed to create dir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write %s: %v", path, err)
+	}
+}
+
+// packageJSONEntry returns the packed package.json FileInfo, failing if absent.
+func packageJSONEntry(t *testing.T, files []*FileInfo) *FileInfo {
+	t.Helper()
+
+	for _, f := range files {
+		if f.RelPath == "package.json" {
+			return f
+		}
+	}
+	t.Fatal("Expected a package.json entry among the packed files")
+	return nil
+}
+
+// packWorkspacePkg packs pkgDir and returns its files.
+func packWorkspacePkg(t *testing.T, pkgDir string) []*FileInfo {
+	t.Helper()
+
+	_, files, err := Pack(pkgDir)
+	if err != nil {
+		t.Fatalf("Failed to pack %s: %v", pkgDir, err)
+	}
+	return files
+}
+
+// depValue reads field.name out of the package.json at path.
+func depValue(t *testing.T, path, field, name string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read %s: %v", path, err)
+	}
+
+	var manifest map[string]any
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("Failed to parse %s: %v", path, err)
+	}
+
+	deps, _ := manifest[field].(map[string]any)
+	value, _ := deps[name].(string)
+	return value
+}
+
+// libManifest renders a lib package.json depending on @ws/util with spec.
+func libManifest(spec string) string {
+	return `{
+  "name": "@ws/lib",
+  "version": "1.0.0",
+  "dependencies": {
+    "@ws/util": "` + spec + `"
+  }
+}
+`
+}
+
+func TestRewriteWorkspaceDepsResolvesSpecifierForms(t *testing.T) {
+	tests := []struct {
+		spec string
+		want string
+	}{
+		{"workspace:*", "2.3.0"},
+		{"workspace:latest", "2.3.0"},
+		{"workspace:^", "^2.3.0"},
+		{"workspace:~", "~2.3.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.spec, func(t *testing.T) {
+			root := newTestWorkspace(t)
+			addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
+			libDir := addTestPackage(t, root, "lib", libManifest(tt.spec))
+
+			files := packWorkspacePkg(t, libDir)
+			cleanup, err := RewriteWorkspaceDeps(libDir, files)
+			defer cleanup()
+			if err != nil {
+				t.Fatalf("RewriteWorkspaceDeps failed: %v", err)
+			}
+
+			entry := packageJSONEntry(t, files)
+			if got := depValue(t, entry.Path, "dependencies", "@ws/util"); got != tt.want {
+				t.Errorf("Expected @ws/util to resolve to %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestRewriteWorkspaceDepsRewritesDevDependencies(t *testing.T) {
+	root := newTestWorkspace(t)
+	addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
+	libDir := addTestPackage(t, root, "lib", `{
+  "name": "@ws/lib",
+  "version": "1.0.0",
+  "devDependencies": {
+    "@ws/util": "workspace:^"
+  }
+}
+`)
+
+	files := packWorkspacePkg(t, libDir)
+	cleanup, err := RewriteWorkspaceDeps(libDir, files)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("RewriteWorkspaceDeps failed: %v", err)
+	}
+
+	entry := packageJSONEntry(t, files)
+	if got := depValue(t, entry.Path, "devDependencies", "@ws/util"); got != "^2.3.0" {
+		t.Errorf("Expected @ws/util to resolve to \"^2.3.0\", got %q", got)
+	}
+}
+
+// The content hash must cover the rewritten bytes, otherwise the hash and the
+// file consumers install would disagree.
+func TestRewriteWorkspaceDepsRehashesRewrittenBytes(t *testing.T) {
+	root := newTestWorkspace(t)
+	addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
+	libDir := addTestPackage(t, root, "lib", libManifest("workspace:*"))
+
+	files := packWorkspacePkg(t, libDir)
+	before := HashFiles(files)
+	entry := packageJSONEntry(t, files)
+	sourceHash := entry.ContentHash
+
+	cleanup, err := RewriteWorkspaceDeps(libDir, files)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("RewriteWorkspaceDeps failed: %v", err)
+	}
+
+	rewritten, err := hashFile(entry.Path)
+	if err != nil {
+		t.Fatalf("Failed to hash rewritten package.json: %v", err)
+	}
+	if entry.ContentHash != rewritten {
+		t.Errorf("Expected entry hash %q to match the rewritten file's hash %q", entry.ContentHash, rewritten)
+	}
+	if entry.ContentHash == sourceHash {
+		t.Error("Expected the rewrite to change the package.json content hash")
+	}
+	if HashFiles(files) == before {
+		t.Error("Expected the rewrite to change the package content hash")
+	}
+
+	info, err := os.Stat(entry.Path)
+	if err != nil {
+		t.Fatalf("Failed to stat rewritten package.json: %v", err)
+	}
+	if entry.Size != info.Size() {
+		t.Errorf("Expected entry size %d to match the rewritten file's size %d", entry.Size, info.Size())
+	}
+	// The stored file's permissions come from this mode (copyFile) or from the
+	// file at Path (reflink), and the content hash folds it in, so the two must
+	// still agree after the rewrite.
+	if info.Mode().Perm() != entry.Mode.Perm() {
+		t.Errorf("Expected rewritten package.json mode %v, got %v", entry.Mode.Perm(), info.Mode().Perm())
+	}
+}
+
+// AC 4: the developer's own package.json must come out byte-identical.
+func TestRewriteWorkspaceDepsLeavesSourceUntouched(t *testing.T) {
+	root := newTestWorkspace(t)
+	addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
+	libDir := addTestPackage(t, root, "lib", libManifest("workspace:*"))
+
+	sourcePath := filepath.Join(libDir, "package.json")
+	before, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("Failed to read source package.json: %v", err)
+	}
+
+	files := packWorkspacePkg(t, libDir)
+	cleanup, err := RewriteWorkspaceDeps(libDir, files)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("RewriteWorkspaceDeps failed: %v", err)
+	}
+
+	after, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("Failed to read source package.json: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Errorf("Expected source package.json to be untouched.\nBefore:\n%s\nAfter:\n%s", before, after)
+	}
+
+	entry := packageJSONEntry(t, files)
+	if entry.Path == sourcePath {
+		t.Error("Expected the packed package.json to point away from the source tree")
+	}
+	if strings.HasPrefix(entry.Path, libDir+string(filepath.Separator)) {
+		t.Errorf("Expected the rewritten package.json to live outside %s, got %s", libDir, entry.Path)
+	}
+}
+
+// The whole point of splicing rather than re-marshalling: every byte outside
+// the rewritten value survives, so key order and indentation are preserved.
+func TestRewriteWorkspaceDepsPreservesFormatting(t *testing.T) {
+	root := newTestWorkspace(t)
+	addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
+	manifest := `{
+    "version": "1.0.0",
+    "name": "@ws/lib",
+    "zzz": 9007199254740993,
+    "dependencies": {
+        "@ws/util": "workspace:^"
+    }
+}
+`
+	libDir := addTestPackage(t, root, "lib", manifest)
+
+	files := packWorkspacePkg(t, libDir)
+	cleanup, err := RewriteWorkspaceDeps(libDir, files)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("RewriteWorkspaceDeps failed: %v", err)
+	}
+
+	entry := packageJSONEntry(t, files)
+	data, err := os.ReadFile(entry.Path)
+	if err != nil {
+		t.Fatalf("Failed to read rewritten package.json: %v", err)
+	}
+
+	want := strings.Replace(manifest, `"workspace:^"`, `"^2.3.0"`, 1)
+	if string(data) != want {
+		t.Errorf("Expected only the specifier to change.\nWant:\n%s\nGot:\n%s", want, data)
+	}
+}
+
+// AC 3: a package with no workspace: specifiers is left completely alone.
+func TestRewriteWorkspaceDepsWithoutWorkspaceSpecifiers(t *testing.T) {
+	root := newTestWorkspace(t)
+	addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
+	libDir := addTestPackage(t, root, "lib", libManifest("^2.0.0"))
+
+	files := packWorkspacePkg(t, libDir)
+	entry := packageJSONEntry(t, files)
+	beforePath, beforeHash, beforeSize := entry.Path, entry.ContentHash, entry.Size
+
+	cleanup, err := RewriteWorkspaceDeps(libDir, files)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("RewriteWorkspaceDeps failed: %v", err)
+	}
+
+	if entry.Path != beforePath {
+		t.Errorf("Expected package.json to still be packed from %s, got %s", beforePath, entry.Path)
+	}
+	if entry.ContentHash != beforeHash || entry.Size != beforeSize {
+		t.Errorf("Expected package.json hash/size to be untouched, got %s/%d", entry.ContentHash, entry.Size)
+	}
+}
+
+// AC 3 again, for the case Detect reports no workspace at all: a package with
+// no workspace: specifiers outside a workspace must still publish.
+func TestRewriteWorkspaceDepsOutsideWorkspaceWithoutSpecifiers(t *testing.T) {
+	pkgDir := t.TempDir()
+	writeTestFile(t, filepath.Join(pkgDir, "package.json"), `{"name":"lonely","version":"1.0.0"}`)
+
+	files := packWorkspacePkg(t, pkgDir)
+	cleanup, err := RewriteWorkspaceDeps(pkgDir, files)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("RewriteWorkspaceDeps failed: %v", err)
+	}
+}
+
+// AC 5, first case: a workspace: specifier outside any workspace.
+func TestRewriteWorkspaceDepsOutsideWorkspaceFails(t *testing.T) {
+	pkgDir := t.TempDir()
+	writeTestFile(t, filepath.Join(pkgDir, "package.json"), libManifest("workspace:*"))
+
+	files := packWorkspacePkg(t, pkgDir)
+	cleanup, err := RewriteWorkspaceDeps(pkgDir, files)
+	defer cleanup()
+	if err == nil {
+		t.Fatal("Expected an error for a workspace: specifier outside a workspace, got nil")
+	}
+	for _, want := range []string{"@ws/util", "workspace:*", "workspace"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Expected error to mention %q, got: %v", want, err)
+		}
+	}
+}
+
+// AC 5, second case: the sibling is not a package of the detected workspace.
+func TestRewriteWorkspaceDepsUnknownSiblingFails(t *testing.T) {
+	root := newTestWorkspace(t)
+	libDir := addTestPackage(t, root, "lib", libManifest("workspace:*"))
+
+	files := packWorkspacePkg(t, libDir)
+	cleanup, err := RewriteWorkspaceDeps(libDir, files)
+	defer cleanup()
+	if err == nil {
+		t.Fatal("Expected an error for a sibling missing from the workspace, got nil")
+	}
+	for _, want := range []string{"@ws/util", "workspace:*", root} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Expected error to mention %q, got: %v", want, err)
+		}
+	}
+}
+
+// A workspace: form this rewrite cannot resolve must fail loudly rather than
+// ship the literal specifier to consumers.
+func TestRewriteWorkspaceDepsUnsupportedSpecifierFails(t *testing.T) {
+	root := newTestWorkspace(t)
+	addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
+	libDir := addTestPackage(t, root, "lib", libManifest("workspace:^1.2.3"))
+
+	files := packWorkspacePkg(t, libDir)
+	cleanup, err := RewriteWorkspaceDeps(libDir, files)
+	defer cleanup()
+	if err == nil {
+		t.Fatal("Expected an error for an unsupported workspace: specifier, got nil")
+	}
+	if !strings.Contains(err.Error(), "workspace:^1.2.3") {
+		t.Errorf("Expected error to mention the specifier, got: %v", err)
+	}
+}
+
+// The temporary file must not outlive the publish that created it.
+func TestRewriteWorkspaceDepsCleanupRemovesTempFile(t *testing.T) {
+	root := newTestWorkspace(t)
+	addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
+	libDir := addTestPackage(t, root, "lib", libManifest("workspace:*"))
+
+	files := packWorkspacePkg(t, libDir)
+	cleanup, err := RewriteWorkspaceDeps(libDir, files)
+	if err != nil {
+		t.Fatalf("RewriteWorkspaceDeps failed: %v", err)
+	}
+
+	entry := packageJSONEntry(t, files)
+	if _, err := os.Stat(entry.Path); err != nil {
+		t.Fatalf("Expected the rewritten package.json to exist before cleanup: %v", err)
+	}
+
+	cleanup()
+
+	if _, err := os.Stat(entry.Path); !os.IsNotExist(err) {
+		t.Errorf("Expected cleanup to remove %s, stat returned %v", entry.Path, err)
+	}
+}
+
+// A failed rewrite must leave nothing behind either.
+func TestRewriteWorkspaceDepsLeavesNoTempFileOnFailure(t *testing.T) {
+	root := newTestWorkspace(t)
+	addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
+	libDir := addTestPackage(t, root, "lib", `{
+  "name": "@ws/lib",
+  "version": "1.0.0",
+  "dependencies": {
+    "@ws/zombie": "workspace:*",
+    "@ws/ghost": "workspace:*"
+  }
+}
+`)
+
+	files := packWorkspacePkg(t, libDir)
+	entry := packageJSONEntry(t, files)
+	sourcePath := entry.Path
+
+	cleanup, err := RewriteWorkspaceDeps(libDir, files)
+	defer cleanup()
+	if err == nil {
+		t.Fatal("Expected an error for a sibling missing from the workspace, got nil")
+	}
+	// The entries are resolved in sorted order, so which of the two
+	// unresolvable siblings is reported does not depend on Go's map iteration
+	// order.
+	if !strings.Contains(err.Error(), "@ws/ghost") || strings.Contains(err.Error(), "@ws/zombie") {
+		t.Errorf("Expected the first unresolvable dependency (@ws/ghost) to be reported, got: %v", err)
+	}
+	if entry.Path != sourcePath {
+		t.Errorf("Expected a failed rewrite to leave package.json packed from %s, got %s", sourcePath, entry.Path)
+	}
+}
+
+// A package.json kept out of the published files leaves nothing to rewrite the
+// specifier in, which must be reported rather than silently published.
+func TestRewriteWorkspaceDepsWithoutPackedManifestFails(t *testing.T) {
+	root := newTestWorkspace(t)
+	addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
+	libDir := addTestPackage(t, root, "lib", libManifest("workspace:*"))
+	writeTestFile(t, filepath.Join(libDir, ".npmignore"), "package.json\n")
+
+	files := packWorkspacePkg(t, libDir)
+	if packageJSONEntryOrNil(files) != nil {
+		t.Fatal("Expected .npmignore to keep package.json out of the packed files")
+	}
+
+	cleanup, err := RewriteWorkspaceDeps(libDir, files)
+	defer cleanup()
+	if err == nil {
+		t.Fatal("Expected an error when package.json is not among the packed files, got nil")
+	}
+	if !strings.Contains(err.Error(), "package.json") {
+		t.Errorf("Expected the error to name package.json, got: %v", err)
+	}
+}
+
+// packageJSONEntryOrNil is packageJSONEntry without the t.Fatal, for the one
+// test that expects the entry to be absent.
+func packageJSONEntryOrNil(files []*FileInfo) *FileInfo {
+	for _, f := range files {
+		if f.RelPath == "package.json" {
+			return f
+		}
+	}
+	return nil
+}

--- a/internal/pack/workspacedeps_test.go
+++ b/internal/pack/workspacedeps_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -104,6 +105,13 @@ func TestRewriteWorkspaceDepsResolvesSpecifierForms(t *testing.T) {
 		{"workspace:latest", "2.3.0"},
 		{"workspace:^", "^2.3.0"},
 		{"workspace:~", "~2.3.0"},
+		// Every other form is the protocol prefix stripped off, exactly as pnpm
+		// does it: the range the developer wrote is the range consumers get,
+		// whatever the sibling's current version happens to be.
+		{"workspace:^1.2.3", "^1.2.3"},
+		{"workspace:~1.2.3", "~1.2.3"},
+		{"workspace:1.2.3", "1.2.3"},
+		{"workspace:>=1.0.0 <3", ">=1.0.0 <3"},
 	}
 
 	for _, tt := range tests {
@@ -127,28 +135,70 @@ func TestRewriteWorkspaceDepsResolvesSpecifierForms(t *testing.T) {
 	}
 }
 
-func TestRewriteWorkspaceDepsRewritesDevDependencies(t *testing.T) {
-	root := newTestWorkspace(t)
-	addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
-	libDir := addTestPackage(t, root, "lib", `{
+// pnpm accepts the workspace: protocol in all four dependency maps, and a
+// specifier left in any of them reaches consumers through the stored manifest.
+func TestRewriteWorkspaceDepsRewritesEveryDependencyField(t *testing.T) {
+	for _, field := range []string{"dependencies", "devDependencies", "peerDependencies", "optionalDependencies"} {
+		t.Run(field, func(t *testing.T) {
+			root := newTestWorkspace(t)
+			addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
+			libDir := addTestPackage(t, root, "lib", `{
   "name": "@ws/lib",
   "version": "1.0.0",
-  "devDependencies": {
+  "`+field+`": {
     "@ws/util": "workspace:^"
   }
 }
 `)
 
-	files := packWorkspacePkg(t, libDir)
-	cleanup, err := RewriteWorkspaceDeps(libDir, files)
-	defer cleanup()
+			files := packWorkspacePkg(t, libDir)
+			cleanup, err := RewriteWorkspaceDeps(libDir, files)
+			defer cleanup()
+			if err != nil {
+				t.Fatalf("RewriteWorkspaceDeps failed: %v", err)
+			}
+
+			entry := packageJSONEntry(t, files)
+			if got := depValue(t, entry.Path, field, "@ws/util"); got != "^2.3.0" {
+				t.Errorf("Expected %s.@ws/util to resolve to \"^2.3.0\", got %q", field, got)
+			}
+		})
+	}
+}
+
+// findWorkspaceDeps reads Go maps, whose iteration order is randomised, so it
+// sorts: errors and debug output must name the same dependency on every run.
+// The fields below are deliberately in two orders - depFields lists
+// peerDependencies before optionalDependencies, sorting puts them the other way
+// round - so this pins the sort rather than the traversal order.
+func TestFindWorkspaceDepsSortsByFieldThenName(t *testing.T) {
+	deps, err := findWorkspaceDeps([]byte(`{
+  "name": "@ws/lib",
+  "version": "1.0.0",
+  "dependencies": {"@ws/d": "workspace:*", "@ws/b": "workspace:*"},
+  "devDependencies": {"@ws/c": "workspace:*", "@ws/a": "workspace:*"},
+  "peerDependencies": {"@ws/e": "workspace:*"},
+  "optionalDependencies": {"@ws/f": "workspace:*"}
+}`))
 	if err != nil {
-		t.Fatalf("RewriteWorkspaceDeps failed: %v", err)
+		t.Fatalf("findWorkspaceDeps failed: %v", err)
 	}
 
-	entry := packageJSONEntry(t, files)
-	if got := depValue(t, entry.Path, "devDependencies", "@ws/util"); got != "^2.3.0" {
-		t.Errorf("Expected @ws/util to resolve to \"^2.3.0\", got %q", got)
+	want := []workspaceDep{
+		{field: "dependencies", name: "@ws/b", spec: "workspace:*"},
+		{field: "dependencies", name: "@ws/d", spec: "workspace:*"},
+		{field: "devDependencies", name: "@ws/a", spec: "workspace:*"},
+		{field: "devDependencies", name: "@ws/c", spec: "workspace:*"},
+		{field: "optionalDependencies", name: "@ws/f", spec: "workspace:*"},
+		{field: "peerDependencies", name: "@ws/e", spec: "workspace:*"},
+	}
+	if len(deps) != len(want) {
+		t.Fatalf("Expected %d workspace deps, got %d: %v", len(want), len(deps), deps)
+	}
+	for i, w := range want {
+		if deps[i] != w {
+			t.Errorf("Dep %d: expected %v, got %v", i, w, deps[i])
+		}
 	}
 }
 
@@ -170,7 +220,7 @@ func TestRewriteWorkspaceDepsRehashesRewrittenBytes(t *testing.T) {
 		t.Fatalf("RewriteWorkspaceDeps failed: %v", err)
 	}
 
-	rewritten, err := hashFile(entry.Path)
+	rewritten, err := HashFile(entry.Path)
 	if err != nil {
 		t.Fatalf("Failed to hash rewritten package.json: %v", err)
 	}
@@ -344,21 +394,23 @@ func TestRewriteWorkspaceDepsUnknownSiblingFails(t *testing.T) {
 	}
 }
 
-// A workspace: form this rewrite cannot resolve must fail loudly rather than
-// ship the literal specifier to consumers.
-func TestRewriteWorkspaceDepsUnsupportedSpecifierFails(t *testing.T) {
+// A bare "workspace:" carries no range to strip down to, so there is nothing to
+// publish: it must fail rather than ship an empty specifier.
+func TestRewriteWorkspaceDepsBareProtocolFails(t *testing.T) {
 	root := newTestWorkspace(t)
 	addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
-	libDir := addTestPackage(t, root, "lib", libManifest("workspace:^1.2.3"))
+	libDir := addTestPackage(t, root, "lib", libManifest("workspace:"))
 
 	files := packWorkspacePkg(t, libDir)
 	cleanup, err := RewriteWorkspaceDeps(libDir, files)
 	defer cleanup()
 	if err == nil {
-		t.Fatal("Expected an error for an unsupported workspace: specifier, got nil")
+		t.Fatal("Expected an error for a bare workspace: specifier, got nil")
 	}
-	if !strings.Contains(err.Error(), "workspace:^1.2.3") {
-		t.Errorf("Expected error to mention the specifier, got: %v", err)
+	for _, want := range []string{"workspace:", "@ws/util"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("Expected error to mention %q, got: %v", want, err)
+		}
 	}
 }
 
@@ -386,37 +438,71 @@ func TestRewriteWorkspaceDepsCleanupRemovesTempFile(t *testing.T) {
 	}
 }
 
-// A failed rewrite must leave nothing behind either.
-func TestRewriteWorkspaceDepsLeavesNoTempFileOnFailure(t *testing.T) {
+// A rewrite that fails while resolving gives up before any temporary file is
+// created, so the packed entry must still point at the source tree - publish
+// deferred the cleanup before checking the error, and the entry it hands to the
+// store has to be the untouched one.
+func TestRewriteWorkspaceDepsFailingResolutionKeepsPackedEntry(t *testing.T) {
 	root := newTestWorkspace(t)
-	addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
-	libDir := addTestPackage(t, root, "lib", `{
-  "name": "@ws/lib",
-  "version": "1.0.0",
-  "dependencies": {
-    "@ws/zombie": "workspace:*",
-    "@ws/ghost": "workspace:*"
-  }
-}
-`)
+	libDir := addTestPackage(t, root, "lib", libManifest("workspace:*"))
 
 	files := packWorkspacePkg(t, libDir)
 	entry := packageJSONEntry(t, files)
-	sourcePath := entry.Path
+	sourcePath, sourceHash, sourceSize := entry.Path, entry.ContentHash, entry.Size
 
 	cleanup, err := RewriteWorkspaceDeps(libDir, files)
 	defer cleanup()
 	if err == nil {
 		t.Fatal("Expected an error for a sibling missing from the workspace, got nil")
 	}
-	// The entries are resolved in sorted order, so which of the two
-	// unresolvable siblings is reported does not depend on Go's map iteration
-	// order.
-	if !strings.Contains(err.Error(), "@ws/ghost") || strings.Contains(err.Error(), "@ws/zombie") {
-		t.Errorf("Expected the first unresolvable dependency (@ws/ghost) to be reported, got: %v", err)
-	}
 	if entry.Path != sourcePath {
 		t.Errorf("Expected a failed rewrite to leave package.json packed from %s, got %s", sourcePath, entry.Path)
+	}
+	if entry.ContentHash != sourceHash || entry.Size != sourceSize {
+		t.Errorf("Expected a failed rewrite to leave the packed hash/size alone, got %s/%d", entry.ContentHash, entry.Size)
+	}
+}
+
+// The genuine leak path: a failure raised after the temporary file exists must
+// still remove it. Mode 0 is what gets it there - materialization gives the
+// temporary file the packed entry's mode, and hashing an unreadable file fails.
+func TestRewriteWorkspaceDepsRemovesTempFileWhenMaterializationFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows leaves a mode 0 file readable, so hashing it would not fail")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root reads a mode 0 file whatever its permissions say")
+	}
+
+	root := newTestWorkspace(t)
+	addTestPackage(t, root, "util", `{"name":"@ws/util","version":"2.3.0"}`)
+	libDir := addTestPackage(t, root, "lib", libManifest("workspace:*"))
+
+	// os.CreateTemp writes into os.TempDir(), so pointing that at an empty
+	// directory makes anything left behind directly observable.
+	tmpDir := t.TempDir()
+	t.Setenv("TMPDIR", tmpDir)
+
+	files := packWorkspacePkg(t, libDir)
+	entry := packageJSONEntry(t, files)
+	entry.Mode = 0
+
+	cleanup, err := RewriteWorkspaceDeps(libDir, files)
+	defer cleanup()
+	if err == nil {
+		t.Fatal("Expected hashing an unreadable rewritten package.json to fail, got nil")
+	}
+
+	left, readErr := os.ReadDir(tmpDir)
+	if readErr != nil {
+		t.Fatalf("Failed to read %s: %v", tmpDir, readErr)
+	}
+	if len(left) != 0 {
+		names := make([]string, len(left))
+		for i, e := range left {
+			names[i] = e.Name()
+		}
+		t.Errorf("Expected a failed rewrite to leave no temporary file, found %v in %s", names, tmpDir)
 	}
 }
 

--- a/tests/e2e/fixtures/workspace-deps/consumer/package.json
+++ b/tests/e2e/fixtures/workspace-deps/consumer/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ws-deps-consumer",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/e2e/fixtures/workspace-deps/monorepo/package.json
+++ b/tests/e2e/fixtures/workspace-deps/monorepo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ws-deps-monorepo",
+  "version": "0.0.0",
+  "private": true
+}

--- a/tests/e2e/fixtures/workspace-deps/monorepo/packages/lib/index.js
+++ b/tests/e2e/fixtures/workspace-deps/monorepo/packages/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = "lib-v1+" + require("@ws-deps/util");

--- a/tests/e2e/fixtures/workspace-deps/monorepo/packages/lib/package.json
+++ b/tests/e2e/fixtures/workspace-deps/monorepo/packages/lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@ws-deps/lib",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "@ws-deps/util": "workspace:^"
+  }
+}

--- a/tests/e2e/fixtures/workspace-deps/monorepo/packages/util/index.js
+++ b/tests/e2e/fixtures/workspace-deps/monorepo/packages/util/index.js
@@ -1,0 +1,1 @@
+module.exports = "util-v1";

--- a/tests/e2e/fixtures/workspace-deps/monorepo/packages/util/package.json
+++ b/tests/e2e/fixtures/workspace-deps/monorepo/packages/util/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@ws-deps/util",
+  "version": "2.3.0",
+  "main": "index.js"
+}

--- a/tests/e2e/fixtures/workspace-deps/monorepo/pnpm-workspace.yaml
+++ b/tests/e2e/fixtures/workspace-deps/monorepo/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/tests/e2e/monorepo_test.go
+++ b/tests/e2e/monorepo_test.go
@@ -1,7 +1,9 @@
 package e2e
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -120,4 +122,59 @@ func TestNpmYarnWorkspaceResolution(t *testing.T) {
 		appDir:  filepath.Join("apps", "app"),
 		pkgName: "npm-yarn-fix-lib",
 	})
+}
+
+// TestWorkspaceDependencyResolution publishes two packages of one workspace,
+// where the library depends on its sibling through "workspace:^", into a
+// consumer project that sits outside the workspace entirely.
+//
+// npm cannot install a workspace: specifier there, so the manifest lnpm links
+// must carry the sibling's real version instead — and real node must still
+// resolve the library and, through it, the sibling.
+func TestWorkspaceDependencyResolution(t *testing.T) {
+	t.Parallel()
+
+	if !nodeAvailable {
+		t.Skip("node not available; skipping real-resolution e2e test")
+	}
+
+	root := copyFixture(t, "workspace-deps")
+	store := newStore(t)
+
+	libDir := filepath.Join(root, "monorepo", "packages", "lib")
+	utilDir := filepath.Join(root, "monorepo", "packages", "util")
+	consumerDir := filepath.Join(root, "consumer")
+
+	runLNPM(t, store, utilDir, "publish")
+	runLNPM(t, store, libDir, "publish")
+
+	runLNPM(t, store, consumerDir, "add", "@ws-deps/util")
+	runLNPM(t, store, consumerDir, "add", "@ws-deps/lib")
+
+	// The linked manifest must be installable by npm: the sibling specifier is
+	// resolved, and no workspace: protocol survives anywhere in it.
+	linked := filepath.Join(consumerDir, ".lnpm", "@ws-deps", "lib")
+	assertDepValue(t, linked, "@ws-deps/util", "^2.3.0")
+	manifest, err := os.ReadFile(filepath.Join(linked, "package.json"))
+	if err != nil {
+		t.Fatalf("failed to read linked package.json: %v", err)
+	}
+	if strings.Contains(string(manifest), "workspace:") {
+		t.Fatalf("linked package.json still carries a workspace: specifier:\n%s", manifest)
+	}
+
+	// The developer's own manifest keeps the workspace: specifier.
+	source, err := os.ReadFile(filepath.Join(libDir, "package.json"))
+	if err != nil {
+		t.Fatalf("failed to read source package.json: %v", err)
+	}
+	if !strings.Contains(string(source), `"workspace:^"`) {
+		t.Fatalf("expected the source package.json to keep workspace:^, got:\n%s", source)
+	}
+
+	// node must resolve the library and the sibling it requires.
+	script := `process.stdout.write(require("@ws-deps/lib"))`
+	if got := runNode(t, consumerDir, script); got != "lib-v1+util-v1" {
+		t.Fatalf("expected node to resolve @ws-deps/lib to \"lib-v1+util-v1\", got %q", got)
+	}
 }

--- a/tests/fixtures/pnpm-workspace/packages/lib-b/package.json
+++ b/tests/fixtures/pnpm-workspace/packages/lib-b/package.json
@@ -1,8 +1,5 @@
 {
   "name": "@pnpm-test/lib-b",
   "version": "2.0.0",
-  "main": "index.js",
-  "dependencies": {
-    "@pnpm-test/lib-a": "workspace:*"
-  }
+  "main": "index.js"
 }

--- a/tests/fixtures/pnpm-workspace/packages/lib-b/package.json
+++ b/tests/fixtures/pnpm-workspace/packages/lib-b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@pnpm-test/lib-b",
   "version": "2.0.0",
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "@pnpm-test/lib-a": "workspace:*"
+  }
 }

--- a/tests/fixtures/workspace-deps/package.json
+++ b/tests/fixtures/workspace-deps/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "workspace-deps-test",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/fixtures/workspace-deps/packages/lib/index.js
+++ b/tests/fixtures/workspace-deps/packages/lib/index.js
@@ -1,0 +1,1 @@
+module.exports = { name: 'lib' };

--- a/tests/fixtures/workspace-deps/packages/lib/package.json
+++ b/tests/fixtures/workspace-deps/packages/lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@ws-deps/lib",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "@ws-deps/util": "workspace:*"
+  }
+}

--- a/tests/fixtures/workspace-deps/packages/util/index.js
+++ b/tests/fixtures/workspace-deps/packages/util/index.js
@@ -1,0 +1,1 @@
+module.exports = { name: 'util' };

--- a/tests/fixtures/workspace-deps/packages/util/package.json
+++ b/tests/fixtures/workspace-deps/packages/util/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@ws-deps/util",
+  "version": "2.3.0",
+  "main": "index.js"
+}

--- a/tests/fixtures/workspace-deps/pnpm-workspace.yaml
+++ b/tests/fixtures/workspace-deps/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -2,15 +2,12 @@ package tests
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
-
-	"github.com/cespare/xxhash/v2"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
 	"github.com/pedrosousa13/lnpm/internal/db"
@@ -835,6 +832,11 @@ func (te *TestEnvironment) AssertLinkedFileContent(projectDir, pkg, rel, want st
 // that changes a file's contents between packing and storing - a specifier
 // rewrite, say - has to be reflected in both or the store entry is addressed by
 // a hash of content it does not hold.
+//
+// The invariant only holds for packages without a prepare or prepublish script:
+// store.stripLifecycleScripts re-marshals the stored package.json after the
+// hash is taken, so for those the stored bytes legitimately differ from the
+// hashed ones and this helper would report a mismatch it did not cause.
 func (te *TestEnvironment) AssertStoredContentHash(packageName string) {
 	te.t.Helper()
 
@@ -853,11 +855,13 @@ func (te *TestEnvironment) AssertStoredContentHash(packageName string) {
 
 	data := make([]pack.FileEntryData, len(entries))
 	for i, e := range entries {
-		contents, err := os.ReadFile(filepath.Join(pkg.StorePath, e.RelativePath))
+		// pack.HashFile rather than a local xxhash of the bytes: the manifest
+		// records what pack produced, so the check has to be pack's own.
+		got, err := pack.HashFile(filepath.Join(pkg.StorePath, e.RelativePath))
 		if err != nil {
-			te.t.Fatalf("Failed to read stored %s: %v", e.RelativePath, err)
+			te.t.Fatalf("Failed to hash stored %s: %v", e.RelativePath, err)
 		}
-		if got := fmt.Sprintf("%016x", xxhash.Sum64(contents)); got != e.ContentHash {
+		if got != e.ContentHash {
 			te.t.Errorf("Stored %s hashes to %s, but the manifest records %s",
 				e.RelativePath, got, e.ContentHash)
 		}
@@ -872,6 +876,18 @@ func (te *TestEnvironment) AssertStoredContentHash(packageName string) {
 	if got := pack.HashFiles(pack.FileInfoFromStore(pkg.StorePath, data)); got != pkg.ContentHash {
 		te.t.Errorf("Expected content hash %s for %s, got %s", pkg.ContentHash, packageName, got)
 	}
+}
+
+// storedPackageJSONPath returns the path of a published package's package.json
+// inside the isolated store.
+func (te *TestEnvironment) storedPackageJSONPath(packageName string) string {
+	te.t.Helper()
+
+	pkg, err := te.Database.GetPackageByName(packageName)
+	if err != nil || pkg == nil {
+		te.t.Fatalf("Package %s not found in database: %v", packageName, err)
+	}
+	return filepath.Join(pkg.StorePath, "package.json")
 }
 
 // writeFile writes content to path (relative to cwd or absolute), failing on error.

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -9,8 +10,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/cespare/xxhash/v2"
+
 	"github.com/pedrosousa13/lnpm/internal/cli"
 	"github.com/pedrosousa13/lnpm/internal/db"
+	"github.com/pedrosousa13/lnpm/internal/pack"
 	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
 
@@ -824,6 +828,50 @@ func (te *TestEnvironment) publishAndAdd(pkgName string) (pkgDir, projectDir str
 func (te *TestEnvironment) AssertLinkedFileContent(projectDir, pkg, rel, want string) {
 	te.t.Helper()
 	te.AssertFileContent(filepath.Join(projectDir, ".lnpm", pkg, rel), want)
+}
+
+// AssertStoredContentHash checks that the package's recorded content hash is
+// the hash of the bytes actually sitting in the store, file by file. Anything
+// that changes a file's contents between packing and storing - a specifier
+// rewrite, say - has to be reflected in both or the store entry is addressed by
+// a hash of content it does not hold.
+func (te *TestEnvironment) AssertStoredContentHash(packageName string) {
+	te.t.Helper()
+
+	pkg, err := te.Database.GetPackageByName(packageName)
+	if err != nil || pkg == nil {
+		te.t.Fatalf("Package %s not found in database: %v", packageName, err)
+	}
+
+	entries, err := te.Database.GetFilesForPackage(pkg.ID)
+	if err != nil {
+		te.t.Fatalf("Failed to get file manifest for %s: %v", packageName, err)
+	}
+	if len(entries) == 0 {
+		te.t.Fatalf("Expected a file manifest for %s, got none", packageName)
+	}
+
+	data := make([]pack.FileEntryData, len(entries))
+	for i, e := range entries {
+		contents, err := os.ReadFile(filepath.Join(pkg.StorePath, e.RelativePath))
+		if err != nil {
+			te.t.Fatalf("Failed to read stored %s: %v", e.RelativePath, err)
+		}
+		if got := fmt.Sprintf("%016x", xxhash.Sum64(contents)); got != e.ContentHash {
+			te.t.Errorf("Stored %s hashes to %s, but the manifest records %s",
+				e.RelativePath, got, e.ContentHash)
+		}
+		data[i] = pack.FileEntryData{
+			RelPath: e.RelativePath,
+			Size:    e.Size,
+			Mode:    e.Mode,
+			Hash:    e.ContentHash,
+		}
+	}
+
+	if got := pack.HashFiles(pack.FileInfoFromStore(pkg.StorePath, data)); got != pkg.ContentHash {
+		te.t.Errorf("Expected content hash %s for %s, got %s", pkg.ContentHash, packageName, got)
+	}
 }
 
 // writeFile writes content to path (relative to cwd or absolute), failing on error.

--- a/tests/workspace_test.go
+++ b/tests/workspace_test.go
@@ -135,86 +135,77 @@ func TestNoWorkspace(t *testing.T) {
 
 // --- workspace: dependency specifiers ----------------------------------------
 //
-// The pnpm-workspace fixture's lib-b depends on its sibling lib-a with
-// "workspace:*". npm cannot install that specifier outside the workspace, so
-// publish must resolve it to the sibling's real version on the way into the
-// store, without touching the developer's own package.json.
-
-// storedPackageJSONPath returns the path of a published package's package.json
-// inside the isolated store.
-func storedPackageJSONPath(t *testing.T, env *TestEnvironment, name string) string {
-	t.Helper()
-
-	pkg, err := env.Database.GetPackageByName(name)
-	if err != nil || pkg == nil {
-		t.Fatalf("Package %s not found in database: %v", name, err)
-	}
-	return filepath.Join(pkg.StorePath, "package.json")
-}
+// The workspace-deps fixture exists for this and nothing else: its lib depends
+// on its sibling util with "workspace:*", at 2.3.0. npm cannot install that
+// specifier outside the workspace, so publish must resolve it to the sibling's
+// real version on the way into the store, without touching the developer's own
+// package.json. The other workspace fixtures stay free of workspace: specifiers
+// so the tests that only care about workspace discovery do not depend on this
+// rewrite working.
 
 func TestPublishResolvesWorkspaceDependency(t *testing.T) {
 	env := setupTest(t)
 
-	wsDir := env.CopyFixture("pnpm-workspace")
-	libBDir := filepath.Join(wsDir, "packages", "lib-b")
-	sourcePath := filepath.Join(libBDir, "package.json")
+	wsDir := env.CopyFixture("workspace-deps")
+	libDir := filepath.Join(wsDir, "packages", "lib")
+	sourcePath := filepath.Join(libDir, "package.json")
 
 	source, err := os.ReadFile(sourcePath)
 	if err != nil {
-		t.Fatalf("Failed to read lib-b package.json: %v", err)
+		t.Fatalf("Failed to read lib package.json: %v", err)
 	}
 	if !strings.Contains(string(source), `"workspace:*"`) {
-		t.Fatalf("Fixture lib-b must depend on lib-a with workspace:*, got:\n%s", source)
+		t.Fatalf("Fixture lib must depend on util with workspace:*, got:\n%s", source)
 	}
 
-	env.chdir(libBDir)
+	env.chdir(libDir)
 	// Skip validation: fixtures have no built files.
 	if err := cli.RunPublish(false, false, false, true); err != nil {
-		t.Fatalf("Failed to publish @pnpm-test/lib-b: %v", err)
+		t.Fatalf("Failed to publish @ws-deps/lib: %v", err)
 	}
 
 	// The developer's own package.json must come out byte-identical.
 	after, err := os.ReadFile(sourcePath)
 	if err != nil {
-		t.Fatalf("Failed to re-read lib-b package.json: %v", err)
+		t.Fatalf("Failed to re-read lib package.json: %v", err)
 	}
 	if string(after) != string(source) {
 		t.Errorf("Expected the source package.json to be untouched.\nBefore:\n%s\nAfter:\n%s", source, after)
 	}
 
-	// The stored package.json carries lib-a's real version, and nothing but the
+	// The stored package.json carries util's real version, and nothing but the
 	// specifier changed - key order and indentation survive the rewrite.
-	want := strings.Replace(string(source), `"workspace:*"`, `"1.0.0"`, 1)
-	env.AssertFileContent(storedPackageJSONPath(t, env, "@pnpm-test/lib-b"), want)
+	want := strings.Replace(string(source), `"workspace:*"`, `"2.3.0"`, 1)
+	env.AssertFileContent(env.storedPackageJSONPath("@ws-deps/lib"), want)
 
 	// The content hash addresses those rewritten bytes, not the ones on disk.
-	env.AssertStoredContentHash("@pnpm-test/lib-b")
+	env.AssertStoredContentHash("@ws-deps/lib")
 
 	// And that is exactly what a consumer receives.
-	projectDir := env.newProject("lib-b-consumer")
-	env.addPkg(projectDir, "@pnpm-test/lib-b", false, false)
-	env.AssertLinkedFileContent(projectDir, "@pnpm-test/lib-b", "package.json", want)
+	projectDir := env.newProject("lib-consumer")
+	env.addPkg(projectDir, "@ws-deps/lib", false, false)
+	env.AssertLinkedFileContent(projectDir, "@ws-deps/lib", "package.json", want)
 }
 
 // A package with no workspace: specifiers is stored byte-for-byte as written.
 func TestPublishWithoutWorkspaceDependenciesIsUnchanged(t *testing.T) {
 	env := setupTest(t)
 
-	wsDir := env.CopyFixture("pnpm-workspace")
-	libADir := filepath.Join(wsDir, "packages", "lib-a")
+	wsDir := env.CopyFixture("workspace-deps")
+	utilDir := filepath.Join(wsDir, "packages", "util")
 
-	source, err := os.ReadFile(filepath.Join(libADir, "package.json"))
+	source, err := os.ReadFile(filepath.Join(utilDir, "package.json"))
 	if err != nil {
-		t.Fatalf("Failed to read lib-a package.json: %v", err)
+		t.Fatalf("Failed to read util package.json: %v", err)
 	}
 
-	env.chdir(libADir)
+	env.chdir(utilDir)
 	if err := cli.RunPublish(false, false, false, true); err != nil {
-		t.Fatalf("Failed to publish @pnpm-test/lib-a: %v", err)
+		t.Fatalf("Failed to publish @ws-deps/util: %v", err)
 	}
 
-	env.AssertFileContent(storedPackageJSONPath(t, env, "@pnpm-test/lib-a"), string(source))
-	env.AssertStoredContentHash("@pnpm-test/lib-a")
+	env.AssertFileContent(env.storedPackageJSONPath("@ws-deps/util"), string(source))
+	env.AssertStoredContentHash("@ws-deps/util")
 }
 
 // A workspace: specifier in a package that is not in any workspace has nothing
@@ -244,12 +235,12 @@ func TestPublishWorkspaceDependencyOutsideWorkspaceFails(t *testing.T) {
 func TestPublishUnknownWorkspaceSiblingFails(t *testing.T) {
 	env := setupTest(t)
 
-	wsDir := env.CopyFixture("pnpm-workspace")
-	libBDir := filepath.Join(wsDir, "packages", "lib-b")
-	env.writeFile(filepath.Join(libBDir, "package.json"),
-		`{"name":"@pnpm-test/lib-b","version":"2.0.0","dependencies":{"@pnpm-test/ghost":"workspace:*"}}`)
+	wsDir := env.CopyFixture("workspace-deps")
+	libDir := filepath.Join(wsDir, "packages", "lib")
+	env.writeFile(filepath.Join(libDir, "package.json"),
+		`{"name":"@ws-deps/lib","version":"1.0.0","dependencies":{"@ws-deps/ghost":"workspace:*"}}`)
 
-	env.chdir(libBDir)
+	env.chdir(libDir)
 	err := cli.RunPublish(false, false, false, true)
 	if err == nil {
 		t.Fatal("Expected publish to fail for a sibling missing from the workspace, got nil")
@@ -257,7 +248,7 @@ func TestPublishUnknownWorkspaceSiblingFails(t *testing.T) {
 	if !strings.Contains(err.Error(), "no such package in the workspace") {
 		t.Errorf("Expected an error naming the missing sibling, got: %v", err)
 	}
-	env.AssertPackageInDatabase("@pnpm-test/lib-b", false)
+	env.AssertPackageInDatabase("@ws-deps/lib", false)
 }
 
 // push re-packs and re-stores, so it has to resolve specifiers exactly as
@@ -265,33 +256,33 @@ func TestPublishUnknownWorkspaceSiblingFails(t *testing.T) {
 func TestPushResolvesWorkspaceDependency(t *testing.T) {
 	env := setupTest(t)
 
-	wsDir := env.CopyFixture("pnpm-workspace")
-	libBDir := filepath.Join(wsDir, "packages", "lib-b")
+	wsDir := env.CopyFixture("workspace-deps")
+	libDir := filepath.Join(wsDir, "packages", "lib")
 
-	source, err := os.ReadFile(filepath.Join(libBDir, "package.json"))
+	source, err := os.ReadFile(filepath.Join(libDir, "package.json"))
 	if err != nil {
-		t.Fatalf("Failed to read lib-b package.json: %v", err)
+		t.Fatalf("Failed to read lib package.json: %v", err)
 	}
-	want := strings.Replace(string(source), `"workspace:*"`, `"1.0.0"`, 1)
+	want := strings.Replace(string(source), `"workspace:*"`, `"2.3.0"`, 1)
 
-	env.chdir(libBDir)
+	env.chdir(libDir)
 	if err := cli.RunPublish(false, false, false, true); err != nil {
-		t.Fatalf("Failed to publish @pnpm-test/lib-b: %v", err)
+		t.Fatalf("Failed to publish @ws-deps/lib: %v", err)
 	}
 
-	projectDir := env.newProject("lib-b-push-consumer")
-	env.addPkg(projectDir, "@pnpm-test/lib-b", false, false)
+	projectDir := env.newProject("lib-push-consumer")
+	env.addPkg(projectDir, "@ws-deps/lib", false, false)
 
 	// Change the source so push has new content to store.
-	env.writeFile(filepath.Join(libBDir, "index.js"), "module.exports = 'lib-b-v2';")
-	env.chdir(libBDir)
+	env.writeFile(filepath.Join(libDir, "index.js"), "module.exports = 'lib-v2';")
+	env.chdir(libDir)
 	if err := cli.RunPush(false); err != nil {
-		t.Fatalf("Failed to push @pnpm-test/lib-b: %v", err)
+		t.Fatalf("Failed to push @ws-deps/lib: %v", err)
 	}
 
-	env.AssertFileContent(storedPackageJSONPath(t, env, "@pnpm-test/lib-b"), want)
-	env.AssertStoredContentHash("@pnpm-test/lib-b")
-	env.AssertLinkedFileContent(projectDir, "@pnpm-test/lib-b", "package.json", want)
+	env.AssertFileContent(env.storedPackageJSONPath("@ws-deps/lib"), want)
+	env.AssertStoredContentHash("@ws-deps/lib")
+	env.AssertLinkedFileContent(projectDir, "@ws-deps/lib", "package.json", want)
 }
 
 // push on a package that was never published delegates to the publish path, so
@@ -299,20 +290,20 @@ func TestPushResolvesWorkspaceDependency(t *testing.T) {
 func TestPushUnpublishedResolvesWorkspaceDependency(t *testing.T) {
 	env := setupTest(t)
 
-	wsDir := env.CopyFixture("pnpm-workspace")
-	libBDir := filepath.Join(wsDir, "packages", "lib-b")
+	wsDir := env.CopyFixture("workspace-deps")
+	libDir := filepath.Join(wsDir, "packages", "lib")
 
-	source, err := os.ReadFile(filepath.Join(libBDir, "package.json"))
+	source, err := os.ReadFile(filepath.Join(libDir, "package.json"))
 	if err != nil {
-		t.Fatalf("Failed to read lib-b package.json: %v", err)
+		t.Fatalf("Failed to read lib package.json: %v", err)
 	}
 
-	env.chdir(libBDir)
+	env.chdir(libDir)
 	if err := cli.RunPush(false); err != nil {
-		t.Fatalf("Failed to push @pnpm-test/lib-b: %v", err)
+		t.Fatalf("Failed to push @ws-deps/lib: %v", err)
 	}
 
-	want := strings.Replace(string(source), `"workspace:*"`, `"1.0.0"`, 1)
-	env.AssertFileContent(storedPackageJSONPath(t, env, "@pnpm-test/lib-b"), want)
-	env.AssertStoredContentHash("@pnpm-test/lib-b")
+	want := strings.Replace(string(source), `"workspace:*"`, `"2.3.0"`, 1)
+	env.AssertFileContent(env.storedPackageJSONPath("@ws-deps/lib"), want)
+	env.AssertStoredContentHash("@ws-deps/lib")
 }

--- a/tests/workspace_test.go
+++ b/tests/workspace_test.go
@@ -1,9 +1,12 @@
 package tests
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/pedrosousa13/lnpm/internal/cli"
 	"github.com/pedrosousa13/lnpm/internal/workspace"
 )
 
@@ -128,4 +131,188 @@ func TestNoWorkspace(t *testing.T) {
 	if ws != nil {
 		t.Error("Expected nil workspace for /tmp")
 	}
+}
+
+// --- workspace: dependency specifiers ----------------------------------------
+//
+// The pnpm-workspace fixture's lib-b depends on its sibling lib-a with
+// "workspace:*". npm cannot install that specifier outside the workspace, so
+// publish must resolve it to the sibling's real version on the way into the
+// store, without touching the developer's own package.json.
+
+// storedPackageJSONPath returns the path of a published package's package.json
+// inside the isolated store.
+func storedPackageJSONPath(t *testing.T, env *TestEnvironment, name string) string {
+	t.Helper()
+
+	pkg, err := env.Database.GetPackageByName(name)
+	if err != nil || pkg == nil {
+		t.Fatalf("Package %s not found in database: %v", name, err)
+	}
+	return filepath.Join(pkg.StorePath, "package.json")
+}
+
+func TestPublishResolvesWorkspaceDependency(t *testing.T) {
+	env := setupTest(t)
+
+	wsDir := env.CopyFixture("pnpm-workspace")
+	libBDir := filepath.Join(wsDir, "packages", "lib-b")
+	sourcePath := filepath.Join(libBDir, "package.json")
+
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("Failed to read lib-b package.json: %v", err)
+	}
+	if !strings.Contains(string(source), `"workspace:*"`) {
+		t.Fatalf("Fixture lib-b must depend on lib-a with workspace:*, got:\n%s", source)
+	}
+
+	env.chdir(libBDir)
+	// Skip validation: fixtures have no built files.
+	if err := cli.RunPublish(false, false, false, true); err != nil {
+		t.Fatalf("Failed to publish @pnpm-test/lib-b: %v", err)
+	}
+
+	// The developer's own package.json must come out byte-identical.
+	after, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("Failed to re-read lib-b package.json: %v", err)
+	}
+	if string(after) != string(source) {
+		t.Errorf("Expected the source package.json to be untouched.\nBefore:\n%s\nAfter:\n%s", source, after)
+	}
+
+	// The stored package.json carries lib-a's real version, and nothing but the
+	// specifier changed - key order and indentation survive the rewrite.
+	want := strings.Replace(string(source), `"workspace:*"`, `"1.0.0"`, 1)
+	env.AssertFileContent(storedPackageJSONPath(t, env, "@pnpm-test/lib-b"), want)
+
+	// The content hash addresses those rewritten bytes, not the ones on disk.
+	env.AssertStoredContentHash("@pnpm-test/lib-b")
+
+	// And that is exactly what a consumer receives.
+	projectDir := env.newProject("lib-b-consumer")
+	env.addPkg(projectDir, "@pnpm-test/lib-b", false, false)
+	env.AssertLinkedFileContent(projectDir, "@pnpm-test/lib-b", "package.json", want)
+}
+
+// A package with no workspace: specifiers is stored byte-for-byte as written.
+func TestPublishWithoutWorkspaceDependenciesIsUnchanged(t *testing.T) {
+	env := setupTest(t)
+
+	wsDir := env.CopyFixture("pnpm-workspace")
+	libADir := filepath.Join(wsDir, "packages", "lib-a")
+
+	source, err := os.ReadFile(filepath.Join(libADir, "package.json"))
+	if err != nil {
+		t.Fatalf("Failed to read lib-a package.json: %v", err)
+	}
+
+	env.chdir(libADir)
+	if err := cli.RunPublish(false, false, false, true); err != nil {
+		t.Fatalf("Failed to publish @pnpm-test/lib-a: %v", err)
+	}
+
+	env.AssertFileContent(storedPackageJSONPath(t, env, "@pnpm-test/lib-a"), string(source))
+	env.AssertStoredContentHash("@pnpm-test/lib-a")
+}
+
+// A workspace: specifier in a package that is not in any workspace has nothing
+// to resolve against, and must fail rather than ship the literal specifier.
+func TestPublishWorkspaceDependencyOutsideWorkspaceFails(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.CreateTestPackage("orphan-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'orphan-lib';",
+	})
+	env.writeFile(filepath.Join(pkgDir, "package.json"),
+		`{"name":"orphan-lib","version":"1.0.0","dependencies":{"some-sibling":"workspace:*"}}`)
+
+	env.chdir(pkgDir)
+	err := cli.RunPublish(false, false, false, true)
+	if err == nil {
+		t.Fatal("Expected publish to fail for a workspace: specifier outside a workspace, got nil")
+	}
+	if !strings.Contains(err.Error(), "not part of a workspace") {
+		t.Errorf("Expected an error explaining the package is not in a workspace, got: %v", err)
+	}
+	env.AssertPackageInDatabase("orphan-lib", false)
+}
+
+// A workspace: specifier naming a package the workspace does not contain must
+// fail too - the sibling's version is simply not knowable.
+func TestPublishUnknownWorkspaceSiblingFails(t *testing.T) {
+	env := setupTest(t)
+
+	wsDir := env.CopyFixture("pnpm-workspace")
+	libBDir := filepath.Join(wsDir, "packages", "lib-b")
+	env.writeFile(filepath.Join(libBDir, "package.json"),
+		`{"name":"@pnpm-test/lib-b","version":"2.0.0","dependencies":{"@pnpm-test/ghost":"workspace:*"}}`)
+
+	env.chdir(libBDir)
+	err := cli.RunPublish(false, false, false, true)
+	if err == nil {
+		t.Fatal("Expected publish to fail for a sibling missing from the workspace, got nil")
+	}
+	if !strings.Contains(err.Error(), "no such package in the workspace") {
+		t.Errorf("Expected an error naming the missing sibling, got: %v", err)
+	}
+	env.AssertPackageInDatabase("@pnpm-test/lib-b", false)
+}
+
+// push re-packs and re-stores, so it has to resolve specifiers exactly as
+// publish does or the first push would put the literal specifier back.
+func TestPushResolvesWorkspaceDependency(t *testing.T) {
+	env := setupTest(t)
+
+	wsDir := env.CopyFixture("pnpm-workspace")
+	libBDir := filepath.Join(wsDir, "packages", "lib-b")
+
+	source, err := os.ReadFile(filepath.Join(libBDir, "package.json"))
+	if err != nil {
+		t.Fatalf("Failed to read lib-b package.json: %v", err)
+	}
+	want := strings.Replace(string(source), `"workspace:*"`, `"1.0.0"`, 1)
+
+	env.chdir(libBDir)
+	if err := cli.RunPublish(false, false, false, true); err != nil {
+		t.Fatalf("Failed to publish @pnpm-test/lib-b: %v", err)
+	}
+
+	projectDir := env.newProject("lib-b-push-consumer")
+	env.addPkg(projectDir, "@pnpm-test/lib-b", false, false)
+
+	// Change the source so push has new content to store.
+	env.writeFile(filepath.Join(libBDir, "index.js"), "module.exports = 'lib-b-v2';")
+	env.chdir(libBDir)
+	if err := cli.RunPush(false); err != nil {
+		t.Fatalf("Failed to push @pnpm-test/lib-b: %v", err)
+	}
+
+	env.AssertFileContent(storedPackageJSONPath(t, env, "@pnpm-test/lib-b"), want)
+	env.AssertStoredContentHash("@pnpm-test/lib-b")
+	env.AssertLinkedFileContent(projectDir, "@pnpm-test/lib-b", "package.json", want)
+}
+
+// push on a package that was never published delegates to the publish path, so
+// it must resolve specifiers there too.
+func TestPushUnpublishedResolvesWorkspaceDependency(t *testing.T) {
+	env := setupTest(t)
+
+	wsDir := env.CopyFixture("pnpm-workspace")
+	libBDir := filepath.Join(wsDir, "packages", "lib-b")
+
+	source, err := os.ReadFile(filepath.Join(libBDir, "package.json"))
+	if err != nil {
+		t.Fatalf("Failed to read lib-b package.json: %v", err)
+	}
+
+	env.chdir(libBDir)
+	if err := cli.RunPush(false); err != nil {
+		t.Fatalf("Failed to push @pnpm-test/lib-b: %v", err)
+	}
+
+	want := strings.Replace(string(source), `"workspace:*"`, `"1.0.0"`, 1)
+	env.AssertFileContent(storedPackageJSONPath(t, env, "@pnpm-test/lib-b"), want)
+	env.AssertStoredContentHash("@pnpm-test/lib-b")
 }


### PR DESCRIPTION
Nothing in lnpm rewrote `workspace:` specifiers. A package published from a
pnpm/npm/yarn workspace shipped the literal `"@myorg/utils": "workspace:*"` into
every consumer's `.lnpm/<pkg>/package.json`, and `npm install` there failed —
npm has no idea what `workspace:*` means outside a workspace.

Publishing now resolves those specifiers against the sibling's real version, the
way pnpm and yalc do:

| Specifier | Stored as |
| --- | --- |
| `workspace:*`, `workspace:latest` | `2.3.0` |
| `workspace:^` | `^2.3.0` |
| `workspace:~` | `~2.3.0` |
| `workspace:^1.2.3`, `workspace:>=1 <3` | the range verbatim |

All four dependency fields are scanned — `dependencies`, `devDependencies`,
`peerDependencies` and `optionalDependencies`. pnpm permits `workspace:` in all
of them, and a literal specifier in any one is the same broken install.

Two cases are errors rather than a silently unusable package: a `workspace:`
dependency on a sibling that is not in the detected workspace, and a bare
`workspace:` with nothing after it.

## The source tree is never touched

`FileInfo.Path` is the absolute path of the developer's own file, and the store
copies from exactly that path — so rewriting in place would edit the workspace's
package.json. Instead the rewritten document is materialised to a temp file, that
one `FileInfo` is repointed at it, and its content hash and size are recomputed
before `HashFiles` runs. The resolved version therefore reaches both the content
hash and what consumers link, while the developer's package.json comes out
byte-identical. The CLI command owns the temp file's lifetime and removes it on
every path, including failure.

The rewrite splices through `internal/pkgjson` rather than round-tripping the
document through a map, so key order, indentation and large integer literals
survive untouched.

## `push` too

`push` re-packs and re-stores, so without the same rewrite the first push after a
publish put the literal `workspace:*` straight back into the consumer. Verified
by counterfactual build: with the `push` change reverted, a publish → add → push
regresses the consumer's linked manifest.

## Tests

Unit tests in `internal/pack`, integration tests over a dedicated
`tests/fixtures/workspace-deps/` fixture, and an e2e test that publishes two
workspace packages, adds the consumer outside the workspace, and lets real node
resolve it. Every assertion was mutation-tested against the production code it
pins.

One known interaction, pre-existing and out of scope: `stripLifecycleScripts`
still re-marshals the stored package.json through a map, so a package with a
`prepare` or `prepublish` script has its formatting reflowed after hashing. The
resolved versions survive that; the formatting does not. `AssertStoredContentHash`
documents the limit rather than pretending the invariant is unconditional.

Closes #192
