### PR TITLE
Fall back to the user completion directory when the system one refuses the write

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -113,7 +115,7 @@ func installBashCompletion() error {
 		return fmt.Errorf("failed to get home directory: %w", err)
 	}
 
-	var compDir string
+	var systemDir string
 	if runtime.GOOS == "darwin" {
 		// Try Homebrew location first
 		brewPrefix := os.Getenv("HOMEBREW_PREFIX")
@@ -123,33 +125,35 @@ func installBashCompletion() error {
 				brewPrefix = "/opt/homebrew" // Default for Apple Silicon
 			}
 		}
-		compDir = filepath.Join(brewPrefix, "etc", "bash_completion.d")
-
-		// Fallback to user directory if Homebrew dir doesn't exist
-		if _, err := os.Stat(compDir); os.IsNotExist(err) {
-			compDir = filepath.Join(home, ".bash_completion.d")
-		}
+		systemDir = filepath.Join(brewPrefix, "etc", "bash_completion.d")
 	} else {
-		// Linux - try system directory, fall back to user
-		compDir = "/etc/bash_completion.d"
-		if _, err := os.Stat(compDir); os.IsNotExist(err) {
-			compDir = filepath.Join(home, ".bash_completion.d")
-		}
+		systemDir = "/etc/bash_completion.d"
 	}
 
-	if err := os.MkdirAll(compDir, 0755); err != nil {
-		return fmt.Errorf("failed to create completion directory: %w", err)
+	_, err = installBashCompletionInto(home, systemDir, filepath.Join(home, ".bash_completion.d"))
+	return err
+}
+
+// installBashCompletionInto writes the completion script to systemDir, falling
+// back to fallbackDir when systemDir does not exist or will not take the write,
+// and prints the setup instructions for wherever it landed. It returns the
+// directory written to.
+func installBashCompletionInto(home, systemDir, fallbackDir string) (string, error) {
+	compDir := systemDir
+	if _, err := os.Stat(compDir); os.IsNotExist(err) {
+		compDir = fallbackDir
 	}
 
-	compFile := filepath.Join(compDir, "lnpm")
-	file, err := os.Create(compFile)
+	compFile, err := writeBashCompletionFile(compDir)
+	// The system directory usually exists but belongs to root, so a permission
+	// error there means the user directory instead - not a failed install.
+	// Anything else (a full disk, a read-only filesystem) still surfaces.
+	if err != nil && compDir != fallbackDir && errors.Is(err, fs.ErrPermission) {
+		compDir = fallbackDir
+		compFile, err = writeBashCompletionFile(compDir)
+	}
 	if err != nil {
-		return fmt.Errorf("failed to create completion file: %w", err)
-	}
-	defer func() { _ = file.Close() }()
-
-	if err := rootCmd.GenBashCompletion(file); err != nil {
-		return fmt.Errorf("failed to generate completion: %w", err)
+		return "", err
 	}
 
 	fmt.Printf("✓ Installed bash completion to %s\n\n", compFile)
@@ -163,7 +167,28 @@ func installBashCompletion() error {
 
 	fmt.Println("Then reload your shell: exec bash")
 
-	return nil
+	return compDir, nil
+}
+
+// writeBashCompletionFile generates the completion script into compDir and
+// returns the file it wrote.
+func writeBashCompletionFile(compDir string) (string, error) {
+	if err := os.MkdirAll(compDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create completion directory: %w", err)
+	}
+
+	compFile := filepath.Join(compDir, "lnpm")
+	file, err := os.Create(compFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to create completion file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	if err := rootCmd.GenBashCompletion(file); err != nil {
+		return "", fmt.Errorf("failed to generate completion: %w", err)
+	}
+
+	return compFile, nil
 }
 
 func installFishCompletion() error {

--- a/internal/cli/completion_permissions_test.go
+++ b/internal/cli/completion_permissions_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// unwritableSystemDir creates the system completion directory and takes away
+// the write bit, standing in for /etc/bash_completion.d as an unprivileged
+// user sees it: present, but closed to everyone but root.
+func unwritableSystemDir(t *testing.T, systemDir string) {
+	t.Helper()
+
+	if err := os.MkdirAll(systemDir, 0755); err != nil {
+		t.Fatalf("create system dir: %v", err)
+	}
+	if err := os.Chmod(systemDir, 0555); err != nil {
+		t.Fatalf("chmod system dir: %v", err)
+	}
+	// t.TempDir cleanup cannot remove what it cannot write to.
+	t.Cleanup(func() { _ = os.Chmod(systemDir, 0755) })
+}
+
+// An existing system directory the user cannot write to is the common case for
+// an unprivileged user. Existence alone must not commit the install to that
+// directory.
+func TestInstallBashCompletionFallsBackWhenSystemDirIsNotWritable(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	home, systemDir, fallbackDir := bashCompletionDirs(t)
+	unwritableSystemDir(t, systemDir)
+
+	dir, _, err := installBashCompletionIn(t, home, systemDir, fallbackDir)
+	if err != nil {
+		t.Fatalf("installBashCompletionInto: %v", err)
+	}
+	if dir != fallbackDir {
+		t.Fatalf("installed to %q, want fallback %q", dir, fallbackDir)
+	}
+	assertCompletionFile(t, fallbackDir)
+	assertNoCompletionFile(t, systemDir)
+}
+
+// The hint tells the user to source the file from ~/.bashrc, which is right
+// only once the install has fallen back into their home directory. The
+// system-wide counterpart lives in completion_test.go.
+func TestInstallBashCompletionHintsBashrcForHomeInstalls(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	home, systemDir, fallbackDir := bashCompletionDirs(t)
+	unwritableSystemDir(t, systemDir)
+
+	dir, out, err := installBashCompletionIn(t, home, systemDir, fallbackDir)
+	if err != nil {
+		t.Fatalf("installBashCompletionInto: %v", err)
+	}
+	if dir != fallbackDir {
+		t.Fatalf("installed to %q, want fallback %q", dir, fallbackDir)
+	}
+	if !strings.Contains(out, bashrcHint) {
+		t.Fatalf("output missing %q hint:\n%s", bashrcHint, out)
+	}
+}

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// bashrcHint is the opening of the instruction only a home-directory install
+// should print.
+const bashrcHint = "Add this to your ~/.bashrc"
+
+// bashCompletionDirs lays out a home directory and a system completion
+// directory side by side under one temp root. The system directory is
+// deliberately outside home so the "did it land under home?" check the
+// ~/.bashrc hint depends on can tell the two apart.
+func bashCompletionDirs(t *testing.T) (home, systemDir, fallbackDir string) {
+	t.Helper()
+
+	root := t.TempDir()
+	home = filepath.Join(root, "home")
+	systemDir = filepath.Join(root, "system")
+	fallbackDir = filepath.Join(home, ".bash_completion.d")
+
+	if err := os.MkdirAll(home, 0755); err != nil {
+		t.Fatalf("create home: %v", err)
+	}
+	return home, systemDir, fallbackDir
+}
+
+// installBashCompletionIn runs the installer with stdout captured, so the test
+// output stays clean and the printed instructions can be asserted on.
+//
+// Don't use t.Parallel() in callers - this helper swaps the process-wide
+// os.Stdout.
+func installBashCompletionIn(t *testing.T, home, systemDir, fallbackDir string) (dir, out string, err error) {
+	t.Helper()
+
+	out = captureStdout(t, func() {
+		dir, err = installBashCompletionInto(home, systemDir, fallbackDir)
+	})
+	return dir, out, err
+}
+
+func assertCompletionFile(t *testing.T, dir string) {
+	t.Helper()
+
+	info, err := os.Stat(filepath.Join(dir, "lnpm"))
+	if err != nil {
+		t.Fatalf("stat completion file in %s: %v", dir, err)
+	}
+	if info.Size() == 0 {
+		t.Fatalf("completion file in %s is empty", dir)
+	}
+}
+
+func assertNoCompletionFile(t *testing.T, dir string) {
+	t.Helper()
+
+	if _, err := os.Stat(filepath.Join(dir, "lnpm")); !os.IsNotExist(err) {
+		t.Fatalf("completion file in %s: stat error = %v, want IsNotExist", dir, err)
+	}
+}
+
+func TestInstallBashCompletionUsesWritableSystemDir(t *testing.T) {
+	home, systemDir, fallbackDir := bashCompletionDirs(t)
+	if err := os.MkdirAll(systemDir, 0755); err != nil {
+		t.Fatalf("create system dir: %v", err)
+	}
+
+	dir, _, err := installBashCompletionIn(t, home, systemDir, fallbackDir)
+	if err != nil {
+		t.Fatalf("installBashCompletionInto: %v", err)
+	}
+	if dir != systemDir {
+		t.Fatalf("installed to %q, want system dir %q", dir, systemDir)
+	}
+	assertCompletionFile(t, systemDir)
+	if _, err := os.Stat(fallbackDir); !os.IsNotExist(err) {
+		t.Fatalf("fallback dir %s: stat error = %v, want IsNotExist", fallbackDir, err)
+	}
+}
+
+func TestInstallBashCompletionFallsBackWhenSystemDirIsAbsent(t *testing.T) {
+	home, systemDir, fallbackDir := bashCompletionDirs(t)
+
+	dir, _, err := installBashCompletionIn(t, home, systemDir, fallbackDir)
+	if err != nil {
+		t.Fatalf("installBashCompletionInto: %v", err)
+	}
+	if dir != fallbackDir {
+		t.Fatalf("installed to %q, want fallback %q", dir, fallbackDir)
+	}
+	assertCompletionFile(t, fallbackDir)
+	if _, err := os.Stat(systemDir); !os.IsNotExist(err) {
+		t.Fatalf("system dir %s: stat error = %v, want IsNotExist", systemDir, err)
+	}
+}
+
+// A system-wide install is already sourced by bash itself, so telling the user
+// to source it from ~/.bashrc would be wrong. The matching home-directory case
+// lives in completion_permissions_test.go.
+func TestInstallBashCompletionOmitsBashrcHintForSystemInstalls(t *testing.T) {
+	home, systemDir, fallbackDir := bashCompletionDirs(t)
+	if err := os.MkdirAll(systemDir, 0755); err != nil {
+		t.Fatalf("create system dir: %v", err)
+	}
+
+	dir, out, err := installBashCompletionIn(t, home, systemDir, fallbackDir)
+	if err != nil {
+		t.Fatalf("installBashCompletionInto: %v", err)
+	}
+	if dir != systemDir {
+		t.Fatalf("installed to %q, want system dir %q", dir, systemDir)
+	}
+	if strings.Contains(out, bashrcHint) {
+		t.Fatalf("output has %q hint for a system-wide install:\n%s", bashrcHint, out)
+	}
+}


### PR DESCRIPTION
`lnpm completion install` picked the system completion directory whenever
`os.Stat` succeeded — that is, whenever the directory merely *existed*. On most
Linux systems and Homebrew installs `/etc/bash_completion.d` exists but is
writable only by root, so an unprivileged user got a permission error and a
failed install, even though `~/.bash_completion.d` would have worked. The
existing fallback only fired on "directory absent", never on "present but not
writable".

## Change

- `installBashCompletion` now only resolves paths and delegates to
  `installBashCompletionInto(home, systemDir, fallbackDir)`, which attempts the
  write and retries in the fallback when the failure `errors.Is(err,
  fs.ErrPermission)`. Both conditions — absent, and present-but-unwritable —
  route to the same fallback.
- Only `EACCES`/`EPERM` route to the fallback. A read-only filesystem or a full
  disk still surfaces as a real failure rather than being silently redirected.
- The retry is guarded by `compDir != fallbackDir`, so a permission error on the
  fallback itself surfaces instead of being retried into itself.
- The macOS Homebrew-prefix resolution and the Linux path choice are unchanged;
  their duplicated absent-directory fallback is now shared in the helper.
- The `~/.bashrc` hint's `filepath.Rel(home, compDir)` guard is byte-identical
  to before.

## Tests

`internal/cli/completion_test.go` and `internal/cli/completion_permissions_test.go`
cover: unwritable system dir falls back; writable system dir is used with no
fallback directory created; absent system dir falls back; and the `~/.bashrc`
hint appears only for home installs. Permission-dependent cases sit in the
`*_permissions_test.go` file per the repo convention and use the existing
`requirePermissionEnforcement` guard, which skips as root and on Windows.

Both tests that assert the new behaviour were confirmed to fail with the
fallback condition neutralised. The other three are deliberate regression pins
for behaviour this change must not break.

Gates: `go test ./...` under `umask 022`, `go vet`, `golangci-lint`, `gofmt`,
plus `windows/amd64` build and `windows/amd64`, `darwin/arm64`, `linux/arm64`
vet — all clean.

Closes #169