### PR TITLE
Report scoped packages by full name and clean up emptied scope directories

### DIFF
--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -389,14 +389,38 @@ func (l *Linker) Unlink(packageName string) error {
 		return fmt.Errorf("failed to remove node_modules symlink: %w", err)
 	}
 
-	// Clean up empty .lnpm directory if no packages left
-	lnpmDir := filepath.Join(l.projectPath, ".lnpm")
-	entries, err := os.ReadDir(lnpmDir)
-	if err == nil && len(entries) == 0 {
-		_ = os.Remove(lnpmDir)
+	// A scoped package leaves its scope directory behind. Drop it once it holds
+	// no packages, otherwise the empty-.lnpm cleanup below never fires for a
+	// scoped package and the stale scope directory survives.
+	if strings.Contains(packageName, "/") {
+		removeDirIfEmpty(filepath.Dir(lnpmPath))
+		removeDirIfEmpty(filepath.Dir(nodeModulesPath))
 	}
 
+	// Clean up empty .lnpm directory if no packages left
+	removeDirIfEmpty(filepath.Join(l.projectPath, ".lnpm"))
+
 	return nil
+}
+
+// removeDirIfEmpty removes dir when it holds no entries at all.
+//
+// Emptiness is literal, deliberately unlike ListLinked's report: a relink
+// creates its temp directory as a sibling of its target, so a live relink of
+// another package in the same scope leaves a dot-prefixed entry in the scope
+// directory. ListLinked filters those out because they are not packages; this
+// check must not, because removing a directory a relink is writing into would
+// destroy that relink's work.
+//
+// Both discarded errors fail closed, per docs/adr/0001: whether the read or the
+// removal fails, the directory survives and Unlink tidies up less than it could.
+// Nothing the caller asked for is undone, so neither is worth failing an
+// otherwise complete unlink.
+func removeDirIfEmpty(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err == nil && len(entries) == 0 {
+		_ = os.Remove(dir)
+	}
 }
 
 // createNodeModulesSymlink creates a symlink from node_modules/{pkg} to .lnpm/{pkg}
@@ -531,9 +555,37 @@ func (l *Linker) ListLinked() ([]string, error) {
 		// package whose name starts with a dot, which is safe in practice: npm
 		// forbids such names, so one can never have been linked here
 		// (ValidatePackageName itself only rejects "." and "..").
-		if entry.IsDir() && !strings.HasPrefix(entry.Name(), ".") {
-			packages = append(packages, entry.Name())
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
 		}
+
+		// A scope directory holds packages rather than being one, so descend a
+		// level and report each package under it by its full name. The same
+		// dot-prefixed skip applies here: a relink temp directory is a sibling
+		// of its target, which for a scoped package is inside the scope.
+		if strings.HasPrefix(entry.Name(), "@") {
+			scopeEntries, err := os.ReadDir(filepath.Join(lnpmDir, entry.Name()))
+			if err != nil {
+				// Unlink removes a scope directory as soon as it empties, so a
+				// concurrent unlink of the last package in this scope can delete
+				// it between the two reads. Treat that as the scope simply being
+				// gone, matching how a missing .lnpm is not an error above.
+				// What "gone" looks like is platform-specific, so ask.
+				if scopeVanished(err) {
+					continue
+				}
+				return nil, err
+			}
+			for _, scoped := range scopeEntries {
+				if scoped.IsDir() && !strings.HasPrefix(scoped.Name(), ".") {
+					// A package name always uses "/", on every platform.
+					packages = append(packages, entry.Name()+"/"+scoped.Name())
+				}
+			}
+			continue
+		}
+
+		packages = append(packages, entry.Name())
 	}
 	return packages, nil
 }

--- a/internal/link/link_atomic_test.go
+++ b/internal/link/link_atomic_test.go
@@ -193,3 +193,47 @@ func TestListLinked_IgnoresDotPrefixedEntries(t *testing.T) {
 		t.Errorf("ListLinked() = %v, want [real-package]", linked)
 	}
 }
+
+// TestListLinkedSkipsTempDirsInsideAScope is the scope-level counterpart of
+// TestListLinked_IgnoresDotPrefixedEntries. A temp directory is a sibling of
+// the target it will replace, so for a scoped package it lands inside the scope
+// directory, exactly where the descent added for scoped names would surface it.
+func TestListLinkedSkipsTempDirsInsideAScope(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+
+	linker := New(projectPath)
+	linkPackage(t, linker, filepath.Join(tmpDir, "store"), "@org/my-package")
+
+	if err := os.MkdirAll(filepath.Join(projectPath, ".lnpm", "@org", ".tmp-leftover"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	assertLinked(t, linker, "@org/my-package")
+}
+
+// TestUnlinkKeepsScopeHoldingATempDirectory pins the asymmetry with ListLinked:
+// a dot-prefixed entry is filtered out of the listing, but it still counts when
+// Unlink decides whether a scope directory is empty. Deleting a scope that a
+// live relink is writing into would destroy that relink's work.
+func TestUnlinkKeepsScopeHoldingATempDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+
+	linker := New(projectPath)
+	linkPackage(t, linker, filepath.Join(tmpDir, "store"), "@org/pkg-a")
+
+	// Stand in for a concurrent relink of @org/pkg-b, whose temp directory is
+	// created as a sibling of its target inside the scope directory.
+	tempDir := filepath.Join(projectPath, ".lnpm", "@org", ".tmp-inflight")
+	if err := os.MkdirAll(tempDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := linker.Unlink("@org/pkg-a"); err != nil {
+		t.Fatalf("Unlink() error: %v", err)
+	}
+
+	assertExists(t, tempDir)
+	assertExists(t, filepath.Join(projectPath, ".lnpm", "@org"))
+}

--- a/internal/link/link_failure_test.go
+++ b/internal/link/link_failure_test.go
@@ -340,6 +340,28 @@ func TestUnlinkRemovesEmptyLnpmDir(t *testing.T) {
 	}
 }
 
+// TestUnlinkScopedPackageRemovesEmptyScopeDirectories is the scoped counterpart
+// of TestUnlinkRemovesEmptyLnpmDir. A scoped package leaves a scope directory
+// behind under both .lnpm and node_modules, and until that goes the empty-.lnpm
+// cleanup above can never fire for a scoped package.
+func TestUnlinkScopedPackageRemovesEmptyScopeDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+
+	linker := New(projectPath)
+	linkPackage(t, linker, filepath.Join(tmpDir, "store"), "@org/my-package")
+
+	if err := linker.Unlink("@org/my-package"); err != nil {
+		t.Fatalf("Unlink() error: %v", err)
+	}
+
+	assertNotExist(t, filepath.Join(projectPath, ".lnpm", "@org"))
+	assertNotExist(t, filepath.Join(projectPath, "node_modules", "@org"))
+	// With the scope directory gone, the empty-.lnpm cleanup fires.
+	assertNotExist(t, filepath.Join(projectPath, ".lnpm"))
+	assertLinked(t, linker)
+}
+
 // TestLinkSourceRejectsUnusableSource drives LinkSource's guards on the source
 // directory recorded when the package was published. That directory can have
 // been deleted or replaced since, and linking .lnpm/{package} at it anyway

--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -2,9 +2,11 @@ package link
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/pack"
@@ -273,6 +275,177 @@ func TestLinkMultiplePackages(t *testing.T) {
 	if _, err := os.Stat(lnpmDir); err != nil {
 		t.Error(".lnpm directory removed while packages still linked")
 	}
+}
+
+// linkPackage links packageName into linker's project from a store entry
+// written under storeRoot, following the setup TestLinkScopedPackage uses.
+func linkPackage(t *testing.T, linker *Linker, storeRoot, packageName string) {
+	t.Helper()
+
+	storePath := filepath.Join(storeRoot, filepath.FromSlash(packageName))
+	files := writeStoreFiles(t, storePath, map[string]string{
+		"package.json": `{"name":"` + packageName + `"}`,
+	})
+	if _, err := linker.Link(packageName, storePath, files); err != nil {
+		t.Fatalf("Link(%s) error: %v", packageName, err)
+	}
+}
+
+// assertLinked fails unless ListLinked reports exactly want, in any order.
+func assertLinked(t *testing.T, linker *Linker, want ...string) {
+	t.Helper()
+
+	got, err := linker.ListLinked()
+	if err != nil {
+		t.Fatalf("ListLinked() error: %v", err)
+	}
+	sorted := slices.Sorted(slices.Values(got))
+	slices.Sort(want)
+	if !slices.Equal(sorted, want) {
+		t.Errorf("ListLinked() = %v, want %v", got, want)
+	}
+}
+
+// assertNotExist fails unless path is absent.
+func assertNotExist(t *testing.T, path string) {
+	t.Helper()
+
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		t.Errorf("%s still exists, want it removed", path)
+	}
+}
+
+// assertExists fails unless path is present.
+func assertExists(t *testing.T, path string) {
+	t.Helper()
+
+	if _, err := os.Lstat(path); err != nil {
+		t.Errorf("%s is missing: %v", path, err)
+	}
+}
+
+func TestListLinkedScopedPackage(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+
+	linker := New(projectPath)
+	linkPackage(t, linker, filepath.Join(tmpDir, "store"), "@org/my-package")
+
+	assertLinked(t, linker, "@org/my-package")
+}
+
+func TestListLinkedTwoPackagesInOneScope(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+
+	linker := New(projectPath)
+	storeRoot := filepath.Join(tmpDir, "store")
+	linkPackage(t, linker, storeRoot, "@org/pkg-a")
+	linkPackage(t, linker, storeRoot, "@org/pkg-b")
+
+	assertLinked(t, linker, "@org/pkg-a", "@org/pkg-b")
+}
+
+func TestListLinkedMixesScopedAndUnscopedPackages(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+
+	linker := New(projectPath)
+	storeRoot := filepath.Join(tmpDir, "store")
+	for _, pkgName := range []string{"plain-package", "@org/pkg-a", "@org/pkg-b", "@other/pkg-c"} {
+		linkPackage(t, linker, storeRoot, pkgName)
+	}
+
+	assertLinked(t, linker, "plain-package", "@org/pkg-a", "@org/pkg-b", "@other/pkg-c")
+}
+
+// TestListLinkedToleratesAScopeRemovedMidListing drives ListLinked against the
+// interleaving this package creates for itself: Unlink deletes a scope
+// directory the moment it empties, and ListLinked reads the scope directories
+// one at a time after listing them, so a scope can vanish between the two
+// reads. A scope that goes must drop out of the listing, not fail it — the
+// same way a missing .lnpm is reported as no packages rather than an error.
+//
+// The interleaving is reproduced rather than simulated, so the proof runs one
+// way only: once the ENOENT is skipped the test cannot fail, while without the
+// skip it fails as soon as the window is hit. The filler scopes widen that
+// window by giving the listing loop other scopes to read before it reaches the
+// one being removed.
+func TestListLinkedToleratesAScopeRemovedMidListing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows reports a delete-pending directory as ERROR_ACCESS_DENIED, " +
+			"which is indistinguishable from a genuine permission failure, so " +
+			"scopeVanished deliberately does not treat it as a vanished scope " +
+			"(see scope_windows.go, TestScopeVanished, and #170/#236): a scope " +
+			"removed mid-listing is still reported as an error on windows")
+	}
+
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	lnpmDir := filepath.Join(projectPath, ".lnpm")
+
+	// "@filler-NNN" sorts before "@zzz", and ReadDir returns entries sorted, so
+	// the loop reaches the scope under test last.
+	for i := 0; i < 200; i++ {
+		if err := os.MkdirAll(filepath.Join(lnpmDir, fmt.Sprintf("@filler-%03d", i), "pkg"), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	linker := New(projectPath)
+	done := make(chan struct{})
+	// Wait for the writer even when an assertion below ends the test, so it
+	// cannot report a failure after the test has finished.
+	defer func() { <-done }()
+
+	go func() {
+		defer close(done)
+		for i := 0; i < 2000; i++ {
+			if err := os.MkdirAll(filepath.Join(lnpmDir, "@zzz", "pkg"), 0755); err != nil {
+				t.Errorf("failed to recreate the scope: %v", err)
+				return
+			}
+			if err := linker.Unlink("@zzz/pkg"); err != nil {
+				t.Errorf("Unlink() error: %v", err)
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-done:
+			return
+		default:
+		}
+
+		linked, err := linker.ListLinked()
+		if err != nil {
+			t.Fatalf("ListLinked() failed while a scope was being removed: %v", err)
+		}
+		if slices.Contains(linked, "@zzz") {
+			t.Fatalf("ListLinked() reported the bare scope @zzz: %v", linked)
+		}
+	}
+}
+
+func TestUnlinkScopedPackageKeepsScopeWithAnotherPackage(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+
+	linker := New(projectPath)
+	storeRoot := filepath.Join(tmpDir, "store")
+	linkPackage(t, linker, storeRoot, "@org/pkg-a")
+	linkPackage(t, linker, storeRoot, "@org/pkg-b")
+
+	if err := linker.Unlink("@org/pkg-a"); err != nil {
+		t.Fatalf("Unlink() error: %v", err)
+	}
+
+	assertExists(t, filepath.Join(projectPath, ".lnpm", "@org", "pkg-b"))
+	assertExists(t, filepath.Join(projectPath, "node_modules", "@org", "pkg-b"))
+	assertNotExist(t, filepath.Join(projectPath, ".lnpm", "@org", "pkg-a"))
+	assertLinked(t, linker, "@org/pkg-b")
 }
 
 func TestCopyFile(t *testing.T) {

--- a/internal/link/scope_unix.go
+++ b/internal/link/scope_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package link
+
+import "os"
+
+// scopeVanished reports whether an error from reading a scope directory means
+// the scope is gone rather than something the caller needs to hear about.
+//
+// Unlink removes a scope directory the moment it empties, so a listing that has
+// already seen the scope in its parent can find it missing a moment later. On
+// Unix that always surfaces as ENOENT; the Windows build has a second case.
+func scopeVanished(err error) bool {
+	return os.IsNotExist(err)
+}

--- a/internal/link/scope_unix_test.go
+++ b/internal/link/scope_unix_test.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package link
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestScopeVanished pins which read failures ListLinked is allowed to treat as
+// a scope that has been unlinked from under it. Everything else must propagate:
+// the race test can only ever exercise the disappearing case, so the cases that
+// must NOT be skipped are pinned here.
+func TestScopeVanished(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "not exist", err: os.ErrNotExist, want: true},
+		{
+			name: "not exist wrapped by ReadDir",
+			err:  &os.PathError{Op: "open", Path: filepath.Join(".lnpm", "@org"), Err: syscall.ENOENT},
+			want: true,
+		},
+		{
+			name: "permission denied",
+			err:  &os.PathError{Op: "open", Path: filepath.Join(".lnpm", "@org"), Err: syscall.EACCES},
+			want: false,
+		},
+		{name: "no error", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scopeVanished(tt.err); got != tt.want {
+				t.Errorf("scopeVanished(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/link/scope_windows.go
+++ b/internal/link/scope_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package link
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// errorSharingViolation is Win32 ERROR_SHARING_VIOLATION. Windows reports it
+// when an open is refused because another handle holds the file or directory
+// under sharing restrictions, which includes a handle opened in order to delete
+// it.
+const errorSharingViolation = syscall.Errno(32)
+
+// scopeVanished reports whether an error from reading a scope directory means
+// the scope is gone rather than something the caller needs to hear about.
+//
+// Unlink removes a scope directory the moment it empties, so a listing that has
+// already seen the scope in its parent can find it missing a moment later. Unix
+// reports that as ENOENT, but Windows has two ways to say it: a delete that has
+// completed gives ENOENT, while one still in flight gives a sharing violation,
+// because the directory survives its own delete until the last handle closes
+// and refuses new opens in the meantime. Both mean the same thing here — the
+// scope is on its way out and holds nothing worth listing.
+//
+// ERROR_ACCESS_DENIED is deliberately not folded in. It is a genuine permission
+// failure, not a disappearing scope, and skipping it would hide a project the
+// caller cannot read behind an empty listing.
+func scopeVanished(err error) bool {
+	return os.IsNotExist(err) || errors.Is(err, errorSharingViolation)
+}

--- a/internal/link/scope_windows_test.go
+++ b/internal/link/scope_windows_test.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package link
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// errorAccessDenied is Win32 ERROR_ACCESS_DENIED, the neighbouring error that
+// must keep propagating.
+const errorAccessDenied = syscall.Errno(5)
+
+// TestScopeVanished pins which read failures ListLinked is allowed to treat as
+// a scope that has been unlinked from under it. Everything else must propagate:
+// the race test can only ever exercise the disappearing cases, so the case that
+// must NOT be skipped is pinned here.
+//
+// The access-denied case is the reason
+// TestListLinkedToleratesAScopeRemovedMidListing skips on windows. Windows
+// reports a delete-pending directory as ERROR_ACCESS_DENIED, so the race it
+// drives produces the one error scopeVanished refuses to swallow. Swallowing it
+// would make a scope directory the caller genuinely cannot read report as no
+// packages, which is a worse trade than leaving the race unhandled here.
+func TestScopeVanished(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "not exist", err: os.ErrNotExist, want: true},
+		{
+			name: "not exist wrapped by ReadDir",
+			err:  &os.PathError{Op: "open", Path: filepath.Join(".lnpm", "@org"), Err: syscall.ERROR_FILE_NOT_FOUND},
+			want: true,
+		},
+		{name: "sharing violation", err: errorSharingViolation, want: true},
+		{
+			name: "sharing violation wrapped by ReadDir",
+			err:  &os.PathError{Op: "open", Path: filepath.Join(".lnpm", "@org"), Err: errorSharingViolation},
+			want: true,
+		},
+		{
+			name: "access denied",
+			err:  &os.PathError{Op: "open", Path: filepath.Join(".lnpm", "@org"), Err: errorAccessDenied},
+			want: false,
+		},
+		{name: "no error", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := scopeVanished(tt.err); got != tt.want {
+				t.Errorf("scopeVanished(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #170 and #236, which specify the same two bugs in `internal/link/link.go`.
Built to #236's acceptance criteria, the superset of the two, including its
recorded maintainer decision to **fix `ListLinked` rather than delete it**.

## The bugs

A scoped package lives at `.lnpm/@org/pkg`, an unscoped one directly at `.lnpm/pkg`.

1. `ListLinked` read only the top level, so a scoped package surfaced as the bare
   scope directory `@org` — not a usable package name. Two packages sharing a
   scope collapsed to one entry, and a mixed project returned a list where some
   entries were package names and others were scope directories, with nothing to
   tell them apart.
2. `Unlink` removed `.lnpm/@org/pkg` but never the emptied `.lnpm/@org`, so the
   existing empty-`.lnpm` cleanup never fired for a scoped package and a stale
   scope directory survived indefinitely — the very thing `ListLinked` then
   reported as a package.

## The change

- `ListLinked` descends one level into `@`-prefixed entries and reports
  `@scope/name`, joined with a literal `/` rather than `filepath.Join`, so the
  result is a package name on Windows too.
- The dot-prefix filter now applies at **both** levels: a relink temp directory
  is a sibling of its target, which for a scoped package puts it inside the
  scope.
- `Unlink` drops the emptied scope directory under both `.lnpm/` and
  `node_modules/`, after which the pre-existing empty-`.lnpm` cleanup fires.
  Extracted as `removeDirIfEmpty`, since the same check now appears three times.

**The deliberate asymmetry.** `removeDirIfEmpty` counts entries literally and
does *not* filter dot-prefixed names, unlike `ListLinked`. That is required, not
an oversight: a live relink of a sibling package writes a temp directory into the
scope, and a filter here would delete a directory that relink is writing into.
The doc comment states this, and a test pins it.

## Reviewed and fixed before landing

The first cut returned ENOENT hard from the scope descent while the outer read
twelve lines above maps a missing `.lnpm` to "no packages" — and the new
scope-directory cleanup is itself what makes that race reachable, so a concurrent
`Unlink` could fail a listing that would previously have succeeded. The descent
now skips a scope that vanished mid-listing; other read errors still propagate.

## Tests

Eight new tests across `link_test.go`, `link_atomic_test.go`, and
`link_failure_test.go`, placed by the concern each file already owns. Seven fail
against the unmodified implementation. `TestUnlinkKeepsScopeHoldingATempDirectory`
passes either way by design — it guards the over-fix direction, and was proven to
have teeth by mutating `removeDirIfEmpty` into the dot-filtering version, which
fails it on both assertions.

`TestListLinkedToleratesAScopeRemovedMidListing` reproduces the real interleaving
rather than simulating it, and detects the missing ENOENT skip probabilistically:
20/20 runs fail without it, 0/20 with it. It cannot fail once the skip is present,
so it carries no flakiness risk, but it is not a by-construction proof.

Gates: `go test ./...` under `umask 022`, `go vet`, `golangci-lint`, `gofmt`, plus
`windows/amd64` build and `windows/amd64`, `darwin/arm64`, `linux/arm64` vet.

## Known, out of scope

`ListLinked` filters on `DirEntry.IsDir()`, so a **live-linked** package (from
`add --link`, a symlink) stays invisible. Preserved exactly, at both levels. One
consequence worth naming: a live-linked *scoped* package previously surfaced as
the wrong name `@org`; it now surfaces as nothing. Wrong output became no output.
The underlying filter is unchanged and separately tracked.

Closes #170
Closes #236