### PR TITLE
Push from the package directory, and never install lnpm as a dependency

### DIFF
--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -43,12 +43,12 @@ lnpm integrates seamlessly with monorepo tools by:
 lnpm is a **system-wide binary** that can link packages from any workspace to any project (inside or outside the monorepo).
 
 ```
+lnpm ← one binary on your PATH (e.g. /usr/local/bin/lnpm), never in node_modules
+
 my-monorepo/                    external-app/
 ├── package.json                ├── package.json
-├── node_modules/               └── node_modules/
-│   └── lnpm ← installed here       └── @my/ui ← linked from monorepo
-├── packages/
-│   └── ui/
+├── packages/                   └── node_modules/
+│   └── ui/                         └── @my/ui ← linked from monorepo
 │       ├── package.json
 │       └── src/
 └── apps/
@@ -81,13 +81,18 @@ go install github.com/pedrosousa13/lnpm/cmd/lnpm@latest
   "scripts": {
     "dev": "turbo run dev",
     "build": "turbo run build",
-    "lnpm:publish": "lnpm publish --all",
-    "lnpm:push": "lnpm push"
+    "lnpm:publish": "lnpm publish --all"
   },
   "devDependencies": {
     "turbo": "latest"
   }
 }
+```
+
+There is deliberately no root `lnpm:push` script here. `lnpm publish --all` reads your workspace configuration and so works from the root, but `lnpm push` only ever acts on the `package.json` in the directory it runs from — a root script would pack the root package and exit 0 without touching your library. Push an individual package from inside that package's directory:
+
+```bash
+cd packages/ui && lnpm push
 ```
 
 ### Workflow: Publishing Monorepo Packages
@@ -134,7 +139,8 @@ npm run lnpm:publish
 cd apps/web
 lnpm add @my/ui
 
-# Build and push changes
+# Build and push changes — push from the package you changed, not from apps/web
+cd ../../packages/ui
 turbo run build --filter=@my/ui
 lnpm push
 ```
@@ -161,10 +167,12 @@ lnpm push
 }
 ```
 
-Add a custom task:
+Add the matching script to **the package's own `package.json`** — `packages/ui/package.json`, not the root one. Turborepo runs each task with that package's directory as the working directory, which is what makes `lnpm push` act on `@my/ui`:
 
 ```json
 {
+  "name": "@my/ui",
+  "version": "1.0.0",
   "scripts": {
     "lnpm:push": "lnpm push"
   }
@@ -196,11 +204,12 @@ go install github.com/pedrosousa13/lnpm/cmd/lnpm@latest
 ```json
 {
   "scripts": {
-    "lnpm:publish": "lnpm publish --all",
-    "lnpm:push": "lnpm push"
+    "lnpm:publish": "lnpm publish --all"
   }
 }
 ```
+
+As in the Turborepo section, there is no root push script: `lnpm push` acts on whichever `package.json` is in the current directory. Push a single library either from inside it (`cd libs/feature-auth && lnpm push`) or through the Nx target below, which sets `cwd` for you.
 
 ### Workflow: Publishing Libraries
 
@@ -262,6 +271,8 @@ Add a custom target in `project.json` for your library:
 
 Then run: `nx run feature-auth:lnpm-push`
 
+Note the `outputPath`: it follows the Nx default of `dist/libs/feature-auth` at the workspace root, which is outside the directory `lnpm push` packs. Point it at `libs/feature-auth/dist` instead, or every push ships the library's previous build no matter how often you rebuild.
+
 ### Nx Task Pipeline
 
 Use Nx task pipeline to auto-push after build:
@@ -281,13 +292,12 @@ Use Nx task pipeline to auto-push after build:
 If you only want to publish specific Nx libraries:
 
 ```bash
-# Publish single library
-cd libs/feature-auth
-lnpm publish
+# From the workspace root, publish one library
+(cd libs/feature-auth && lnpm publish)
 
-# Or from root with filters
-cd libs/ui && lnpm publish
-cd libs/data-access && lnpm publish
+# Or several, each from its own directory
+(cd libs/ui && lnpm publish)
+(cd libs/data-access && lnpm publish)
 ```
 
 ---
@@ -312,12 +322,11 @@ packages:
 {
   "scripts": {
     "lnpm:publish": "lnpm publish --all"
-  },
-  "devDependencies": {
-    "lnpm": "*"
   }
 }
 ```
+
+lnpm is not listed as a dependency — it is a system binary, so nothing in the workspace installs it.
 
 ### Workflow
 
@@ -330,11 +339,12 @@ lnpm publish --all
 
 # Link to external project
 cd ~/external-app
-lnpm add @my/package
+lnpm add @my/ui
 
-# Build and push from monorepo
+# Build from the root, then push from the package directory
 cd ~/my-monorepo
-pnpm --filter @my/package build
+pnpm --filter @my/ui build
+cd packages/ui
 lnpm push
 ```
 
@@ -357,9 +367,6 @@ lnpm push
   ],
   "scripts": {
     "lnpm:publish": "lnpm publish --all"
-  },
-  "devDependencies": {
-    "lnpm": "*"
   }
 }
 ```
@@ -375,11 +382,12 @@ lnpm publish --all
 
 # Link to external project
 cd ~/external-app
-lnpm add @my/package
+lnpm add @my/ui
 
-# Build and push from monorepo
+# Build from the root, then push from the package directory
 cd ~/my-monorepo
-npm run build -w @my/package
+npm run build -w @my/ui
+cd packages/ui
 lnpm push
 ```
 
@@ -401,9 +409,6 @@ lnpm push
   ],
   "scripts": {
     "lnpm:publish": "lnpm publish --all"
-  },
-  "devDependencies": {
-    "lnpm": "*"
   }
 }
 ```
@@ -419,11 +424,12 @@ lnpm publish --all
 
 # Link to external project
 cd ~/external-app
-lnpm add @my/package
+lnpm add @my/ui
 
-# Build and push from monorepo
+# Build from the root, then push from the package directory
 cd ~/my-monorepo
-yarn workspace @my/package build
+yarn workspace @my/ui build
+cd packages/ui
 lnpm push
 ```
 
@@ -455,17 +461,21 @@ This respects your workspace configuration automatically.
 
 ### 3. Combine with Task Orchestration
 
-Let your task runner handle builds, use lnpm for distribution:
+Let your task runner handle builds, use lnpm for distribution. The build is filtered by package name, but the push is decided by the current directory, so `cd` into the package before pushing:
 
 **Turborepo:**
 ```bash
-turbo run build --filter=@my/ui && lnpm push
+turbo run build --filter=@my/ui
+cd packages/ui && lnpm push
 ```
 
 **Nx:**
 ```bash
-nx build my-lib && lnpm push
+nx build feature-auth
+cd libs/feature-auth && lnpm push
 ```
+
+Nx writes build output to `dist/libs/<name>` at the workspace root by default, which push never sees — see [Nx Project Configuration](#nx-project-configuration).
 
 ### 4. Link External Projects, Not Internal
 
@@ -492,14 +502,17 @@ For active development, use your build tool's watch mode combined with `lnpm pus
 # Terminal 1: Watch and build with turbo/nx
 turbo run build --filter=@my/ui --watch
 
-# Terminal 2: Push when ready
+# Terminal 2: Push when ready, from the package directory
+cd packages/ui
 lnpm push
 ```
 
-Or integrate into your build scripts:
+Or integrate into the package's own `package.json` — never the root one, since the script's working directory is what push acts on:
 
 ```json
 {
+  "name": "@my/ui",
+  "version": "1.0.0",
   "scripts": {
     "build:dev": "tsc --watch --onSuccess \"lnpm push\""
   }
@@ -576,11 +589,17 @@ If `files` in your `package.json` ships `dist/`, then `dist/` is what push packs
 
 ```bash
 # Turborepo
-turbo run build --filter=@my/ui && lnpm push
-
-# Nx
-nx build my-lib && lnpm push
+turbo run build --filter=@my/ui
+cd packages/ui && lnpm push
 ```
+
+```bash
+# Nx
+nx build feature-auth
+cd libs/feature-auth && lnpm push
+```
+
+With Nx, also check where the build writes: its default `outputPath` sits at the workspace root, outside the directory push packs, so the rebuild never reaches the pushed package. See [Nx Project Configuration](#nx-project-configuration).
 
 lnpm runs your `prepublishOnly`, `prepare` and `prepack` scripts before packing, so if your build is wired into one of those, push rebuilds for you. A plain `build` script is not run automatically.
 
@@ -627,7 +646,7 @@ lnpm status
 cd packages/ui
 lnpm publish
 
-# Push changes to linked projects
+# Push changes to linked projects (still inside packages/ui)
 lnpm push
 ```
 
@@ -648,7 +667,11 @@ npm publish
 Enable debug mode:
 
 ```bash
+# From the workspace root
 LNPM_DEBUG=1 lnpm publish --all
+
+# From the package you want to push
+cd packages/ui
 LNPM_DEBUG=1 lnpm push
 ```
 
@@ -656,13 +679,13 @@ LNPM_DEBUG=1 lnpm push
 
 ## Summary
 
-| Tool | Install Location | Publish Command | Push Command |
-|------|------------------|-----------------|--------------|
-| **Turborepo** | System (global) | `lnpm publish --all` | `lnpm push` |
-| **Nx** | System (global) | `lnpm publish --all` | `lnpm push` |
-| **PNPM** | System (global) | `lnpm publish --all` | `lnpm push` |
-| **NPM** | System (global) | `lnpm publish --all` | `lnpm push` |
-| **Yarn** | System (global) | `lnpm publish --all` | `lnpm push` |
+| Tool | Install Location | Publish Command (run from the workspace root) | Push Command (run from the package directory) |
+|------|------------------|-----------------------------------------------|-----------------------------------------------|
+| **Turborepo** | System (global) | `lnpm publish --all` | `cd packages/ui && lnpm push` |
+| **Nx** | System (global) | `lnpm publish --all` | `cd libs/feature-auth && lnpm push` |
+| **PNPM** | System (global) | `lnpm publish --all` | `cd packages/ui && lnpm push` |
+| **NPM** | System (global) | `lnpm publish --all` | `cd packages/ui && lnpm push` |
+| **Yarn** | System (global) | `lnpm publish --all` | `cd packages/ui && lnpm push` |
 
 **Key Takeaway:** lnpm complements your monorepo tool—it doesn't replace it. Use your tool for internal dependencies and orchestration, use lnpm to rapidly iterate with external projects.
 

--- a/README.md
+++ b/README.md
@@ -135,10 +135,11 @@ lnpm integrates seamlessly with Turborepo, Nx, and all workspace managers:
 # lnpm is installed globally (one-time system install)
 # See installation section above
 
-# Publish all workspace packages
+# Publish all workspace packages (from the workspace root)
 lnpm publish --all
 
-# Push updates to all linked projects
+# Push updates for one package (from that package's own directory)
+cd packages/ui
 lnpm push
 ```
 
@@ -312,17 +313,17 @@ lnpm publish --skip-validation # Skip validation (for broken packages)
 
 ```bash
 # In your TypeScript library
-cd my-library
+cd ~/code/my-library
 # package.json has "prepare": "tsc"
 
 lnpm publish    # Automatically builds TypeScript → dist/
 
 # In your app
-cd my-app
+cd ~/code/my-app
 lnpm add my-library   # Links and runs npm install
 
 # Make changes to library
-cd my-library
+cd ~/code/my-library
 # Edit src/index.ts
 lnpm push       # Rebuilds and updates all linked projects
 ```

--- a/examples/nx-example.md
+++ b/examples/nx-example.md
@@ -6,7 +6,7 @@ Quick example showing lnpm with Nx monorepo.
 
 ```
 my-nx-workspace/
-├── package.json         # Root with lnpm installed
+├── package.json         # Root workspace config (lnpm is a system binary, not a dependency)
 ├── nx.json             # Nx config
 ├── libs/
 │   ├── feature-auth/
@@ -31,8 +31,7 @@ my-nx-workspace/
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "lnpm:pub": "lnpm publish --all",
-    "lnpm:push": "lnpm push"
+    "lnpm:pub": "lnpm publish --all"
   },
   "devDependencies": {
     "nx": "latest",
@@ -40,6 +39,8 @@ my-nx-workspace/
   }
 }
 ```
+
+No root `lnpm:push` script: `lnpm push` acts on the `package.json` in the directory it runs from, so from the root it would pack `my-nx-workspace` instead of your library. Push from `libs/feature-auth`, or via the `lnpm-push` target below, which sets `cwd` for you.
 
 **2. Library project.json (libs/feature-auth/project.json):**
 
@@ -175,10 +176,10 @@ nx run feature-auth:lnpm-push
 If you have non-buildable libs (just TypeScript, no build step), publish only buildable ones:
 
 ```bash
-# From root - manually specify
-cd libs/feature-auth && lnpm publish
-cd libs/ui && lnpm publish
-cd libs/data-access && lnpm publish
+# From the workspace root - manually specify, each in its own directory
+(cd libs/feature-auth && lnpm publish)
+(cd libs/ui && lnpm publish)
+(cd libs/data-access && lnpm publish)
 ```
 
 Or create a script:
@@ -197,8 +198,8 @@ Or create a script:
 # Rebuild several libs (optionally with nx watch), then push each
 nx run-many --target=build --projects=feature-auth,ui
 
-cd libs/feature-auth && lnpm push
-cd libs/ui && lnpm push
+(cd libs/feature-auth && lnpm push)
+(cd libs/ui && lnpm push)
 ```
 
 ### Use Nx affected
@@ -343,16 +344,15 @@ lnpm push
 ## Example Commands Summary
 
 ```bash
-# Publish all workspace libs
+# Publish all workspace libs (from the workspace root)
 npm run lnpm:pub
 
 # Link to external project
-cd ~/my-app && lnpm add @my-org/feature-auth
+(cd ~/my-app && lnpm add @my-org/feature-auth)
 
 # Build then push (from lib directory)
 nx build feature-auth
-cd libs/feature-auth
-lnpm push
+(cd libs/feature-auth && lnpm push)
 
 # Use custom Nx target (builds + pushes)
 nx run feature-auth:lnpm-push

--- a/examples/turborepo-example.md
+++ b/examples/turborepo-example.md
@@ -6,7 +6,7 @@ Quick example showing lnpm with Turborepo.
 
 ```
 my-turborepo/
-├── package.json         # Root with lnpm installed
+├── package.json         # Root workspace config (lnpm is a system binary, not a dependency)
 ├── turbo.json          # Turborepo config
 ├── packages/
 │   └── ui/
@@ -34,14 +34,15 @@ my-turborepo/
   "scripts": {
     "dev": "turbo run dev",
     "build": "turbo run build",
-    "lnpm:pub": "lnpm publish --all",
-    "lnpm:push": "lnpm push"
+    "lnpm:pub": "lnpm publish --all"
   },
   "devDependencies": {
     "turbo": "latest"
   }
 }
 ```
+
+No root `lnpm:push` script: `lnpm push` acts on the `package.json` in the directory it runs from, so from the root it would pack `my-turborepo` instead of `@my/ui`. Push from `packages/ui`, or via the `lnpm:push` script below, which Turborepo runs with that package's directory as its cwd.
 
 **2. Package config (packages/ui/package.json):**
 
@@ -52,7 +53,8 @@ my-turborepo/
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "lnpm:push": "lnpm push"
   }
 }
 ```
@@ -70,10 +72,16 @@ my-turborepo/
     "dev": {
       "cache": false,
       "persistent": true
+    },
+    "lnpm:push": {
+      "dependsOn": ["build"],
+      "cache": false
     }
   }
 }
 ```
+
+Then `turbo run lnpm:push --filter=@my/ui` builds `@my/ui` and pushes it, both with `packages/ui` as the working directory.
 
 ## Usage
 
@@ -107,12 +115,12 @@ lnpm add @my/ui
 Run Turborepo's own watch mode to rebuild on change, then push when you're ready:
 
 ```bash
-cd ~/projects/my-turborepo
-
 # Terminal 1: watch and rebuild on changes
+cd ~/projects/my-turborepo
 turbo run build --filter=@my/ui --watch
 
 # Terminal 2: push built output to linked projects
+cd ~/projects/my-turborepo/packages/ui
 lnpm push
 ```
 
@@ -131,7 +139,8 @@ vim packages/ui/src/button.tsx
 # Build with Turborepo
 npm run build
 
-# Push to linked projects
+# Push to linked projects, from the package directory
+cd packages/ui
 lnpm push
 ```
 
@@ -150,11 +159,11 @@ turbo run build --filter=@my/ui...
 **2. Combine Turborepo watch with push:**
 
 ```bash
-# Terminal 1: rebuild on change
+# Terminal 1: rebuild on change (from the workspace root)
 turbo run build --filter=@my/ui --watch
 
-# Terminal 2: push built output when ready
-lnpm push
+# Terminal 2: push built output when ready (from the package)
+cd packages/ui && lnpm push
 ```
 
 **3. Multiple packages:**
@@ -171,9 +180,10 @@ lnpm add @my/ui
 lnpm add @my/components
 lnpm add @my/utils
 
-# Rebuild a specific package, then push
+# Rebuild a specific package, then push from that package's directory
 cd ~/projects/my-turborepo
 turbo run build --filter=@my/ui
+cd packages/ui
 lnpm push
 ```
 
@@ -228,7 +238,8 @@ Pushed to 1/1 projects
 
 And build before you push. `@my/ui` points `main` at `./dist/index.js`, so the app loads the built output — editing `src/` alone ships the previous build and push still reports `Pushed to 1/1 projects`:
 ```bash
-turbo run build --filter=@my/ui && lnpm push
+turbo run build --filter=@my/ui
+cd packages/ui && lnpm push
 ```
 
 lnpm does run your `prepublishOnly`, `prepare` and `prepack` scripts before packing, so moving the build into one of those makes push rebuild for you. The plain `build` script above is not run automatically.


### PR DESCRIPTION
`MONOREPO.md` contradicted itself twice.

Its banner says lnpm is a standalone Go binary that must never be added to
`package.json`, and Best Practice #1 shows `npm install -D lnpm` under a "❌
Wrong" heading — while three root `package.json` snippets in the same file listed
`"lnpm": "*"` in `devDependencies`, and the architecture diagram showed `lnpm ←
installed here` under `node_modules/`. lnpm is not published to npm, so those
snippets could never resolve.

Separately, several workflows ran `lnpm push` from the monorepo root. Push reads
`package.json` from the working directory, so from the root it packs the root —
publishing the wrong package, printing success, and exiting 0. There is no
`--all` for push, so pushing everything from the root is impossible rather than
merely undocumented. (`publish --all` does exist, so the root
`"lnpm:publish"` script stays.)

## Not a blanket removal

`lnpm:push` appears at seven sites, and the issue named one. What decides each is
whose `package.json` the script lives in: a root-level one is wrong, but a
per-package script invoked through a task runner is correct, because the runner
sets the package directory as the working directory. Four root-level scripts are
removed; three package-level sites are kept and their location made explicit.

Verified rather than assumed — a probe task confirmed `turbo run lnpm:push
--filter=@my/ui` executes with `packages/ui` as cwd and pushes `@my/ui`, and an
Nx `run-commands` target with `"cwd": "libs/feature-auth"` does the same. All
three corrected pnpm/npm/yarn workflow blocks were run verbatim against fixtures,
each ending with the linked consumer resolving the new build.

## Beyond the issue's list

A repo-wide sweep found the same defect at sites the issue did not name — seven
more in `MONOREPO.md`, five in `examples/turborepo-example.md`, and one in
`README.md`. All corrected, since leaving them would have left each file
contradicting its own troubleshooting section.

Also fixed: chained relative `cd`s that cannot work (`cd libs/feature-auth &&
lnpm publish` followed by `cd libs/ui` resolves against the first and errors —
confirmed in bash and zsh); a promise in `examples/turborepo-example.md` of a
`lnpm:push` script the file never actually showed, now made real; and the Nx trap
`39ac6a5` documented — that example's build target writes outside the directory
push packs — which the first draft of this change reintroduced in `MONOREPO.md`.

## Found while working, deliberately not fixed

Three real defects outside this issue's scope, worth their own tickets:

- Both turbo examples use turbo 1.x's `"pipeline"` key. Turbo 2.x renamed it to
  `"tasks"` and hard-errors otherwise, so **every turbo example is broken for
  anyone on turbo 2**.
- `MONOREPO.md` shows `tsc --watch --onSuccess`; `tsc` has no `--onSuccess` flag.
- The pnpm/npm/yarn workflow blocks publish before building, so on a virgin tree
  `lnpm publish --all` fails validation with "main file not found".

Documentation only. No Go was touched.

Closes #201
