### PR TITLE
Fail doctor when it finds issues and print its markers through the icon helpers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -479,6 +479,17 @@ lnpm doctor
 # ⚠ Found 1 warning(s)
 ```
 
+Doctor separates issues from warnings, and so does its exit code: it exits
+non-zero once it has reported an issue, and zero otherwise. Warnings alone —
+the run above among them — still exit zero, because they describe cleanup worth
+doing rather than something broken. That makes `lnpm doctor && deploy.sh` safe
+to script. The findings are printed either way; the exit code only says whether
+any of them was an issue.
+
+The markers are decorative. On a terminal doctor prints `✓`/`✗`/`⚠` as shown
+above; when its output is piped, or `NO_COLOR` is set, it prints `OK`/`x`/`!`
+instead, like the rest of the CLI.
+
 ---
 
 ## Configuration

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -23,28 +23,28 @@ func RunDoctor() error {
 	storeUsable := false
 	storePath, err := config.GetStorePath()
 	if err != nil {
-		fmt.Println("✗ ERROR")
+		fmt.Printf("%s ERROR\n", iconFail())
 		fmt.Printf("  Failed to resolve store path: %v\n", err)
 		issues++
 	} else if info, err := os.Stat(storePath); err != nil {
-		fmt.Println("✗ NOT FOUND")
+		fmt.Printf("%s NOT FOUND\n", iconFail())
 		fmt.Printf("  Store directory does not exist: %s\n", storePath)
 		fmt.Println("  Fix: Run 'lnpm publish' to create it")
 		issues++
 	} else if !info.IsDir() {
-		fmt.Println("✗ ERROR")
+		fmt.Printf("%s ERROR\n", iconFail())
 		fmt.Printf("  %s exists but is not a directory\n", storePath)
 		issues++
 	} else {
 		// Check writable
 		testFile := filepath.Join(storePath, ".write-test")
 		if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
-			fmt.Println("✗ NOT WRITABLE")
+			fmt.Printf("%s NOT WRITABLE\n", iconFail())
 			fmt.Printf("  Cannot write to store directory: %v\n", err)
 			issues++
 		} else {
 			_ = os.Remove(testFile)
-			fmt.Println("✓ OK")
+			fmt.Printf("%s OK\n", iconOK())
 			storeUsable = true
 		}
 	}
@@ -53,11 +53,11 @@ func RunDoctor() error {
 	fmt.Print("Checking database... ")
 	database, err := db.GetDB()
 	if err != nil {
-		fmt.Println("✗ ERROR")
+		fmt.Printf("%s ERROR\n", iconFail())
 		fmt.Printf("  Failed to open database: %v\n", err)
 		issues++
 	} else {
-		fmt.Println("✓ OK")
+		fmt.Printf("%s OK\n", iconOK())
 
 		// Check 3: Orphaned packages (packages with no links)
 		fmt.Print("Checking for orphaned packages... ")
@@ -70,11 +70,11 @@ func RunDoctor() error {
 			}
 		}
 		if orphanedCount > 0 {
-			fmt.Printf("⚠ %d orphaned package(s)\n", orphanedCount)
+			fmt.Printf("%s %d orphaned package(s)\n", iconWarn(), orphanedCount)
 			fmt.Println("  Fix: Run 'lnpm gc' to remove unused packages")
 			warnings++
 		} else {
-			fmt.Println("✓ OK")
+			fmt.Printf("%s OK\n", iconOK())
 		}
 
 		// Check 4: Orphaned links (links to non-existent projects)
@@ -95,11 +95,11 @@ func RunDoctor() error {
 			}
 		}
 		if orphanedLinks > 0 {
-			fmt.Printf("⚠ %d orphaned link(s)\n", orphanedLinks)
+			fmt.Printf("%s %d orphaned link(s)\n", iconWarn(), orphanedLinks)
 			fmt.Println("  Fix: Run 'lnpm gc --fix-links' to clean up")
 			warnings++
 		} else {
-			fmt.Println("✓ OK")
+			fmt.Printf("%s OK\n", iconOK())
 		}
 
 		// Check 5: Verify store files exist
@@ -114,11 +114,11 @@ func RunDoctor() error {
 			}
 		}
 		if missingFiles > 0 {
-			fmt.Printf("✗ %d package(s) with missing files\n", missingFiles)
+			fmt.Printf("%s %d package(s) with missing files\n", iconFail(), missingFiles)
 			fmt.Println("  Fix: Re-publish affected packages")
 			issues++
 		} else {
-			fmt.Println("✓ OK")
+			fmt.Printf("%s OK\n", iconOK())
 		}
 	}
 
@@ -132,30 +132,37 @@ func RunDoctor() error {
 		fmt.Print("Checking store completeness markers... ")
 		done, err := store.BackfillDone()
 		if err != nil {
-			fmt.Println("✗ ERROR")
+			fmt.Printf("%s ERROR\n", iconFail())
 			fmt.Printf("  Failed to read the backfill status: %v\n", err)
 			issues++
 		} else if !done {
-			fmt.Println("⚠ PENDING")
+			fmt.Printf("%s PENDING\n", iconWarn())
 			fmt.Println("  Store entries have not been backfilled with completeness markers yet")
 			fmt.Println("  Fix: Run 'lnpm gc --dry-run' (or any command that opens the store)")
 			warnings++
 		} else {
-			fmt.Println("✓ OK")
+			fmt.Printf("%s OK\n", iconOK())
 		}
 	}
 
 	// Summary
 	fmt.Println()
 	if issues == 0 && warnings == 0 {
-		fmt.Println("✓ All checks passed!")
+		fmt.Printf("%s All checks passed!\n", iconOK())
 	} else {
 		if issues > 0 {
-			fmt.Printf("✗ Found %d issue(s)\n", issues)
+			fmt.Printf("%s Found %d issue(s)\n", iconFail(), issues)
 		}
 		if warnings > 0 {
-			fmt.Printf("⚠ Found %d warning(s)\n", warnings)
+			fmt.Printf("%s Found %d warning(s)\n", iconWarn(), warnings)
 		}
+	}
+
+	// The findings are already printed above; the error exists so that a script
+	// running `lnpm doctor && ...` sees a non-zero exit. Warnings do not fail
+	// the command: they describe cleanup worth doing, not a broken install.
+	if issues > 0 {
+		return fmt.Errorf("doctor found %d issue(s)", issues)
 	}
 
 	return nil

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -19,7 +20,7 @@ import (
 func TestRunDoctorChecksConfiguredStorePath(t *testing.T) {
 	want := filepath.Join(newDoctorStoreConfig(t), "mystore")
 
-	out := captureDoctorStdout(t)
+	out := captureFailingDoctorStdout(t)
 
 	if !strings.Contains(out, "Store directory does not exist: "+want) {
 		t.Errorf("RunDoctor did not check the configured store %q, output was:\n%s", want, out)
@@ -42,10 +43,13 @@ func TestRunDoctorReportsConfiguredStoreHealthy(t *testing.T) {
 		t.Fatalf("Failed to create configured store %q: %v", want, err)
 	}
 
-	out := captureDoctorStdout(t)
+	out, err := runDoctor(t)
 
 	if strings.Contains(out, "NOT FOUND") {
 		t.Errorf("RunDoctor reported the existing configured store %q as missing, output was:\n%s", want, out)
+	}
+	if err != nil {
+		t.Errorf("RunDoctor() = %v for a store that is present, want nil", err)
 	}
 }
 
@@ -57,7 +61,7 @@ func TestRunDoctorPrefersEnvStoreOverConfig(t *testing.T) {
 	fromEnv := filepath.Join(dir, "from-env")
 	t.Setenv("LNPM_STORE", fromEnv)
 
-	out := captureDoctorStdout(t)
+	out := captureFailingDoctorStdout(t)
 
 	if !strings.Contains(out, "Store directory does not exist: "+fromEnv) {
 		t.Errorf("RunDoctor did not check the LNPM_STORE path %q, output was:\n%s", fromEnv, out)
@@ -112,7 +116,10 @@ func TestRunDoctorReportsPendingBackfill(t *testing.T) {
 		t.Fatalf("create store: %v", err)
 	}
 
-	out := captureDoctorStdout(t)
+	out, err := runDoctor(t)
+	if err != nil {
+		t.Errorf("RunDoctor() = %v for a pending backfill, want nil: a backfill still to run is a warning", err)
+	}
 
 	if !strings.Contains(out, "completeness marker") {
 		t.Errorf("RunDoctor did not report the pending completeness-marker backfill, output was:\n%s", out)
@@ -134,7 +141,7 @@ func TestRunDoctorReportsPendingBackfill(t *testing.T) {
 func TestRunDoctorSkipsBackfillCheckWithoutStore(t *testing.T) {
 	newDoctorStoreConfig(t) // the configured store is deliberately not created
 
-	out := captureDoctorStdout(t)
+	out := captureFailingDoctorStdout(t)
 
 	if strings.Contains(out, "completeness marker") {
 		t.Errorf("RunDoctor reported on the backfill for a store that does not exist, output was:\n%s", out)
@@ -152,28 +159,291 @@ func TestRunDoctorReportsCompletedBackfill(t *testing.T) {
 		t.Fatalf("open store: %v", err)
 	}
 
-	out := captureDoctorStdout(t)
+	out, err := runDoctor(t)
 
 	if strings.Contains(out, "not been backfilled") {
 		t.Errorf("RunDoctor reported a backfilled store as pending, output was:\n%s", out)
 	}
+	if err != nil {
+		t.Errorf("RunDoctor() = %v for a backfilled store, want nil", err)
+	}
 }
 
-// captureDoctorStdout runs RunDoctor and returns what it printed. RunDoctor
-// reports every check on stdout rather than through its return value, so the
-// findings are only readable this way.
+// TestRunDoctorFailsWhenIssuesFound pins the exit code a script sees:
+// `lnpm doctor && deploy.sh` must not run the deploy when doctor found
+// problems. The configured store is deliberately absent, so Check 1 reports an
+// issue and the returned error is what carries that out to cobra.
+func TestRunDoctorFailsWhenIssuesFound(t *testing.T) {
+	newDoctorStoreConfig(t) // the configured store is deliberately not created
+
+	out, err := runDoctor(t)
+
+	if !strings.Contains(out, "issue(s)") {
+		t.Fatalf("this test needs a run that reports issues, output was:\n%s", out)
+	}
+	if err == nil {
+		t.Errorf("RunDoctor() = nil after reporting issues, want an error; output was:\n%s", out)
+	}
+}
+
+// TestRunDoctorSucceedsWhenAllChecksPass is the other half of the contract: a
+// healthy store must exit zero. The output assertion keeps the nil honest — it
+// has to come from a run that actually passed every check, not from one that
+// failed to reach the summary.
+func TestRunDoctorSucceedsWhenAllChecksPass(t *testing.T) {
+	dir := newDoctorStoreConfig(t)
+	if err := os.MkdirAll(filepath.Join(dir, "mystore", "store"), 0755); err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	if _, err := store.New(); err != nil { // marks the backfill done
+		t.Fatalf("open store: %v", err)
+	}
+
+	out, err := runDoctor(t)
+
+	if !strings.Contains(out, "All checks passed") {
+		t.Fatalf("this test needs a run where every check passes, output was:\n%s", out)
+	}
+	if err != nil {
+		t.Errorf("RunDoctor() = %v on a healthy store, want nil", err)
+	}
+}
+
+// TestRunDoctorSucceedsWithWarningsOnly pins the distinction the summary
+// already draws: warnings describe things worth cleaning up, not things that
+// are broken, so they must not fail the command. The store here exists but has
+// no completeness markers yet, which doctor reports as a warning.
+func TestRunDoctorSucceedsWithWarningsOnly(t *testing.T) {
+	dir := newDoctorStoreConfig(t)
+	if err := os.MkdirAll(filepath.Join(dir, "mystore", "store"), 0755); err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+
+	out, err := runDoctor(t)
+
+	if !strings.Contains(out, "warning(s)") || strings.Contains(out, "issue(s)") {
+		t.Fatalf("this test needs a run reporting warnings and no issues, output was:\n%s", out)
+	}
+	if err != nil {
+		t.Errorf("RunDoctor() = %v for warnings alone, want nil", err)
+	}
+}
+
+// TestRunDoctorMarkersComeFromTheIconHelpers sweeps doctor's report for the
+// decorative markers, one scenario per group of call sites, so a check printing
+// "✓"/"✗"/"⚠" as a string literal instead of calling the helpers is caught
+// wherever it is.
+//
+// That, and only that, is what this proves. Capturing stdout replaces it with a
+// pipe, and the helpers fall back to ASCII whenever stdout is not a terminal,
+// so a report free of glyphs here says nothing about NO_COLOR: the pipe alone
+// would have produced it. NO_COLOR is set anyway, so the sweep does not depend
+// on how the capture is implemented. What NO_COLOR actually does, and what an
+// interactive terminal still shows, are covered in output_tty_linux_test.go,
+// where stdout is a real terminal.
+func TestRunDoctorMarkersComeFromTheIconHelpers(t *testing.T) {
+	cases := []struct {
+		name string
+		// setup prepares the store inside dir so the run reaches a particular
+		// group of call sites, and returns a line the report must contain, to
+		// keep the scenario honest about which branch it exercised.
+		setup func(t *testing.T, dir string) string
+		// requires, when set, skips the scenario where the platform cannot
+		// produce the failure its branch is reached through.
+		requires func(t *testing.T)
+	}{
+		{
+			name: "store missing",
+			setup: func(t *testing.T, dir string) string {
+				return "NOT FOUND" // and the "x Found N issue(s)" summary
+			},
+		},
+		{
+			name: "store path is not a directory",
+			setup: func(t *testing.T, dir string) string {
+				if err := os.WriteFile(filepath.Join(dir, "mystore"), []byte("not a dir"), 0644); err != nil {
+					t.Fatalf("write store file: %v", err)
+				}
+				return "is not a directory" // and the database check's ERROR line
+			},
+		},
+		{
+			name:     "store not writable",
+			requires: requirePermissionEnforcement,
+			setup: func(t *testing.T, dir string) string {
+				storePath := filepath.Join(dir, "mystore")
+				if err := os.MkdirAll(storePath, 0500); err != nil {
+					t.Fatalf("create read-only store: %v", err)
+				}
+				t.Cleanup(func() { _ = os.Chmod(storePath, 0700) }) // so TempDir can clean up
+				return "NOT WRITABLE"
+			},
+		},
+		{
+			name: "everything healthy",
+			setup: func(t *testing.T, dir string) string {
+				newDoctorStore(t, dir)
+				if _, err := store.New(); err != nil { // marks the backfill done
+					t.Fatalf("open store: %v", err)
+				}
+				return "All checks passed"
+			},
+		},
+		{
+			name: "backfill pending",
+			setup: func(t *testing.T, dir string) string {
+				newDoctorStore(t, dir)
+				return "PENDING" // and the "! Found N warning(s)" summary
+			},
+		},
+		{
+			name:     "backfill status unreadable",
+			requires: requireNotADirectoryError,
+			setup: func(t *testing.T, dir string) string {
+				// A file where the package store should be: the store is a
+				// usable directory, so the check runs, but reading the marker
+				// inside it fails.
+				if err := os.MkdirAll(filepath.Join(dir, "mystore"), 0755); err != nil {
+					t.Fatalf("create store: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "mystore", "store"), []byte("not a dir"), 0644); err != nil {
+					t.Fatalf("write store file: %v", err)
+				}
+				return "Failed to read the backfill status"
+			},
+		},
+		{
+			name: "orphaned package with missing store files",
+			setup: func(t *testing.T, dir string) string {
+				newDoctorStore(t, dir)
+				database := openDoctorDB(t)
+				if err := database.InsertPackage(&db.Package{
+					Name:      "orphan",
+					StorePath: filepath.Join(dir, "gone"),
+				}); err != nil {
+					t.Fatalf("insert package: %v", err)
+				}
+				return "orphaned package(s)" // and the missing-files line
+			},
+		},
+		{
+			name: "orphaned link",
+			setup: func(t *testing.T, dir string) string {
+				newDoctorStore(t, dir)
+				database := openDoctorDB(t)
+				pkg := &db.Package{Name: "linked"} // no StorePath: nothing to miss
+				if err := database.InsertPackage(pkg); err != nil {
+					t.Fatalf("insert package: %v", err)
+				}
+				proj := &db.Project{Path: filepath.Join(dir, "gone-project"), Name: "gone"}
+				if err := database.InsertProject(proj); err != nil {
+					t.Fatalf("insert project: %v", err)
+				}
+				if err := database.InsertLink(&db.Link{PackageID: pkg.ID, ProjectID: proj.ID}); err != nil {
+					t.Fatalf("insert link: %v", err)
+				}
+				return "orphaned link(s)"
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.requires != nil {
+				tc.requires(t)
+			}
+
+			t.Setenv("NO_COLOR", "1")
+			dir := newDoctorStoreConfig(t)
+			want := tc.setup(t, dir)
+
+			out, _ := runDoctor(t)
+
+			if !strings.Contains(out, want) {
+				t.Fatalf("this scenario needs a report containing %q, output was:\n%s", want, out)
+			}
+			assertNoRawGlyphs(t, out)
+		})
+	}
+}
+
+// requireNotADirectoryError skips tests that need a path under a plain file to
+// be reported as an error. Unix answers ENOTDIR there, which is what doctor
+// surfaces; Windows answers "path not found", which is indistinguishable from
+// an absent file and doctor reads as "nothing to report yet".
+func requireNotADirectoryError(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows reports a path under a file as not found, not as a not-a-directory error")
+	}
+}
+
+// newDoctorStore creates the configured store directory, without the
+// completeness marker that store.New writes.
+func newDoctorStore(t *testing.T, dir string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Join(dir, "mystore", "store"), 0755); err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+}
+
+// openDoctorDB opens the database the following RunDoctor call will read, so a
+// scenario can plant the packages, projects and links it needs doctor to find.
+func openDoctorDB(t *testing.T) *db.DB {
+	t.Helper()
+
+	db.ResetForTesting()
+	database, err := db.GetDB()
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	return database
+}
+
+// assertNoRawGlyphs fails when out contains any of the decorative markers,
+// which must have been rendered as ASCII.
+func assertNoRawGlyphs(t *testing.T, out string) {
+	t.Helper()
+
+	for _, glyph := range decorativeGlyphs {
+		if strings.ContainsRune(out, glyph) {
+			t.Errorf("output contains the raw glyph %q, want its ASCII fallback; output was:\n%s", string(glyph), out)
+		}
+	}
+}
+
+// decorativeGlyphs are the markers the icon helpers render on a terminal and
+// replace with ASCII everywhere else.
+const decorativeGlyphs = "✓✗⚠💡"
+
+// captureFailingDoctorStdout runs RunDoctor against a store doctor is expected
+// to fault, and returns what it printed. RunDoctor reports each check on stdout
+// rather than through its return value, so the findings are only readable this
+// way; the failure itself is asserted here so no caller has to restate it.
+func captureFailingDoctorStdout(t *testing.T) string {
+	t.Helper()
+
+	out, err := runDoctor(t)
+	if err == nil {
+		t.Errorf("RunDoctor() = nil for a store it reported problems with, want an error; output was:\n%s", out)
+	}
+	return out
+}
+
+// runDoctor runs RunDoctor with stdout captured and returns both what it
+// printed and what it returned.
 //
 // RunDoctor opens the database, which is cached for the process and would keep
 // a file handle inside the test's temp dir, so it is released on the way out.
-func captureDoctorStdout(t *testing.T) string {
+func runDoctor(t *testing.T) (string, error) {
 	t.Helper()
 
 	db.ResetForTesting()
 	t.Cleanup(db.ResetForTesting)
 
-	return captureStdout(t, func() {
-		if err := RunDoctor(); err != nil {
-			t.Errorf("RunDoctor() error = %v", err)
-		}
-	})
+	var err error
+	out := captureStdout(t, func() { err = RunDoctor() })
+	return out, err
 }

--- a/internal/cli/output_tty_linux_test.go
+++ b/internal/cli/output_tty_linux_test.go
@@ -1,0 +1,258 @@
+//go:build linux
+
+// The tests here put stdout on a real terminal, which is the only way to show
+// that NO_COLOR is what turns the markers into ASCII: every other capture in
+// the suite uses a pipe, and the helpers already fall back to ASCII for any
+// stdout that is not a terminal.
+//
+// They are linux-only because they name the terminal with the TIOCGPTN ioctl,
+// which darwin spells differently and windows has no equivalent for. Making
+// them portable would mean taking on a pty dependency. So on those platforms
+// nothing shows directly that NO_COLOR is honored or that a terminal still
+// gets the glyphs: only the pipe-based sweeps run there, and all they
+// establish is that the markers come from the icon helpers.
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/db"
+	"github.com/pedrosousa13/lnpm/internal/store"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
+	"golang.org/x/sys/unix"
+)
+
+// TestRunDoctorOnATerminal pins both halves of the NO_COLOR contract from the
+// only place they can be told apart: a real terminal.
+//
+// The tests that capture stdout through a pipe cannot show that NO_COLOR is
+// what produced the ASCII, because the pipe alone already switches the icon
+// helpers to ASCII. Here stdout is the slave side of a pseudo-terminal, so
+// decoration is on unless NO_COLOR turns it off — which makes the first case
+// the check that an interactive terminal still shows the glyphs, and the
+// second the check that NO_COLOR alone takes them away.
+func TestRunDoctorOnATerminal(t *testing.T) {
+	t.Run("shows the glyphs", func(t *testing.T) {
+		noColor(t, false)
+
+		out := runDoctorOnTTY(t)
+
+		for _, want := range []string{"✓ OK", "✓ All checks passed!"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("Terminal output lost %q; output was:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("NO_COLOR replaces them with ASCII", func(t *testing.T) {
+		noColor(t, true)
+
+		out := runDoctorOnTTY(t)
+
+		if !strings.Contains(out, "OK All checks passed!") {
+			t.Errorf("NO_COLOR output is missing the ASCII marker; output was:\n%s", out)
+		}
+		assertNoRawGlyphs(t, out)
+	})
+}
+
+// TestRunRetreatOnATerminal is the same pair for retreat: its own markers on a
+// real terminal, and what NO_COLOR does to them. Retreat needs a project
+// to retreat from, so this builds the smallest one it will act on - a
+// package.json, a lock file naming one package, and a .lnpm directory - rather
+// than publishing and adding anything.
+func TestRunRetreatOnATerminal(t *testing.T) {
+	t.Run("shows the glyphs", func(t *testing.T) {
+		noColor(t, false)
+
+		out := runRetreatOnTTY(t)
+
+		for _, want := range []string{"✓ Restored", "✓ Retreat complete!", "💡 Run 'npm install'"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("Terminal output lost %q; output was:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("NO_COLOR replaces them with ASCII", func(t *testing.T) {
+		noColor(t, true)
+
+		out := runRetreatOnTTY(t)
+
+		if !strings.Contains(out, "OK Retreat complete!") {
+			t.Errorf("NO_COLOR output is missing the ASCII marker; output was:\n%s", out)
+		}
+		assertNoRawGlyphs(t, out)
+	})
+}
+
+// TestIconsOnATerminal pins the markers themselves, so that a caller printing
+// the right ASCII from a literal rather than from a helper still has something
+// left to fail against.
+func TestIconsOnATerminal(t *testing.T) {
+	noColor(t, false)
+
+	got := captureTTYStdout(t, func() {
+		fmt.Printf("%s %s %s %s\n", iconOK(), iconFail(), iconWarn(), iconTip())
+	})
+
+	if want := "✓ ✗ ⚠ 💡"; !strings.Contains(got, want) {
+		t.Errorf("Icons on a terminal = %q, want them to contain %q", got, want)
+	}
+}
+
+// noColor sets or clears NO_COLOR for the duration of the test. Clearing it has
+// to unset the variable rather than empty it, because the helpers treat any
+// value, empty included, as a request for plain output.
+func noColor(t *testing.T, on bool) {
+	t.Helper()
+
+	t.Setenv("NO_COLOR", "1") // registers the restore of whatever was there
+	if !on {
+		_ = os.Unsetenv("NO_COLOR")
+	}
+}
+
+// runDoctorOnTTY runs RunDoctor against a healthy store with stdout on a
+// terminal, and returns what it printed.
+func runDoctorOnTTY(t *testing.T) string {
+	t.Helper()
+
+	dir := newDoctorStoreConfig(t)
+	if err := os.MkdirAll(filepath.Join(dir, "mystore", "store"), 0755); err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	if _, err := store.New(); err != nil { // marks the backfill done
+		t.Fatalf("open store: %v", err)
+	}
+
+	db.ResetForTesting()
+	t.Cleanup(db.ResetForTesting)
+
+	return captureTTYStdout(t, func() {
+		if err := RunDoctor(); err != nil {
+			t.Errorf("RunDoctor() = %v on a healthy store, want nil", err)
+		}
+	})
+}
+
+// runRetreatOnTTY runs RunRetreat against a throwaway project with stdout on a
+// terminal, and returns what it printed.
+//
+// The store and config are redirected first: retreat opens the database, and
+// without that it would open the real one.
+func runRetreatOnTTY(t *testing.T) string {
+	t.Helper()
+
+	newDoctorStoreConfig(t)
+	db.ResetForTesting()
+	t.Cleanup(db.ResetForTesting)
+
+	project := t.TempDir()
+	writeFile(t, filepath.Join(project, "package.json"),
+		`{"name":"tty-project","version":"1.0.0","dependencies":{"tty-pkg":"file:.lnpm/tty-pkg"}}`)
+	if err := os.MkdirAll(filepath.Join(project, ".lnpm", "tty-pkg"), 0755); err != nil {
+		t.Fatalf("create .lnpm: %v", err)
+	}
+	lock := &lockfile.LockFile{Version: 1, Packages: map[string]lockfile.Package{
+		"tty-pkg": {Version: "1.0.0", OriginalVersion: "^1.0.0"},
+	}}
+	if err := lock.Save(project); err != nil {
+		t.Fatalf("save lock file: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	return captureTTYStdout(t, func() {
+		if err := RunRetreat(true, false); err != nil {
+			t.Errorf("RunRetreat() = %v, want nil", err)
+		}
+	})
+}
+
+// writeFile writes content to path, failing the test if it cannot.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// captureTTYStdout runs fn with os.Stdout pointed at the slave side of a
+// pseudo-terminal and returns what it printed. A pipe would not do: the icon
+// helpers ask whether stdout is a character device, so only a terminal
+// exercises their decorated branch.
+//
+// The reader runs while fn does, so fn can print more than the terminal buffer
+// holds. It stops on a sentinel written after fn returns rather than on the
+// slave being closed: closing the last slave makes the master report EIO, and
+// anything still queued would be lost with it.
+func captureTTYStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	const sentinel = "@@lnpm-tty-capture-end@@"
+
+	master, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		t.Skipf("No pseudo-terminal available: %v", err)
+	}
+	defer func() { _ = master.Close() }()
+
+	n, err := unix.IoctlGetInt(int(master.Fd()), unix.TIOCGPTN)
+	if err != nil {
+		t.Skipf("Could not name the pseudo-terminal: %v", err)
+	}
+	if err := unix.IoctlSetPointerInt(int(master.Fd()), unix.TIOCSPTLCK, 0); err != nil {
+		t.Skipf("Could not unlock the pseudo-terminal: %v", err)
+	}
+	slave, err := os.OpenFile(fmt.Sprintf("/dev/pts/%d", n), os.O_RDWR|unix.O_NOCTTY, 0)
+	if err != nil {
+		t.Skipf("Could not open the pseudo-terminal: %v", err)
+	}
+	defer func() { _ = slave.Close() }()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf []byte
+		chunk := make([]byte, 1024)
+		for {
+			n, err := master.Read(chunk)
+			buf = append(buf, chunk[:n]...)
+			if err != nil || bytes.Contains(buf, []byte(sentinel)) {
+				break
+			}
+		}
+		done <- string(buf)
+	}()
+
+	orig := os.Stdout
+	os.Stdout = slave
+	func() {
+		defer func() { os.Stdout = orig }()
+		fn()
+	}()
+
+	if _, err := slave.WriteString(sentinel + "\n"); err != nil {
+		t.Fatalf("Failed to end the capture: %v", err)
+	}
+
+	out := <-done
+	if i := strings.Index(out, sentinel); i >= 0 {
+		out = out[:i]
+	}
+	return out
+}

--- a/internal/cli/retreat.go
+++ b/internal/cli/retreat.go
@@ -99,15 +99,15 @@ func RunRetreat(force bool, runInstall bool) error {
 
 		if originalVersion != "" {
 			if err := restorePackageJSON(cwd, name, originalVersion); err != nil {
-				fmt.Printf("    ⚠ Failed to restore package.json: %v\n", err)
+				fmt.Printf("    %s Failed to restore package.json: %v\n", iconWarn(), err)
 			} else {
-				fmt.Printf("    ✓ Restored %s to %s\n", name, originalVersion)
+				fmt.Printf("    %s Restored %s to %s\n", iconOK(), name, originalVersion)
 			}
 		} else {
 			if err := removeFromPackageJSON(cwd, name); err != nil {
-				fmt.Printf("    ⚠ Failed to update package.json: %v\n", err)
+				fmt.Printf("    %s Failed to update package.json: %v\n", iconWarn(), err)
 			} else {
-				fmt.Printf("    ✓ Removed %s from package.json\n", name)
+				fmt.Printf("    %s Removed %s from package.json\n", iconOK(), name)
 			}
 		}
 
@@ -123,27 +123,27 @@ func RunRetreat(force bool, runInstall bool) error {
 	// Remove .lnpm directory
 	lnpmDir := filepath.Join(cwd, ".lnpm")
 	if err := os.RemoveAll(lnpmDir); err != nil {
-		fmt.Printf("  ⚠ Failed to remove .lnpm/: %v\n", err)
+		fmt.Printf("  %s Failed to remove .lnpm/: %v\n", iconWarn(), err)
 	} else {
-		fmt.Println("  ✓ Removed .lnpm/")
+		fmt.Printf("  %s Removed .lnpm/\n", iconOK())
 	}
 
 	// Clean up .gitignore if enabled
 	cfg := config.Get()
 	if cfg.ShouldManageGitignore() {
 		if err := gitignore.RemoveFromGitignore(cwd, ".lnpm/"); err != nil {
-			fmt.Printf("  ⚠ Could not clean .gitignore: %v\n", err)
+			fmt.Printf("  %s Could not clean .gitignore: %v\n", iconWarn(), err)
 		} else {
-			fmt.Println("  ✓ Cleaned .gitignore")
+			fmt.Printf("  %s Cleaned .gitignore\n", iconOK())
 		}
 	}
 
 	// Remove lnpm.lock
 	lockPath := filepath.Join(cwd, "lnpm.lock")
 	if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
-		fmt.Printf("  ⚠ Failed to remove lnpm.lock: %v\n", err)
+		fmt.Printf("  %s Failed to remove lnpm.lock: %v\n", iconWarn(), err)
 	} else {
-		fmt.Println("  ✓ Removed lnpm.lock")
+		fmt.Printf("  %s Removed lnpm.lock\n", iconOK())
 	}
 
 	// Run package manager install if requested
@@ -157,15 +157,15 @@ func RunRetreat(force bool, runInstall bool) error {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
-			fmt.Printf("⚠ Install failed: %v\n", err)
+			fmt.Printf("%s Install failed: %v\n", iconWarn(), err)
 		}
 	}
 
 	fmt.Println()
-	fmt.Println("✓ Retreat complete!")
+	fmt.Printf("%s Retreat complete!\n", iconOK())
 
 	if !runInstall {
-		fmt.Println("\n💡 Run 'npm install' to restore original packages")
+		fmt.Printf("\n%s Run 'npm install' to restore original packages\n", iconTip())
 	}
 
 	return nil

--- a/tests/retreat_test.go
+++ b/tests/retreat_test.go
@@ -290,3 +290,123 @@ func TestRetreatIgnoresLinkReferenceAsOriginalVersion(t *testing.T) {
 
 	env.AssertPackageJSONMissing(projectDir, "stale-ref-lib")
 }
+
+// TestRetreatMarkersComeFromTheIconHelpers sweeps retreat's progress report for
+// the decorative markers, so a line printing "✓"/"⚠"/"💡" as a string literal
+// instead of calling the helpers is caught.
+//
+// That, and only that, is what this proves. Capturing stdout replaces it with a
+// pipe, and the helpers fall back to ASCII whenever stdout is not a terminal,
+// so a report free of glyphs here says nothing about NO_COLOR: the pipe alone
+// would have produced it. NO_COLOR is set anyway, so the sweep does not depend
+// on how the capture is implemented. What NO_COLOR does to retreat's own output
+// is covered by TestRunRetreatOnATerminal in internal/cli, which runs retreat
+// with stdout on a real terminal.
+func TestRetreatMarkersComeFromTheIconHelpers(t *testing.T) {
+	cases := []struct {
+		name string
+		// originalVersion, when set, is written into the lock entry so retreat
+		// restores the dependency instead of dropping it. Each branch prints
+		// its own marker, so both are worth sweeping.
+		originalVersion string
+		// readOnly, when set, makes part of the project unwritable so
+		// retreat's failure lines are reached: they carry markers of their
+		// own. Any scenario that sets it needs the filesystem to enforce
+		// permissions, so setting it also selects the guard.
+		readOnly func(t *testing.T, projectDir string)
+		want     string
+	}{
+		{
+			name: "dependency dropped",
+			want: "Removed glyph-pkg from package.json",
+		},
+		{
+			name:            "dependency restored",
+			originalVersion: "^1.0.0",
+			want:            "Restored glyph-pkg to ^1.0.0",
+		},
+		{
+			name:     "package.json cannot be written",
+			readOnly: makePackageJSONReadOnly,
+			want:     "Failed to update package.json",
+		},
+		{
+			name:            "package.json cannot be restored",
+			originalVersion: "^1.0.0",
+			readOnly:        makePackageJSONReadOnly,
+			want:            "Failed to restore package.json",
+		},
+		{
+			name:            "nothing in the project directory can be removed",
+			originalVersion: "^1.0.0",
+			readOnly:        makeProjectDirReadOnly,
+			want:            "Failed to remove .lnpm/", // and .gitignore, lnpm.lock
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.readOnly != nil {
+				requirePermissionEnforcement(t)
+			}
+
+			t.Setenv("NO_COLOR", "1")
+			env := setupTest(t)
+			_, projectDir := env.publishAndAdd("glyph-pkg")
+
+			if tc.originalVersion != "" {
+				env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+					entry, ok := lock.Get("glyph-pkg")
+					if !ok {
+						t.Fatal("glyph-pkg missing from lockfile")
+					}
+					entry.OriginalVersion = tc.originalVersion
+					lock.Add("glyph-pkg", entry)
+					if err := lock.Save(projectDir); err != nil {
+						t.Fatalf("Failed to save lockfile: %v", err)
+					}
+				})
+			}
+			if tc.readOnly != nil {
+				tc.readOnly(t, projectDir)
+			}
+
+			out := captureStdout(t, func() {
+				if err := cli.RunRetreat(true, false); err != nil {
+					t.Errorf("Failed to retreat: %v", err)
+				}
+			})
+
+			if !strings.Contains(out, tc.want) {
+				t.Fatalf("Expected the report to contain %q, got:\n%s", tc.want, out)
+			}
+			assertNoRawGlyphs(t, out)
+		})
+	}
+}
+
+// makeProjectDirReadOnly makes the project directory itself unwritable, so
+// every unlink and create inside it fails while its existing files stay
+// readable and writable. makePackageJSONReadOnly cannot stand in for this: it
+// addresses one named file, and its 0444 would also cost the directory the
+// execute bit that makes it traversable at all.
+func makeProjectDirReadOnly(t *testing.T, projectDir string) {
+	t.Helper()
+
+	if err := os.Chmod(projectDir, 0555); err != nil {
+		t.Fatalf("Failed to make the project directory read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(projectDir, 0755) })
+}
+
+// assertNoRawGlyphs fails when out contains any of the decorative markers,
+// which must have been rendered as ASCII.
+func assertNoRawGlyphs(t *testing.T, out string) {
+	t.Helper()
+
+	for _, glyph := range "✓✗⚠💡" {
+		if strings.ContainsRune(out, glyph) {
+			t.Errorf("Output contains the raw glyph %q, want its ASCII fallback; output was:\n%s", string(glyph), out)
+		}
+	}
+}


### PR DESCRIPTION
Closes #162.

Two related defects. `RunDoctor` always returned `nil`, so `lnpm doctor && deploy.sh` could not detect that doctor had reported problems. And `doctor.go`/`retreat.go` printed raw `✓`/`✗`/`⚠`/`💡` glyphs directly instead of going through the `iconOK`/`iconFail`/`iconWarn`/`iconTip` helpers, so `NO_COLOR=1` and piped output still emitted Unicode, unlike the rest of the CLI.

`RunDoctor` now returns an error once `issues > 0`, and `nil` otherwise — **warnings alone still succeed**, matching the summary's existing separation of issues from warnings. All 19 marker call sites in `doctor.go` and all 13 in `retreat.go` now go through the helpers.

Six of those sites were not in the issue's line list. Three belong to the "store completeness markers" check that #237 added after this issue was filed; one is `retreat.go`'s `💡` tip line, which `iconTip` (pre-existing) covers. A repo-wide sweep confirms no raw glyphs remain in either file.

No wiring change was needed: `root.go` already sets `SilenceUsage: true`, so cobra prints `Error: doctor found 1 issue(s)` on stderr with no usage block, and exits 1. Verified against the real binary with a throwaway store.

## The testing problem this issue hides

Capturing stdout replaces it with a pipe — and the icon helpers already fall back to ASCII on a non-tty. So the obvious test, "capture stdout with `NO_COLOR=1` and assert no glyphs", **passes whether or not NO_COLOR works at all**. Confirmed rather than assumed: deleting the NO_COLOR check from `decorate()` leaves every pipe-based test green.

So the pipe-based sweeps are named for what they actually establish — `TestRunDoctorMarkersComeFromTheIconHelpers` and `TestRetreatMarkersComeFromTheIconHelpers` — and causation is proven separately by a `/dev/ptmx` harness that puts stdout on a real pty, asserts the glyphs appear on a terminal, then asserts pure ASCII on that same terminal with `NO_COLOR=1`. That pair is what distinguishes "NO_COLOR did it" from "the pipe did it". It is a genuine tty, not a pipe — CR-LF translation is visible in the captured bytes — and it survived 65 consecutive runs across two review rounds without flaking.

Both `RunDoctor` and `RunRetreat` are driven through that harness, so acceptance criteria 3 and 4 are verified directly for both commands rather than inferred.

## Verification

Every marker was mutation-checked individually — each `iconX()` call swapped back to a raw literal in turn:

- `doctor.go`: **18 of 19 caught**. The miss is the `config.GetStorePath()` error branch, unreachable without breaking store resolution itself.
- `retreat.go`: **12 of 13 caught**. The miss is "Install failed", which needs a real `npm install` run.

The exit-code contract was checked against three mutants: `return nil` (fails 4 tests), always-return-error (fails 6), and the subtle `issues > 0 || warnings > 0` (fails exactly the warnings-only test and the orphaned-package test).

Assertions ended up **stronger than before this change**: the shared capture helper previously stood in for both expectations with one `err != nil` check. Tests that expect success now assert `nil` explicitly, and the helper — renamed `captureFailingDoctorStdout` — asserts failure for the rest.

Tests that make something unwritable are guarded by `requirePermissionEnforcement`, the package's existing helper, which skips on Windows **and as root** — root ignores permission bits, so without it those tests fail for the wrong reason on a root runner. The guard is now selected by the table data rather than a separate flag, so a future row cannot forget it. Guard wiring was verified by inverting each predicate and confirming exactly the intended scenarios skip.

`go test ./...`, `go vet`, `golangci-lint` (0 issues), `gofmt` and four cross-compile gates are green.

## Known limits, stated rather than implied

- The pty harness is `//go:build linux`, since `/dev/ptmx` is Linux-specific. On darwin and Windows only the pipe-based sweeps run, and those pass for the wrong reason — so NO_COLOR causation is unverified on those platforms. Making it portable needs a new dependency.
- The two uncovered call sites above.

## Found, not fixed — reported on the issue

Piped output now reads `Checking database... OK OK`, because `iconOK()`'s ASCII fallback is `OK` and the check label is also `OK`. Literally what the acceptance criteria asked for, but visibly duplicated. Fixing it means rewording the check labels, which the brief puts out of scope.