### PR TITLE
Chmod linked and cloned files so umask cannot strip mode bits

### DIFF
--- a/internal/fsutil/reflink_linux.go
+++ b/internal/fsutil/reflink_linux.go
@@ -46,6 +46,16 @@ func tryReflink(src, dst string) bool {
 	)
 
 	if errno == 0 {
+		// FICLONE clones data blocks only, never permissions, and the
+		// destination was created with a mode the umask masked. Chmod is not
+		// masked, so the clone ends up with the source's exact bits. If it
+		// fails, clean up so the caller falls back to a copy rather than
+		// keeping a clone with the wrong mode.
+		if err := dstFile.Chmod(srcInfo.Mode()); err != nil {
+			dstFile.Close()
+			_ = os.Remove(dst)
+			return false
+		}
 		if err := dstFile.Sync(); err != nil {
 			return false
 		}

--- a/internal/fsutil/reflink_linux_test.go
+++ b/internal/fsutil/reflink_linux_test.go
@@ -1,0 +1,57 @@
+//go:build linux
+
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// setUmask sets the process umask for the rest of the test and restores the
+// previous value afterwards. The umask is process-global, so a test using this
+// must not call t.Parallel() and must not run alongside one that does.
+func setUmask(t *testing.T, mask int) {
+	t.Helper()
+	old := syscall.Umask(mask)
+	t.Cleanup(func() { syscall.Umask(old) })
+}
+
+// TestReflink_PreservesModeUnderRestrictiveUmask pins the FICLONE path. The
+// destination file is created with os.OpenFile, whose mode argument the umask
+// masks, and FICLONE clones data blocks only — never permissions — so without
+// an explicit chmod a 0755 source is cloned to a 0700 destination under umask
+// 0077. The test asserts that tryReflink returned true, so the mode it then
+// checks belongs to a file the ioctl really cloned rather than one left behind
+// by a clone that failed.
+func TestReflink_PreservesModeUnderRestrictiveUmask(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "cli.js")
+	writeFile(t, src, "#!/usr/bin/env node\n")
+	// chmod is not subject to the umask, so the fixture really is 0755.
+	if err := os.Chmod(src, 0755); err != nil {
+		t.Fatalf("Failed to chmod source: %v", err)
+	}
+
+	probe := filepath.Join(dir, "probe.js")
+	if !tryReflink(src, probe) {
+		t.Skip("Skipping - the filesystem backing t.TempDir() does not support the FICLONE ioctl")
+	}
+
+	dst := filepath.Join(dir, "cloned-cli.js")
+
+	setUmask(t, 0077)
+
+	if !tryReflink(src, dst) {
+		t.Fatal("tryReflink failed even though the probe clone succeeded, so this run proves nothing about the clone path")
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("Failed to stat cloned file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0755 {
+		t.Errorf("Cloned file mode = %04o, want 0755 (FICLONE does not clone permissions, so the umask-masked mode persisted)", got)
+	}
+}

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -618,5 +618,13 @@ func copyFile(src, dst string) error {
 		}
 	}
 
+	// OpenFile's mode argument is masked by the process umask, so the copy would
+	// not carry the source's exact permission bits: a 0755 bin script would land
+	// at 0700 under umask 0077 and fail to execute from node_modules/.bin. Chmod
+	// is not masked, so set them explicitly.
+	if err := dstFile.Chmod(srcInfo.Mode()); err != nil {
+		return err
+	}
+
 	return dstFile.Sync()
 }

--- a/internal/link/link_umask_unix_test.go
+++ b/internal/link/link_umask_unix_test.go
@@ -1,0 +1,53 @@
+//go:build !windows
+
+package link
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// setUmask sets the process umask for the rest of the test and restores the
+// previous value afterwards. The umask is process-global, so a test using this
+// must not call t.Parallel() and must not run alongside one that does.
+func setUmask(t *testing.T, mask int) {
+	t.Helper()
+	old := syscall.Umask(mask)
+	t.Cleanup(func() { syscall.Umask(old) })
+}
+
+// TestCopyFile_PreservesModeUnderRestrictiveUmask pins the linker's copy path —
+// the non-reflink, non-hardlink way a file reaches a consumer's .lnpm/<pkg>. It
+// calls copyFile directly so no other materialisation path can stand in for it.
+// os.OpenFile's mode argument is masked by the umask, so without an explicit
+// chmod a 0755 store entry is copied forward as 0700 under umask 0077 and the
+// consumer's node_modules/.bin entry fails to execute.
+func TestCopyFile_PreservesModeUnderRestrictiveUmask(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "cli.js")
+	dst := filepath.Join(dir, "copied-cli.js")
+
+	if err := os.WriteFile(src, []byte("#!/usr/bin/env node\n"), 0644); err != nil {
+		t.Fatalf("Failed to write source: %v", err)
+	}
+	// chmod is not subject to the umask, so the fixture really is 0755.
+	if err := os.Chmod(src, 0755); err != nil {
+		t.Fatalf("Failed to chmod source: %v", err)
+	}
+
+	setUmask(t, 0077)
+
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile failed: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("Failed to stat copied file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0755 {
+		t.Errorf("Copied file mode = %04o, want 0755 (the umask masked the mode instead of the copy setting it)", got)
+	}
+}

--- a/internal/store/store_umask_unix_test.go
+++ b/internal/store/store_umask_unix_test.go
@@ -1,0 +1,115 @@
+//go:build !windows
+
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/fsutil"
+	"github.com/pedrosousa13/lnpm/internal/pack"
+)
+
+// setUmask sets the process umask for the rest of the test and restores the
+// previous value afterwards. The umask is process-global, so a test using this
+// must not call t.Parallel() and must not run alongside one that does.
+func setUmask(t *testing.T, mask int) {
+	t.Helper()
+	old := syscall.Umask(mask)
+	t.Cleanup(func() { syscall.Umask(old) })
+}
+
+// TestCopyFile_PreservesModeUnderRestrictiveUmask pins the store's copy path.
+// It calls copyFile directly, so the reflink path cannot stand in for it. The
+// mode argument to os.OpenFile is masked by the umask, so without an explicit
+// chmod a 0755 bin script lands at 0700 under umask 0077 while the content hash
+// and the database still record 0755.
+func TestCopyFile_PreservesModeUnderRestrictiveUmask(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "cli.js")
+	dst := filepath.Join(dir, "copied-cli.js")
+
+	if err := os.WriteFile(src, []byte("#!/usr/bin/env node\n"), 0644); err != nil {
+		t.Fatalf("Failed to write source: %v", err)
+	}
+	// chmod is not subject to the umask, so the fixture really is 0755.
+	if err := os.Chmod(src, 0755); err != nil {
+		t.Fatalf("Failed to chmod source: %v", err)
+	}
+
+	setUmask(t, 0077)
+
+	if err := copyFile(src, dst, 0755); err != nil {
+		t.Fatalf("copyFile failed: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("Failed to stat copied file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0755 {
+		t.Errorf("Copied file mode = %04o, want 0755 (the umask masked the mode instead of the copy setting it)", got)
+	}
+}
+
+// TestStore_PreservesModeUnderRestrictiveUmask is the end-to-end acceptance
+// check: a 0755 file stored under umask 0077 must be executable in the store,
+// because both the content hash and the database record 0755. Store tries a
+// reflink clone before falling back to a copy, so it logs which one ran — a
+// passing run only covers the path it actually took.
+func TestStore_PreservesModeUnderRestrictiveUmask(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("LNPM_STORE", filepath.Join(tmpDir, "store"))
+
+	s, err := New()
+	if err != nil {
+		t.Fatalf("Failed to create store: %v", err)
+	}
+
+	sourceDir := filepath.Join(tmpDir, "source")
+	if err := os.MkdirAll(filepath.Join(sourceDir, "bin"), 0755); err != nil {
+		t.Fatalf("Failed to create source dir: %v", err)
+	}
+	srcFile := filepath.Join(sourceDir, "bin", "cli.js")
+	content := []byte("#!/usr/bin/env node\n")
+	if err := os.WriteFile(srcFile, content, 0644); err != nil {
+		t.Fatalf("Failed to write source: %v", err)
+	}
+	if err := os.Chmod(srcFile, 0755); err != nil {
+		t.Fatalf("Failed to chmod source: %v", err)
+	}
+
+	// Record which path Store will take, so the test says what it covered.
+	probe := filepath.Join(tmpDir, "reflink-probe")
+	reflinkSupported := fsutil.Reflink(srcFile, probe) == nil
+	if reflinkSupported {
+		t.Log("filesystem supports reflink: this run covers the clone path, not copyFile")
+	} else {
+		t.Log("filesystem does not support reflink: this run covers the copyFile path")
+	}
+
+	files := []*pack.FileInfo{{
+		RelPath:     "bin/cli.js",
+		Path:        srcFile,
+		Size:        int64(len(content)),
+		Mode:        0755,
+		ContentHash: "hash-cli",
+	}}
+
+	setUmask(t, 0077)
+
+	destPath, err := s.Store("umask-pkg", "hash123", files, sourceDir)
+	if err != nil {
+		t.Fatalf("Failed to store package: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(destPath, "bin", "cli.js"))
+	if err != nil {
+		t.Fatalf("Failed to stat stored file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0755 {
+		t.Errorf("Stored file mode = %04o, want 0755 (the store disagrees with the mode it hashed and recorded)", got)
+	}
+}


### PR DESCRIPTION
Closes #139.

The `mode` argument to `os.OpenFile` is masked by the process umask, so under a hardened umask (`027`/`077`, common on CI images) a bin script published at `0755` lands on disk at `0750` or `0700`. The content hash and the database still record `0755`, so the store silently disagrees with its own metadata and `node_modules/.bin/<cli>` fails to execute for every consumer, with no error from lnpm. `(*os.File).Chmod` is not subject to the umask, so an explicit chmod after the write fixes it.

## What this actually changes

Two of the three sites the issue names:

- **`internal/link/link.go`**, `copyFile` — chmod to the source's mode after the copy, before `Sync`.
- **`internal/fsutil/reflink_linux.go`**, `tryReflink` — chmod after the `FICLONE` ioctl succeeds. `FICLONE` clones data blocks only, not permissions, so the umask-masked mode survives an otherwise successful clone. On chmod failure it closes and removes the destination and returns `false`, matching the function's existing failure shape, so the caller falls back to a plain copy that sets the mode correctly.

**The store's copy path needed no change** — it already chmods, landed in `624a3e3` (#213), after this issue was filed. The issue's line hints predate that. It gains the regression tests it never had.

## Coverage, stated plainly

Acceptance criteria 1 and 2 are covered by tests that run everywhere.

**Acceptance criterion 3 is not covered on any machine this project runs CI on.** The reflink test needs a CoW filesystem for `FICLONE`, and GitHub-hosted runners are ext4, so it skips there — a reviewer confirmed the mutant survives: deleting the `Chmod` still yields SKIP, not FAIL. The skip names the real reason and the test does assert `tryReflink` returned `true` before checking the mode, so a failed clone cannot make it pass where it does run. The production change was verified against real btrfs out of tree.

## Verification

Every new test was mutation-checked at its own site — the `Chmod` removed, the failure read to confirm it reports the umask-masked `0700` rather than an incidental error, then restored — and reproduced independently by a second reviewer.

Each test pins the site in its name: the two copy tests call the unexported `copyFile` directly so neither reflink nor hardlink can stand in for them, and the reflink test asserts the clone happened first. Fixtures are chmod'd to `0755` before the umask is set, since `os.WriteFile`'s own mode argument is umask-masked too.

Tests are build-tagged `!windows` because `syscall.Umask` does not exist there; per-GOOS inclusion was verified with `go list -f '{{.TestGoFiles}}'` rather than inferred from the tag.

`go test ./...` under both umask `022` and the ambient `002`, `go vet`, `golangci-lint` (0 issues), `gofmt`, and all three cross-compile gates are green.

## Found while verifying, not fixed here

`stripLifecycleScripts` writes the store's `package.json` with `os.WriteFile(tmpPath, output, 0644)` and renames it into place **after** `copyFile` has chmod'd, so for any package carrying a `prepare`/`prepublish` script it re-breaks the one file the fix just corrected — reproduced at `0600` against a recorded `0644` under umask `0077`. Outside this issue's acceptance criteria, which are specific to `0755`, and that function is already flagged for separate rework. Reported on the issue for triage.