### PR TITLE
Remove the false git-staging claims about `lnpm push`

### DIFF
--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -349,6 +349,7 @@ lnpm push
 ```json
 {
   "name": "my-monorepo",
+  "version": "0.0.0",
   "private": true,
   "workspaces": [
     "packages/*",
@@ -393,6 +394,7 @@ lnpm push
 ```json
 {
   "name": "my-monorepo",
+  "version": "0.0.0",
   "private": true,
   "workspaces": [
     "packages/*"
@@ -482,22 +484,7 @@ cd ~/external-app
 lnpm add @my/ui
 ```
 
-### 5. Git Stage for Fast Iteration
-
-Enable fast change detection with git staging:
-
-```bash
-# Make changes
-vim packages/ui/src/button.tsx
-
-# Stage changes (no commit needed)
-git add packages/ui/src/button.tsx
-
-# Push immediately detects staged changes
-lnpm push
-```
-
-### 6. Use Build Tool's Watch Mode
+### 5. Use Build Tool's Watch Mode
 
 For active development, use your build tool's watch mode combined with `lnpm push`:
 
@@ -543,17 +530,59 @@ Ensure your workspace configuration is correct:
 **NPM/Yarn:** Check `workspaces` field in root `package.json`
 **Turborepo:** Uses package manager's workspace config
 
-### Issue: Changes not detected
+### Issue: Changes not picked up after a push
 
-Stage your changes so lnpm picks them up:
+`lnpm push` re-packs whatever is on disk in the directory you run it from. It does not consult git, so committing or staging makes no difference. Two things usually explain a push that appears to succeed but changes nothing.
+
+**1. You ran it from the workspace root instead of the package directory.**
+
+The root `package.json` of a monorepo is itself a package as far as lnpm is concerned, so pushing from the root publishes the root package, not your library:
 
 ```bash
-# Stage changes (no commit needed)
-git add .
-
-# Push detects staged changes
-lnpm push
+$ cd ~/my-monorepo
+$ lnpm push
+Package my-monorepo not published yet, publishing...
+Publishing my-monorepo@0.0.0 (5 files)...
+✓ Published my-monorepo@0.0.0
+  Hash: a8cfcfa7
+  Files: 5
+  Size: 441 B
+  Store: /home/you/.lnpm/store/my-monorepo/a8cfcfa78070eb53
 ```
+
+That exits 0 and nothing warns you. `cd` into the package you actually changed and push from there:
+
+```bash
+$ cd packages/ui
+$ lnpm push
+Pushing @my/ui@1.0.0...
+Updating 1 linked projects...
+  ✓ /home/you/external-app
+
+Pushed to 1/1 projects
+```
+
+A directory with no `package.json` at all is the one case push does complain about:
+
+```bash
+$ cd ~/my-monorepo/apps
+$ lnpm push
+Error: failed to read package.json: failed to read package.json: open /home/you/my-monorepo/apps/package.json: no such file or directory
+```
+
+**2. You changed a source file but did not rebuild.**
+
+If `files` in your `package.json` ships `dist/`, then `dist/` is what push packs. Editing `src/` without running the build sends the previous build's output, and the push still reports `Pushed to 1/1 projects`. Run your build first:
+
+```bash
+# Turborepo
+turbo run build --filter=@my/ui && lnpm push
+
+# Nx
+nx build my-lib && lnpm push
+```
+
+lnpm runs your `prepublishOnly`, `prepare` and `prepack` scripts before packing, so if your build is wired into one of those, push rebuilds for you. A plain `build` script is not run automatically.
 
 ### Issue: Slow push times
 

--- a/examples/nx-example.md
+++ b/examples/nx-example.md
@@ -168,20 +168,6 @@ lnpm push
 nx run feature-auth:lnpm-push
 ```
 
-### Working with git
-
-```bash
-# Make changes
-vim libs/ui/src/button.tsx
-
-# Stage (no commit needed!)
-git add libs/ui/
-
-# Push detects staged changes
-cd libs/ui
-lnpm push
-```
-
 ## Advanced Usage
 
 ### Publish only buildable libraries
@@ -310,18 +296,35 @@ Check your project.json outputs configuration:
 }
 ```
 
-**Issue: Changes not pushed**
+**Issue: Changes not picked up after a push**
 
-Make sure you're in the library directory or use git staging:
+`cd` into the library directory before running `lnpm push`. Push packs whatever is on disk in the directory you run it from — git state plays no part — so from the workspace root it publishes the root package and exits successfully without touching your library:
 ```bash
-cd libs/feature-auth
-lnpm push
-
-# Or from root with git
-git add libs/feature-auth/
-cd libs/feature-auth
-lnpm push
+$ cd ~/projects/my-nx-workspace
+$ lnpm push
+Package my-nx-workspace not published yet, publishing...
+Publishing my-nx-workspace@1.0.0 (6 files)...
+✓ Published my-nx-workspace@1.0.0
+  Hash: 0322bedf
+  Files: 6
+  Size: 480 B
+  Store: /home/you/.lnpm/store/my-nx-workspace/0322bedfad632406
 ```
+
+Run it from the library instead:
+```bash
+$ cd libs/feature-auth
+$ lnpm push
+Pushing @my-org/feature-auth@1.0.0...
+Updating 1 linked projects...
+  ✓ /home/you/projects/my-app
+
+Pushed to 1/1 projects
+```
+
+Build before you push, and make sure the build output lands where push will see it. The library's `main` is `./dist/index.js`, so the app loads `libs/feature-auth/dist` — editing `src/` and pushing ships the new sources alongside the old build, and the app keeps running the previous one. Note that the `build` target above writes to `dist/libs/feature-auth` at the workspace root, which is outside the directory push packs; point its `outputPath` at `libs/feature-auth/dist` so the output lands inside the library.
+
+lnpm does run your `prepublishOnly`, `prepare` and `prepack` scripts before packing, so wiring `nx build feature-auth` into one of those makes push rebuild for you. A plain `build` script is not run automatically — that is what the `lnpm-push` target's `dependsOn` is for.
 
 **Issue: Nx cache conflicts**
 

--- a/examples/turborepo-example.md
+++ b/examples/turborepo-example.md
@@ -25,6 +25,7 @@ my-turborepo/
 ```json
 {
   "name": "my-turborepo",
+  "version": "0.0.0",
   "private": true,
   "workspaces": [
     "apps/*",
@@ -134,19 +135,6 @@ npm run build
 lnpm push
 ```
 
-### Working with git
-
-```bash
-# Make changes
-vim packages/ui/src/button.tsx
-
-# Stage (no commit needed!)
-git add packages/ui/src/button.tsx
-
-# Push detects staged changes instantly
-lnpm push
-```
-
 ## Tips
 
 **1. Use Turborepo's filtering:**
@@ -210,11 +198,38 @@ Then run it (optionally in watch) before pushing:
 turbo run build --filter=@my/ui --watch
 ```
 
-**Issue: Changes not pushed**
+**Issue: Changes not picked up after a push**
 
-Stage your changes so lnpm picks them up:
+`lnpm push` packs whatever is on disk in the directory you run it from, so git state is irrelevant — there is nothing to stage or commit first. Check these two instead.
+
+Run push from the package directory, not the monorepo root. Pushing from the root publishes the root package, and it exits successfully while your library goes nowhere:
 ```bash
-git add .
-lnpm push
+$ cd ~/projects/my-turborepo
+$ lnpm push
+Package my-turborepo not published yet, publishing...
+Publishing my-turborepo@0.0.0 (6 files)...
+✓ Published my-turborepo@0.0.0
+  Hash: 37e17a1b
+  Files: 6
+  Size: 590 B
+  Store: /home/you/.lnpm/store/my-turborepo/37e17a1bf0121ca4
 ```
+
+Run it from the package instead:
+```bash
+$ cd packages/ui
+$ lnpm push
+Pushing @my/ui@1.0.0...
+Updating 1 linked projects...
+  ✓ /home/you/projects/my-app
+
+Pushed to 1/1 projects
+```
+
+And build before you push. `@my/ui` points `main` at `./dist/index.js`, so the app loads the built output — editing `src/` alone ships the previous build and push still reports `Pushed to 1/1 projects`:
+```bash
+turbo run build --filter=@my/ui && lnpm push
+```
+
+lnpm does run your `prepublishOnly`, `prepare` and `prepack` scripts before packing, so moving the build into one of those makes push rebuild for you. The plain `build` script above is not run automatically.
 


### PR DESCRIPTION
`MONOREPO.md` and both example guides told readers to `git add` their changes
before `lnpm push`, framing staging as how push "detects" what to send. It is
fiction: `git grep 'exec.Command("git"' -- internal/` returns nothing, and the
only external commands lnpm runs are `go`, the four package managers, Windows
`mklink`, and the shell. Push re-packs whatever is on disk, staged or not.

Following that advice gives a wrong mental model of a command that writes to a
shared store, so the fix is to describe what actually produces the symptom the
sections were trying to solve.

## The two real causes, both verified by running them

**Pushing from the workspace root.** The root `package.json` is itself a package
as far as lnpm is concerned, so push publishes *the root*, prints a success
message, and exits 0 — while your library goes nowhere. Confirmed: the
consumer's linked files are byte-identical before and after. That silence is
worse than the error the old text implied, and it is now what the troubleshooting
entry leads with.

**Pushing without rebuilding.** If `files` ships `dist/`, editing `src/` sends
the previous build's output and push still reports `Pushed to 1/1 projects`.

With one qualification the issue did not mention, and which is the difference
between "run your build first" being necessary and being redundant: lnpm *does*
run `prepublishOnly`, `prepare` and `prepack` before packing — verified, all
three — while a plain `build` script is not run automatically. That caveat is now
in all three documents.

## The transcripts are real captures

Every shell block was captured from an actual run on a pty rather than through a
pipe, because `iconOK()` renders `✓` on a terminal and falls back to `OK` when
stdout is not a character device — the first draft quoted the piped form, which
no reader would ever see. Each capture uses the package names, versions and paths
its own file already establishes, and includes the `Hash`/`Files`/`Size`/`Store`
lines that `finishPublish` always prints rather than truncating silently.

Two things surfaced while making the transcripts real:

- `pack.readPackageJSON` rejects a `package.json` with no `version`, so a
  versionless workspace root cannot be pushed at all. The three root examples the
  transcripts refer to gain `"version": "0.0.0"`, so the documented workspace is
  one the documented command can actually act on.
- The Nx example's own `build` target writes to `dist/libs/feature-auth` at the
  workspace root — outside the directory push packs — so its library would never
  ship a fresh build. The wording now says so instead of implying otherwise.

Documentation only. No Go was touched; how push decides what to push is
unchanged.

Closes #200
