### PR TITLE
Stream copies with io.Copy and unlink half-made reflink clones

### DIFF
--- a/internal/fsutil/reflink_linux.go
+++ b/internal/fsutil/reflink_linux.go
@@ -11,6 +11,20 @@ import (
 // FICLONE ioctl for copy-on-write cloning on Btrfs, XFS, OCFS2
 const FICLONE = 0x40049409
 
+// ficlone issues the FICLONE ioctl. The third ioctl arg is the SOURCE fd passed
+// BY VALUE (ioctl(dest_fd, FICLONE, src_fd)) — not a pointer to it.
+//
+// It is a variable so that tests can drive the steps that run after a
+// successful clone. A filesystem either supports cloning or it does not, so on
+// one that does not — ext4, the usual dev and CI host — the chmod and Sync
+// steps below are unreachable, and with them the cleanup of a clone that was
+// made and then had to be disowned. The ioctl-failure branch needs no stub: on
+// such a filesystem it is the branch that always runs.
+var ficlone = func(dstFd, srcFd uintptr) syscall.Errno {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, dstFd, uintptr(FICLONE), srcFd)
+	return errno
+}
+
 // tryReflink attempts to create a copy-on-write clone using the FICLONE ioctl.
 // Returns true if successful, false if not supported.
 func tryReflink(src, dst string) bool {
@@ -31,41 +45,38 @@ func tryReflink(src, dst string) bool {
 	if err != nil {
 		return false
 	}
-	defer dstFile.Close()
-
-	// Try FICLONE ioctl. The third ioctl arg is the SOURCE fd passed BY VALUE
-	// (ioctl(dest_fd, FICLONE, src_fd)) — not a pointer to it.
-	srcFd := srcFile.Fd()
-	dstFd := dstFile.Fd()
-
-	_, _, errno := syscall.Syscall(
-		syscall.SYS_IOCTL,
-		dstFd,
-		uintptr(FICLONE),
-		srcFd,
-	)
-
-	if errno == 0 {
-		// FICLONE clones data blocks only, never permissions, and the
-		// destination was created with a mode the umask masked. Chmod is not
-		// masked, so the clone ends up with the source's exact bits. If it
-		// fails, clean up so the caller falls back to a copy rather than
-		// keeping a clone with the wrong mode.
-		if err := dstFile.Chmod(srcInfo.Mode()); err != nil {
-			dstFile.Close()
+	// From here on the destination exists on disk, so every failure below owns
+	// it. One deferred cleanup serves them all: it closes dstFile exactly once,
+	// on every return path, and unlinks the destination unless the clone ran to
+	// completion. Leaving a half-made destination behind would break the
+	// caller's fallback, which reacts to a false return by trying os.Link at
+	// the same path (EEXIST) or a copy (silently overwriting the remains).
+	success := false
+	defer func() {
+		_ = dstFile.Close()
+		if !success {
 			_ = os.Remove(dst)
-			return false
 		}
-		if err := dstFile.Sync(); err != nil {
-			return false
-		}
-		return true
+	}()
+
+	if errno := ficlone(dstFile.Fd(), srcFile.Fd()); errno != 0 {
+		return false
 	}
 
-	// Clean up on failure
-	dstFile.Close()
-	_ = os.Remove(dst)
-	return false
+	// FICLONE clones data blocks only, never permissions, and the destination
+	// was created with a mode the umask masked. Chmod is not masked, so the
+	// clone ends up with the source's exact bits. If it fails, the cleanup
+	// makes the caller fall back to a copy rather than keeping a clone with the
+	// wrong mode.
+	if err := dstFile.Chmod(srcInfo.Mode()); err != nil {
+		return false
+	}
+	if err := dstFile.Sync(); err != nil {
+		return false
+	}
+
+	success = true
+	return true
 }
 
 // Reflink creates a copy-on-write clone of src at dst, returning an error if

--- a/internal/fsutil/reflink_linux_test.go
+++ b/internal/fsutil/reflink_linux_test.go
@@ -3,10 +3,13 @@
 package fsutil
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 // setUmask sets the process umask for the rest of the test and restores the
@@ -53,5 +56,138 @@ func TestReflink_PreservesModeUnderRestrictiveUmask(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0755 {
 		t.Errorf("Cloned file mode = %04o, want 0755 (FICLONE does not clone permissions, so the umask-masked mode persisted)", got)
+	}
+}
+
+// assertNoStrayDestination asserts that a failed tryReflink left nothing at
+// path. A leftover destination is not harmless: the caller reacts to the
+// failure by falling back to os.Link, which then fails with EEXIST against the
+// stray file, or to a copy, which silently overwrites it.
+func assertNoStrayDestination(t *testing.T, path, failure string) {
+	t.Helper()
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("After a %s tryReflink left a destination behind at %s (stat error = %v, want os.ErrNotExist); the caller's os.Link fallback would fail with EEXIST", failure, path, err)
+	}
+}
+
+// stubFiclone replaces the FICLONE syscall for the rest of the test and
+// restores the previous value afterwards. The clone either works on the
+// filesystem under the test or it does not, so on one without copy-on-write
+// support — ext4, the usual dev and CI host — the chmod and Sync steps after
+// the ioctl are not otherwise reachable at all.
+//
+// ficlone is package-global, and production reads it from worker goroutines, so
+// a test using this must not call t.Parallel() and must not run alongside one
+// that does.
+func stubFiclone(t *testing.T, fn func(dstFd, srcFd uintptr) syscall.Errno) {
+	t.Helper()
+	old := ficlone
+	ficlone = fn
+	t.Cleanup(func() { ficlone = old })
+}
+
+// redirectFD points an already-open descriptor at a different file, so that the
+// next operation on the *os.File holding it hits that file instead. It is how
+// the tests below make a specific post-clone step fail while leaving the steps
+// before it working.
+func redirectFD(t *testing.T, fd uintptr, path string) {
+	t.Helper()
+	replacement, err := syscall.Open(path, syscall.O_RDWR|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		t.Fatalf("Failed to open %s: %v", path, err)
+	}
+	defer func() { _ = syscall.Close(replacement) }()
+	// Dup3 rather than Dup2: this file builds on every linux architecture, and
+	// syscall.Dup2 does not exist on arm64, which the release builds target.
+	if err := unix.Dup3(replacement, int(fd), 0); err != nil {
+		t.Fatalf("Failed to point fd %d at %s: %v", fd, path, err)
+	}
+}
+
+// TestTryReflink_RemovesDestinationOnSyncFailure covers the failure this issue
+// is really about: the ioctl clones the data, so a destination now exists on
+// disk, and then the flush fails. tryReflink reports failure, so it owns the
+// file it created and must unlink it.
+//
+// Reaching that branch needs a clone that succeeds followed by a Sync that
+// fails, and no filesystem does both. The stub supplies the successful clone;
+// pointing the destination descriptor at a FIFO supplies the failing flush,
+// because fsync on a FIFO always returns EINVAL. A FIFO is also the one
+// substitute that leaves the preceding fchmod working, so this test fails on
+// the Sync step rather than short-circuiting at the chmod above it.
+func TestTryReflink_RemovesDestinationOnSyncFailure(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	writeFile(t, src, "payload")
+	dst := filepath.Join(dir, "dst.txt")
+
+	fifo := filepath.Join(dir, "fifo")
+	if err := syscall.Mkfifo(fifo, 0644); err != nil {
+		t.Fatalf("Failed to create FIFO: %v", err)
+	}
+
+	stubFiclone(t, func(dstFd, srcFd uintptr) syscall.Errno {
+		redirectFD(t, dstFd, fifo)
+		return 0
+	})
+
+	if tryReflink(src, dst) {
+		t.Fatal("tryReflink reported success even though the post-clone Sync failed")
+	}
+	assertNoStrayDestination(t, dst, "post-clone Sync failure")
+}
+
+// TestTryReflink_RemovesDestinationOnChmodFailure covers the other post-clone
+// step. FICLONE copies data blocks and never permissions, so tryReflink chmods
+// the clone to the source's exact mode; if that fails the clone is left with
+// the wrong bits and must be removed rather than handed to the caller.
+//
+// /dev/null is owned by root, so fchmod on it fails with EPERM for any other
+// user — which makes it a destination whose chmod cannot succeed.
+func TestTryReflink_RemovesDestinationOnChmodFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("Skipping - running as root, which can chmod /dev/null, so this test cannot force the chmod to fail")
+	}
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	writeFile(t, src, "payload")
+	dst := filepath.Join(dir, "dst.txt")
+
+	stubFiclone(t, func(dstFd, srcFd uintptr) syscall.Errno {
+		redirectFD(t, dstFd, os.DevNull)
+		return 0
+	})
+
+	if tryReflink(src, dst) {
+		t.Fatal("tryReflink reported success even though the post-clone Chmod failed")
+	}
+	assertNoStrayDestination(t, dst, "post-clone Chmod failure")
+}
+
+// TestTryReflink_RemovesDestinationOnIoctlFailure covers the failure a
+// filesystem without copy-on-write support produces on its own, with the real
+// ioctl and no stubbing. tryReflink creates the destination before it knows
+// whether the clone is possible, so the ioctl failing is the ordinary case
+// where it has a file to clean up. The os.Link at the end is the caller's
+// actual fallback, and it is what a leftover destination would break.
+func TestTryReflink_RemovesDestinationOnIoctlFailure(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	writeFile(t, src, "payload")
+
+	probe := filepath.Join(dir, "probe.txt")
+	if tryReflink(src, probe) {
+		t.Skip("Skipping - the filesystem backing t.TempDir() supports FICLONE, so the ioctl-failure path is unreachable here")
+	}
+
+	dst := filepath.Join(dir, "dst.txt")
+	if tryReflink(src, dst) {
+		t.Fatal("tryReflink reported success even though the probe clone failed")
+	}
+	assertNoStrayDestination(t, dst, "FICLONE ioctl failure")
+
+	if err := os.Link(src, dst); err != nil {
+		t.Errorf("The caller's os.Link fallback failed after tryReflink: %v", err)
 	}
 }

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -2,6 +2,7 @@ package link
 
 import (
 	"fmt"
+	"io"
 	"math/rand/v2"
 	"os"
 	"path/filepath"
@@ -602,20 +603,8 @@ func copyFile(src, dst string) error {
 	}
 	defer func() { _ = dstFile.Close() }()
 
-	buf := make([]byte, 1024*1024) // 1MB buffer
-	for {
-		n, err := srcFile.Read(buf)
-		if n > 0 {
-			if _, writeErr := dstFile.Write(buf[:n]); writeErr != nil {
-				return writeErr
-			}
-		}
-		if err != nil {
-			if err.Error() == "EOF" {
-				break
-			}
-			return err
-		}
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return err
 	}
 
 	// OpenFile's mode argument is masked by the process umask, so the copy would

--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -1,6 +1,7 @@
 package link
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -296,6 +297,54 @@ func TestCopyFile(t *testing.T) {
 	}
 	if string(data) != content {
 		t.Errorf("copied content = %q, want %q", string(data), content)
+	}
+}
+
+// TestCopyFile_LargeFile pins that a multi-megabyte source round-trips byte for
+// byte. The transfer is internally chunked whatever io.Copy picks as its buffer
+// size, and the source here is deliberately not a whole number of megabytes, so
+// a rewrite that truncated the tail, reordered chunks or repeated one would be
+// caught here. A source small enough to move in a single chunk — which is every
+// other copyFile test — shows none of that.
+func TestCopyFile_LargeFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srcPath := filepath.Join(tmpDir, "large.bin")
+	dstPath := filepath.Join(tmpDir, "large-copy.bin")
+
+	// Deliberately not a whole number of megabytes, so the final chunk of the
+	// transfer is a partial one whatever buffer size the implementation picks.
+	content := make([]byte, 5*1024*1024+7919)
+	// A linear congruential generator: deterministic, dependency-free, and with
+	// a period long enough that no two chunks of the file look alike, so a
+	// transposed or duplicated chunk cannot compare equal by accident.
+	state := uint32(1)
+	for i := range content {
+		state = state*1664525 + 1013904223
+		content[i] = byte(state >> 24)
+	}
+
+	if err := os.WriteFile(srcPath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyFile(srcPath, dstPath); err != nil {
+		t.Fatalf("copyFile() error: %v", err)
+	}
+
+	got, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatalf("failed to read copied file: %v", err)
+	}
+	if len(got) != len(content) {
+		t.Fatalf("copied file is %d bytes, want %d", len(got), len(content))
+	}
+	if !bytes.Equal(got, content) {
+		for i := range got {
+			if got[i] != content[i] {
+				t.Fatalf("copied file differs from source at byte %d: got %#02x, want %#02x", i, got[i], content[i])
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #140.

Two independent robustness gaps in the copy paths.

## (a) `internal/link/link.go`'s `copyFile`

Replaced the hand-rolled read/write loop and its `err.Error() == "EOF"` check with `io.Copy`, matching `internal/store/store.go`'s `copyFile`. The string comparison only worked because `io.EOF` happens to format as the literal `"EOF"`; a wrapped EOF would have been returned as a real I/O failure.

**No behavior changes on the current code path**, and the PR does not pretend otherwise: `os.File.Read` returns a bare `io.EOF`, so the old loop was functionally correct for every reader it actually saw. This is a maintainability fix. `TestCopyFile_LargeFile` accordingly passes with the change reverted — verified, and stated here rather than left for a reviewer to discover. It has teeth against mutations of the *new* code (swapped `io.Copy` arguments, a truncating `io.CopyN`), which is the failure a rewrite would actually introduce, and which the pre-existing 21-byte `TestCopyFile` cannot see.

## (b) `internal/fsutil/reflink_linux.go`'s `tryReflink`

Restructured to exactly one cleanup path — a `success` flag and a single `defer` that closes `dstFile` once and removes `dst` unless the function succeeded. `success = true` is set only after `Sync()` returns nil.

This subsumes three previously separate behaviors: the ioctl-failure branch's explicit close-then-remove, the chmod-failure path added by #139 hours earlier, and the `Sync()` failure that previously returned `false` while **leaving a half-cloned `dst` on disk**. That stray file is what the caller then hit with `os.Link` (`EEXIST`) or silently overwrote. `dstFile` is now closed exactly once on all seven return paths — the three early returns precede its creation.

## Making the headline criterion testable

*"If `FICLONE` succeeds but `Sync()` fails, `dst` does not exist"* is the only criterion whose behavior this change alters, and it is unreachable on ext4 — every dev and CI host here — because the ioctl fails first.

Rather than skip it, the ioctl call became a stubbable package-level `ficlone` variable. This is the repo's established pattern, not a new one: `createDirSymlinkFn` (`internal/link/link.go`) is stubbed with the identical `t.Cleanup` restore, as are `githubAPIBaseURL`, `releaseBaseURL` and `openTimeout`. The generated ioctl arguments are byte-identical to before, so runtime behavior is unchanged.

Tests stub it to report a successful clone and redirect the destination descriptor at a **FIFO**, where `fchmod` succeeds but `fsync` returns `EINVAL` — the only substitute found that fails at `Sync` without short-circuiting at the chmod above it. Both properties were probed empirically before being relied on. The ioctl-failure path needs no stub and runs for real.

## Verification

Mutation-checked three ways, each reproduced independently by a reviewer:

- pre-#140 two-cleanup body → the Sync test fails, chmod and ioctl pass (the old code already cleaned those two up)
- defer closes but never unlinks → all three fail, ioctl additionally with `the caller's os.Link fallback failed: file exists`
- `success = true` moved above `Sync` → the Sync test fails, the other two pass

`go test ./...`, `go vet`, `golangci-lint` (0 issues), `gofmt`, and four cross-compile gates are green. **`linux/arm64` was added to the gate set for this PR** — review caught that the test file used `syscall.Dup2`, which is amd64-only, and goreleaser ships `linux/arm64`. It now uses `unix.Dup3`; `golang.org/x/sys` was already a direct dependency and is already imported elsewhere in this package, so `go.mod`/`go.sum` are unchanged.

#139's chmods in both `copyFile` and `tryReflink` survive in position, and its regression tests still pass.