### PR TITLE
Correct the file-filtering claims in README

### DIFF
--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -5,10 +5,13 @@
 ## APIs & External Services
 
 **Package Managers (External Commands):**
-- npm - Used via `npm pack --dry-run` to determine which files to publish
-  - Purpose: Get list of files that would be included in `npm publish`
-  - Fallback: Custom filtering if npm unavailable
+- npm - Used to run scripts (`npm run <script>`) and installs, never to select files
+  - Purpose: Lifecycle hooks on publish/push, and `npm install` on `add --install`
+  - Location: `internal/hooks/hooks.go`, `internal/config/config.go`
+- File selection - Pure Go, modeled on npm's rules but not identical to them
+  - Purpose: Decide which files land in the store
   - Location: `internal/pack/pack.go`
+  - Differences from `npm publish`: see the README's "File Filtering" section
 
 **Version Control:**
 - git - Optional integration for git-aware file filtering

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -239,7 +239,9 @@ lnpm publish --push
 
 **Process:**
 1. Read `package.json` for name/version
-2. Determine files to include (respects `.npmignore`, `files` field)
+2. Determine files to include (respects `.npmignore`, `files` field — see the
+   README's "File Filtering" section for the rules and where they part company
+   with `npm publish`)
 3. Calculate content hash of all files
 4. Reflink or copy files into a temporary directory alongside
    `~/.lnpm/store/{name}/{hash}/`, then rename it into place

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Debug output goes to stderr with timestamps, useful for diagnosing slow operatio
 
 ## How It Works
 
-1. **Publish** — Uses `npm pack` rules to determine files, strips lifecycle scripts (`prepare`/`prepublish`), resolves `workspace:` dependency specifiers to versions npm can install (see [Monorepo Support](#monorepo-support)), then reflinks or copies to `~/.lnpm/store/{name}/{hash}/`
+1. **Publish** — Selects files with lnpm's own filtering (see [File Filtering](#file-filtering)), strips lifecycle scripts (`prepare`/`prepublish`), resolves `workspace:` dependency specifiers to versions npm can install (see [Monorepo Support](#monorepo-support)), then reflinks or copies to `~/.lnpm/store/{name}/{hash}/`
 2. **Add** — Creates reflinks or hard links from store to `project/.lnpm/{package}/`, updates package.json to `file:.lnpm/{package}`
 3. **Symlink** — Links `node_modules/{package}` → `.lnpm/{package}`
 4. **Push** — Updates store and re-links changed files
@@ -381,17 +381,23 @@ package.json    ──►       pkg/abc123/      (reflink/hardlink)     (symlink
 
 ### File Filtering
 
-lnpm uses **npm's standard packing rules** (via `npm pack --dry-run`) to determine which files to include, ensuring consistency with actual npm publish behavior. This means:
+lnpm decides which files to publish in Go — it does not shell out to the `npm` CLI. The rules are closely modeled on npm's conventions:
 
 - Respects `package.json` `files` field
-- Honors `.npmignore` or falls back to `.gitignore`
-- Follows npm's default exclusions (`.git`, `node_modules`, etc.)
+- Honors a root `.npmignore`, falling back to a root `.gitignore` (ignore files in subdirectories are not read)
+- Supports gitignore pattern syntax — root anchoring (`/dist`), directory patterns (`dist/`) and negation (`*.txt` followed by `!keep.txt`), with the last matching pattern deciding
+- Applies a built-in exclusion list — VCS metadata and ignore files (`.git`, `.hg`, `.svn`, `CVS`, `.gitignore`, `.gitattributes`, `.npmignore`, `.npmrc`), `node_modules`, OS cruft (`.DS_Store`, `Thumbs.db`), editor and merge backups (`*.swp`, `*.swo`, `*~`, `*.orig`), lnpm and yalc state (`.lnpm/`, `.yalc/`, `lnpm.lock`, `yalc.lock`), `*.log`, `*.tgz`, and exactly `.env` and `.env.*` — that a `!` pattern cannot re-include. The patterns are literal, not prefixes: `.envrc` matches neither `.env` nor `.env.*`, so it is published
 - **Additional safety**: Explicit `.git` filtering prevents any VCS files from being linked
 - **Symlinks are skipped, never followed** — a symlink inside a package can't pull files from outside it (e.g. `~/.ssh`) into the store
-- Package names with path separators or `..` are rejected to prevent path traversal
-- Automatic fallback to custom filtering if npm is unavailable
+- Package names are restricted to a plain name (`my-pkg`) or a single scope (`@org/my-pkg`), because the name is joined into the store path. Everything else is rejected: a second `/`, a single `/` whose first segment is not a scope, `.` or `..` segments, absolute paths, backslashes and NUL bytes
 
-This approach prevents issues with git hooks (like Husky) running in linked packages and ensures lnpm behaves identically to npm publish.
+Because the filtering is lnpm's own, some cases differ from `npm publish`:
+
+- The default exclusion list is not npm's. lnpm additionally drops `.env`/`.env.*`, logs and `*.tgz`, and does not drop the lockfiles (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`) that npm always ignores
+- Ignore patterns are applied before the `files` whitelist, so a root `.npmignore` can drop a file that `files` listed; for npm the `files` field wins
+- An excluded directory is pruned during the walk, so a negation can't reach back into it: `dist/` plus `!dist/keep.js` publishes neither file. npm diverges in the opposite direction — the negation defeats the `dist/` rule entirely and npm publishes the whole directory, `dist/other.js` included. Spelled `dist/*` instead, the negation does what it looks like in both
+- Entries in `files` are matched against the full path and never against a basename, so `**/*.md` picks up `docs/guide.md` but misses `top.md` at the package root, which npm includes
+- The always-included set differs: lnpm adds `CHANGELOG*`, `CHANGES*` and `HISTORY*`, and does not automatically include the files named by `main` and `bin`. Those files are exempt from the `files` whitelist only — an ignore pattern still drops them
 
 ### Automatic .gitignore Management
 


### PR DESCRIPTION
README said `lnpm publish` delegates file selection to the real `npm` CLI via
`npm pack --dry-run`, with a fallback to custom logic when npm is unavailable,
and concluded that lnpm "behaves identically to npm publish". None of that has
ever been true — `git grep exec.Command internal/pack/` finds nothing, and the
npm-pack dependency lnpm briefly had was removed outright in v1.7.6 rather than
made optional. Overstating a guarantee about which files reach a shared store is
the kind of doc bug that gets trusted.

The File Filtering section now describes what the Go code actually does, and adds
a short list of the cases where it and `npm publish` genuinely part company.

**Every claim in the rewritten section was verified by running it** — building the
binary, publishing fixture packages into an isolated `LNPM_STORE`, and listing
what landed, with `npm pack --dry-run` on the same fixture for comparison
(npm 11.16.0). That mattered: a first draft asserted three things that reading the
code had made look obvious and experiment disproved.

- A bare `*.md` in `files` was said not to match `docs/guide.md` "the way npm's
  globbing does". npm behaves identically. The real difference runs the other way:
  with `**/*.md`, npm includes a root-level `top.md` and lnpm does not.
- The built-in exclusion list was summarised as `.env*`. The patterns are exactly
  `.env` and `.env.*`, so **`.envrc` is published**. That bullet is framed as a
  safety guarantee, so rounding it off was the worst place to be imprecise. The
  list is now enumerated in full rather than summarised.
- `dist/` plus `!dist/keep.js` was said to publish neither file "where npm
  publishes `keep.js`". npm publishes the entire directory — the negation defeats
  the `dist/` rule outright. It now says so.

Two other corrections found along the way: the old bullet claiming package names
"with path separators" are rejected was wrong, since `@org/pkg` is exactly one
permitted separator; and the negation example in one bullet was `!dist/keep.js`,
the very case another bullet says does not work.

`.planning/codebase/INTEGRATIONS.md` still asserted the deleted claims verbatim
and was the last live statement of them, so it is corrected too — split, because
npm genuinely is still invoked here, just for lifecycle scripts and installs
rather than file selection. `ARCHITECTURE.md`'s publish step, which had become the
shallowest description of filtering in the repo, now points at the README section.

Documentation only. No Go was touched; the filtering behavior itself is #150 and
#207.

Closes #199
