### PR TITLE
Replace the stale roadmap with a current summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ lnpm push
 - **[Monorepo Guide](MONOREPO.md)** — Turborepo, Nx, PNPM/NPM/Yarn workspaces integration
 - **[Architecture](ARCHITECTURE.md)** — System design and implementation details
 - **[Changelog](CHANGELOG.md)** — Version history and updates
-- **[Roadmap](ROADMAP.md)** — Planned features and improvements
+- **[Roadmap](ROADMAP.md)** — What lnpm does today, and where planned work is tracked
 
 ## Commands
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,326 +1,68 @@
-# lnpm Implementation Roadmap
-
-## Go Dependencies
-
-```go
-// Core
-github.com/spf13/cobra       // CLI framework
-github.com/spf13/viper       // Configuration
-modernc.org/sqlite           // Pure Go SQLite (no CGO)
-
-// File operations
-github.com/bmatcuk/doublestar // Glob patterns
-
-// UX
-github.com/charmbracelet/lipgloss   // Styling
-github.com/charmbracelet/bubbles    // Spinners, tables
-github.com/fatih/color              // Terminal colors
-
-// Utilities
-github.com/cespare/xxhash/v2        // Fast hashing
-github.com/pelletier/go-toml/v2     // TOML config
-gopkg.in/yaml.v3                    // YAML lock file
-```
-
----
-
-## Phase 1: Core Foundation
-
-**Goal:** Basic publish/add/remove cycle working end-to-end.
-
-### 1.1 Project Setup
-- [ ] Initialize Go module (`go mod init github.com/pedrosousa13/lnpm`)
-- [ ] Set up directory structure:
-  ```
-  lnpm/
-  ├── cmd/
-  │   └── lnpm/
-  │       └── main.go
-  ├── internal/
-  │   ├── cli/           # Cobra commands
-  │   ├── store/         # Package store operations
-  │   ├── db/            # SQLite operations
-  │   ├── link/          # Hard link manager
-  │   ├── pack/          # Package file resolution
-  │   └── config/        # Configuration
-  ├── pkg/
-  │   └── lockfile/      # Lock file parsing
-  ├── go.mod
-  └── go.sum
-  ```
-- [ ] Configure Cobra with root command
-- [ ] Add version flag (`lnpm --version`)
-
-### 1.2 SQLite Database
-- [ ] Database initialization with migrations
-- [ ] Connection pool management
-- [ ] Schema creation (packages, projects, links, files tables)
-- [ ] Basic CRUD operations for each table
-- [ ] Database location: `~/.lnpm/lnpm.db`
-
-### 1.3 Package Store
-- [ ] Store directory structure (`~/.lnpm/store/{name}/{hash}/`)
-- [ ] Content hash calculation (xxhash of all file contents)
-- [ ] File manifest generation
-- [ ] Copy files to store
-- [ ] Retrieve package from store by name/hash
-
-### 1.4 Pack Logic (npm pack equivalent)
-- [ ] Parse `package.json`
-- [ ] Read `files` field (whitelist)
-- [ ] Read `.npmignore` (blacklist)
-- [ ] Read `.gitignore` as fallback
-- [ ] Default includes: `package.json`, `README*`, `LICENSE*`, `CHANGELOG*`
-- [ ] Default excludes: `node_modules`, `.git`, `*.log`, etc.
-- [ ] Return list of files to publish
-
-### 1.5 `lnpm publish` Command
-- [ ] Validate current directory has `package.json`
-- [ ] Extract name and version
-- [ ] Calculate files to include
-- [ ] Generate content hash
-- [ ] Check if already published (skip if same hash)
-- [ ] Copy files to store
-- [ ] Record in database
-- [ ] Print success message with hash
-
-### 1.6 `lnpm add` Command
-- [ ] Parse package argument (name, optional @version)
-- [ ] Look up package in store
-- [ ] Create `.lnpm/{package}/` directory
-- [ ] Hard link files from store
-- [ ] Create symlink `node_modules/{package}` → `.lnpm/{package}`
-- [ ] Detect package manager
-- [ ] Update `package.json` with `file:` dependency
-- [ ] Create/update `lnpm.lock`
-- [ ] Record link in database
-
-### 1.7 `lnpm remove` Command
-- [ ] Parse package argument
-- [ ] Remove `.lnpm/{package}/` directory
-- [ ] Remove `node_modules/{package}` symlink
-- [ ] Restore original dependency in `package.json` (from lock)
-- [ ] Update `lnpm.lock`
-- [ ] Remove link from database
-
-### 1.8 Lock File
-- [ ] Define YAML schema
-- [ ] Parse existing lock file
-- [ ] Write lock file
-- [ ] Store original dependency versions for restore
-
-**Deliverable:** Can publish a package and add it to another project with hard links.
-
----
-
-## Phase 2: Push & Sync
-
-**Goal:** Update linked packages without re-adding.
-
-### 2.1 `lnpm push` Command
-- [ ] Calculate new content hash
-- [ ] Compare with stored hash
-- [ ] If different:
-  - [ ] Update store with new files
-  - [ ] For each linked project:
-    - [ ] Remove old hard links
-    - [ ] Create new hard links
-  - [ ] Update database
-- [ ] If same: print "No changes"
-
-### 2.2 Incremental Updates
-- [ ] Store file-level hashes in `files` table
-- [ ] On push, compare file hashes
-- [ ] Only re-link changed files
-- [ ] Track added/removed files
-
-### 2.3 `lnpm publish --push`
-- [ ] Combine publish and push in one command
-- [ ] Publish to store
-- [ ] Push to all linked projects
-
-### 2.4 Cross-Filesystem Detection
-- [ ] Detect if store and project are on different filesystems
-- [ ] Fall back to copy mode with warning
-- [ ] Suggest config change for store location
-
-**Deliverable:** Can update linked packages with single command.
-
----
-
-## Phase 3: Status & Visibility
-
-**Goal:** Full visibility into lnpm state.
-
-### 3.1 `lnpm status` Command
-- [ ] Query all published packages
-- [ ] Query all active links
-- [ ] Format as tables with lipgloss
-- [ ] Show relative times ("2 minutes ago")
-
-### 3.2 `lnpm list` Command
-- [ ] `lnpm list` - packages in current project
-- [ ] `lnpm list --store` - all packages in store
-- [ ] `lnpm list <pkg> --projects` - projects using package
-
-### 3.3 `lnpm doctor` Command
-- [ ] Check store directory exists
-- [ ] Validate database integrity
-- [ ] Find orphaned links (project deleted)
-- [ ] Find orphaned packages (no links)
-- [ ] Detect cross-filesystem issues
-- [ ] Suggest fixes for each issue
-
-### 3.4 `lnpm gc` Command
-- [ ] `--dry-run` - show what would be removed
-- [ ] Remove packages with no links
-- [ ] `--older-than` - remove old packages
-- [ ] `--fix-links` - clean orphaned link records
-
-**Deliverable:** Full visibility and maintenance tools.
-
----
-
-## Phase 4: DX Polish
-
-**Goal:** Delightful developer experience.
-
-### 4.1 Rich Output
-- [ ] Colored success/error messages
-- [ ] Spinners for long operations
-- [ ] Progress bars for multi-file copies
-- [ ] Emoji indicators (optional, detect terminal support)
-
-### 4.2 Error Messages
-- [ ] Actionable error messages with suggestions
-- [ ] "Did you mean?" for typos
-- [ ] Link to docs for common issues
-
-### 4.3 Shell Completions
-- [ ] Bash completions
-- [ ] Zsh completions
-- [ ] Fish completions
-- [ ] Auto-install completions
-
-### 4.4 Configuration
-- [ ] Global config (`~/.lnpm/config.toml`)
-- [ ] Project config (`.lnpmrc`)
-- [ ] Environment variable overrides
-- [ ] `lnpm config` command to view/edit
-
-### 4.5 Hooks
-- [ ] `prePublish` - run before publish
-- [ ] `postPublish` - run after publish
-- [ ] `postAdd` - run after add (e.g., `npm install`)
-- [ ] Configure in project or package
-
-**Deliverable:** Polished, professional CLI tool.
-
----
-
-## Phase 5: Advanced Features
-
-**Goal:** Power user features and monorepo support.
-
-### 5.1 Monorepo Support
-- [ ] Detect workspace root (pnpm-workspace.yaml, etc.)
-- [ ] `lnpm publish --all` - publish all workspace packages
-- [ ] Resolve `workspace:*` protocol
-- [ ] Handle inter-package dependencies
-
-### 5.2 Tags
-- [ ] `lnpm publish --tag beta`
-- [ ] `lnpm add pkg@beta`
-- [ ] Store tags in database
-- [ ] `lnpm tag` command to manage tags
-
-### 5.3 History
-- [ ] Keep multiple versions in store
-- [ ] `lnpm list pkg --versions`
-- [ ] `lnpm add pkg@abc123` (by hash)
-- [ ] `lnpm rollback pkg` - revert to previous version
-
-### 5.4 Retreat Command
-- [ ] `lnpm retreat` - remove all lnpm changes
-- [ ] Restore original package.json
-- [ ] Clean .lnpm directory
-- [ ] Useful before `npm publish`
-
-**Deliverable:** Full-featured local package management.
-
----
-
-## Phase 6: Distribution
-
-**Goal:** Easy installation everywhere.
-
-### 6.1 Build Pipeline
-- [ ] GitHub Actions workflow
-- [ ] Build for linux/amd64, linux/arm64
-- [ ] Build for darwin/amd64, darwin/arm64
-- [ ] Build for windows/amd64
-
-### 6.2 Release Automation
-- [ ] goreleaser configuration
-- [ ] Semantic versioning
-- [ ] Changelog generation
-- [ ] GitHub releases with binaries
-
-### 6.3 Package Managers
-- [ ] Homebrew formula (macOS/Linux)
-- [ ] Scoop manifest (Windows)
-- [ ] AUR package (Arch Linux)
-- [ ] npm wrapper (`npx lnpm`)
-
-### 6.4 Installation Script
-- [ ] `curl -fsSL https://lnpm.dev/install.sh | sh`
-- [ ] Detect OS and architecture
-- [ ] Download and install binary
-- [ ] Add to PATH
-
-**Deliverable:** One-command installation on any platform.
-
----
-
-## Success Metrics
-
-| Metric | Target |
-|--------|--------|
-| Startup time | < 10ms |
-| `publish` (100 files) | < 500ms |
-| `add` (hard link) | < 100ms |
-| `push` (1 changed file) | < 50ms |
-| Binary size | < 15MB |
-
----
-
-## Testing Strategy
-
-### Unit Tests
-- Pack logic (file inclusion/exclusion)
-- Hash calculation
-- Lock file parsing
-- Database operations
-
-### Integration Tests
-- Full publish → add → push cycle
-- Cross-project linking
-- Package manager detection
-
-### E2E Tests
-- Real npm/pnpm/yarn/bun projects
-- Monorepo scenarios
-- Cross-filesystem scenarios (Docker)
-
----
-
-## Timeline Estimate
-
-| Phase | Complexity |
-|-------|------------|
-| Phase 1: Core | High |
-| Phase 2: Push | Medium |
-| Phase 3: Status | Low |
-| Phase 4: DX | Medium |
-| Phase 5: Advanced | High |
-| Phase 6: Distribution | Medium |
+# lnpm Roadmap
+
+## What lnpm does today
+
+lnpm publishes a package into a local store and links it into other projects on
+the same machine, so you can develop a library against its consumers without
+going through a registry. The shipped commands cover:
+
+- **Publishing and consuming** — pack a package into the store, add it to a
+  project either as a store snapshot or as a live link to the source directory,
+  and remove it again.
+- **Syncing** — push a package's changes out to every project linked to it, or
+  pull a project's linked packages back into line with the store.
+- **Inspecting** — show what the current project has linked, what the store
+  holds, which projects consume a given package, and diagnose common problems.
+- **Maintaining** — collect unreferenced store entries, undo every change lnpm
+  made to a project, fail if a `package.json` still carries lnpm references
+  before you publish to npm, read or change lnpm's own settings, generate shell
+  completions, and update lnpm itself.
+
+The [command table in the README](README.md#commands) is the authoritative list,
+with the flags for each command. [ARCHITECTURE.md](ARCHITECTURE.md) covers the
+storage layout, the linking strategy and the data flow; its command and
+configuration sections are older than some of what shipped, so use the README
+for those.
+
+Where state lives:
+
+| What | Where |
+|------|-------|
+| Published package contents | `~/.lnpm/store/{name}/{hash}/` |
+| Packages, projects, links and files | `~/.lnpm/lnpm.db`, a [bbolt](https://github.com/etcd-io/bbolt) database |
+| Linked packages inside a project | `.lnpm/{name}/` — a copy of the store entry, or a link to the source directory; `node_modules/{name}` symlinks to it |
+| Which packages a project has linked | `lnpm.lock` in the project, YAML |
+| Configuration | `~/.lnpm/config.yaml`, YAML — see [Configuration](README.md#configuration) |
+
+The store root holds the first two rows — the store directory and the database.
+It is `~/.lnpm` by default; `store_path` in the config moves it, and the
+`LNPM_STORE` environment variable overrides both. Nothing else in the table
+follows it: `.lnpm/` and `lnpm.lock` belong to the consuming project, and the
+config file stays at `~/.lnpm/config.yaml` wherever the store goes (`LNPM_CONFIG`
+is what moves that one).
+
+## Planned work
+
+Planned work is not listed in this file. It lives in the issue tracker, so it
+stays current as issues are filed, triaged and closed:
+
+- **[Open issues](https://github.com/pedrosousa13/lnpm/issues)** — one issue per
+  planned change. Some are still untriaged rather than queued.
+- **[Milestones](https://github.com/pedrosousa13/lnpm/milestones)** — those
+  issues grouped by theme, each milestone showing its own open/closed progress.
+
+The repo's [label list](https://github.com/pedrosousa13/lnpm/labels) shows the
+categories and priorities issues are filed under, if you want to filter.
+
+## History
+
+Until [#202](https://github.com/pedrosousa13/lnpm/issues/202) this file was
+lnpm's implementation plan. It was written alongside the first code rather than
+before it: commit `aaf2d65` added `ROADMAP.md` together with the initial
+`cmd/lnpm`, `internal/cli`, `internal/db`, `internal/link`, `internal/pack`,
+`internal/store` and `pkg/lockfile`. What made it stale was the divergence that
+followed — it planned a storage engine lnpm never used, and of the ten Go
+dependencies it listed only four are in `go.mod` today, with all 135 of its
+checkboxes still unchecked. It is left in git history rather than reproduced
+here — `git show f053f57:ROADMAP.md` — because it records an intended design
+rather than the tool as built.


### PR DESCRIPTION
`ROADMAP.md` was lnpm's original implementation plan, and the README linked it as
the live "Planned features" page. It described a storage engine lnpm never used,
listed six Go dependencies that are not in `go.mod`, documented a
`config.toml`/`.lnpmrc` scheme that was never the config format — and carried 135
checkboxes, every one unchecked, including for commands that shipped long ago.
Anyone using it to gauge project status was being misled.

Per the direction pinned in triage, it becomes a short summary of what lnpm does
today plus a pointer to the issue tracker for planned work. No roadmap items are
invented; anything forward-looking is a link, not prose. A hand-maintained plan
is what drifted in the first place, so the replacement deliberately owns as few
facts as it can and points at the README command table and the live milestones
page for the rest.

The summary was generated from `lnpm --help`, `go.mod` and `internal/{db,store,config}`
rather than transcribed from the old file, so it could not inherit the drift being
removed. That mattered — it now includes `lnpm pull`, which shipped this morning.

## The review caught this doing the same thing in miniature

Fittingly for an issue about confident false claims, the first draft made three
of its own, each found by verification rather than reading:

- It said the old file was "written before any of the code existed". It was not —
  `aaf2d65` added `ROADMAP.md` in the same commit as the initial `cmd/lnpm`,
  `internal/cli`, `internal/db`, `internal/link`, `internal/pack`,
  `internal/store` and `pkg/lockfile`. What made it stale was the divergence
  afterwards, which is what the file now says.
- It said the old file listed "dependencies lnpm never took on", implying all of
  them. Four of the ten shipped and are in `go.mod` today.
- Its store-root sentence sat under the state table and implied every row moves
  with the store root. `~/.lnpm/config.yaml` never does — `internal/config`
  builds that path from the home directory and never consults the store root.

Also fixed: `lnpm config` was missing from the capability groups, the state table
omitted the project-side `.lnpm/` directory, and the file pointed readers at
`docs/agents/triage-labels.md`, which `AGENTS.md` scopes as agent-skill material
and whose first table is headed "Label in mattpocock/skills". That now points at
the repo's own label list.

The old document is left in git history rather than reproduced — `git show
f053f57:ROADMAP.md`. That ref is an ancestor of `main`, so it survives this
branch being deleted.

## Found while working, deliberately not fixed

`.planning/ROADMAP.md` is a second tracked roadmap — "lnpm Stability & Quality",
dated 2026-01-17, seven phases and 18 checkboxes, all unchecked, with a progress
table reading `0/N — Not started` throughout. It is stale the same way: its Phase
1 asks for golangci-lint v2 with staticcheck/gosec/errcheck/gocritic in CI, which
already exists and passes clean. It is internal planning material rather than
user-facing, so it is out of this issue's scope, but it probably wants its own.

Documentation only. No Go was touched.

Closes #202
