### PR TITLE
Make hooks.skip_post_add actually skip the post-add hook

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -69,12 +69,16 @@ func RunPostAdd(projectPath string, runInstall bool) error {
 	}
 
 	cfg := config.Get()
+	if cfg.Hooks.SkipPostAdd {
+		debug.Log("hooks: skipping post-add (disabled via config)")
+		return nil
+	}
 
 	// Use custom hook if configured
 	if cfg.Hooks.PostAdd != "" {
 		fmt.Println("Running post-add hook...")
 		debug.Logf("hooks: running post_add: %s", cfg.Hooks.PostAdd)
-		return runScript(projectPath, cfg.Hooks.PostAdd)
+		return runScriptFn(projectPath, cfg.Hooks.PostAdd)
 	}
 
 	// Default: run package manager install
@@ -84,7 +88,7 @@ func RunPostAdd(projectPath string, runInstall bool) error {
 	fmt.Printf("Running %s to resolve dependencies...\n", installCmd)
 	debug.Logf("hooks: running install: %s", installCmd)
 
-	return runScript(projectPath, installCmd)
+	return runScriptFn(projectPath, installCmd)
 }
 
 // RunCustom runs a custom hook command
@@ -127,6 +131,12 @@ func runNpmScript(dir string, scriptName string) error {
 
 	return nil
 }
+
+// runScriptFn is runScript behind a variable so a test can check which command
+// RunPostAdd decided on without running it: that path ends in a real
+// package-manager install, which a test must never start. Only RunPostAdd goes
+// through it. Production code never reassigns it.
+var runScriptFn = runScript
 
 // runScript executes a shell command in the specified directory
 func runScript(dir string, cmdStr string) error {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -8,6 +8,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/config"
 )
 
 // orderLogName is the file each test lifecycle script appends its own name to.
@@ -169,11 +171,58 @@ func TestRunPrepare(t *testing.T) {
 	}
 }
 
+// useHooksConfig points config.Get at a temp config file holding hooks for the
+// rest of the test. The loaded config is memoized package-wide, so it is
+// cleared both now and on cleanup: otherwise this test would either read
+// whatever config another test loaded first, or pin its own on every test after
+// it.
+func useHooksConfig(t *testing.T, hooks config.HooksConfig) {
+	t.Helper()
+
+	t.Setenv("LNPM_CONFIG", filepath.Join(t.TempDir(), "config.yaml"))
+	if err := config.SaveConfig(&config.Config{Hooks: hooks}); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+}
+
+// ranScript is one command a hook handed to runScriptFn, and the directory it
+// asked for it to run in.
+type ranScript struct {
+	dir string
+	cmd string
+}
+
+// recordScripts replaces runScriptFn for the rest of the test with one that
+// records what it is handed and runs none of it, so a post-add test can check
+// what would have run without starting a real package-manager install. The
+// returned function reports the recorded scripts, in order.
+//
+// Don't use t.Parallel() in callers - this helper swaps the process-wide
+// runScriptFn var, so a caller must also not run alongside a test that does.
+func recordScripts(t *testing.T) func() []ranScript {
+	t.Helper()
+
+	var ran []ranScript
+	prev := runScriptFn
+	runScriptFn = func(dir string, cmdStr string) error {
+		ran = append(ran, ranScript{dir: dir, cmd: cmdStr})
+		return nil
+	}
+	t.Cleanup(func() { runScriptFn = prev })
+
+	return func() []ranScript { return ran }
+}
+
 func TestRunPostAdd(t *testing.T) {
 	tests := []struct {
 		name       string
+		hooks      config.HooksConfig
 		runInstall bool
-		createNPM  bool // create package-lock.json to trigger npm
+		createNPM  bool     // create package-lock.json to trigger npm
+		wantRan    []string // commands that should run (nil if none)
 	}{
 		{
 			name:       "skips when runInstall=false",
@@ -183,6 +232,40 @@ func TestRunPostAdd(t *testing.T) {
 			name:       "skips npm detection when runInstall=false",
 			createNPM:  true,
 			runInstall: false, // don't run install
+		},
+		{
+			name:       "runs the package manager install when runInstall=true",
+			createNPM:  true,
+			runInstall: true,
+			wantRan:    []string{"npm install --legacy-peer-deps"},
+		},
+		{
+			name:       "runs the custom post_add hook when runInstall=true",
+			hooks:      config.HooksConfig{PostAdd: "echo added"},
+			runInstall: true,
+			wantRan:    []string{"echo added"},
+		},
+		{
+			name:       "skip_post_add suppresses the package manager install",
+			hooks:      config.HooksConfig{SkipPostAdd: true},
+			createNPM:  true,
+			runInstall: true,
+		},
+		{
+			name:       "skip_post_add suppresses the custom post_add hook",
+			hooks:      config.HooksConfig{PostAdd: "echo added", SkipPostAdd: true},
+			runInstall: true,
+		},
+		{
+			name:       "runInstall=false still skips the custom post_add hook",
+			hooks:      config.HooksConfig{PostAdd: "echo added"},
+			runInstall: false,
+		},
+		{
+			name:       "runInstall=false skips regardless of skip_post_add",
+			hooks:      config.HooksConfig{PostAdd: "echo added", SkipPostAdd: true},
+			createNPM:  true,
+			runInstall: false,
 		},
 	}
 
@@ -198,11 +281,25 @@ func TestRunPostAdd(t *testing.T) {
 				}
 			}
 
-			err := RunPostAdd(tmpDir, tt.runInstall)
+			useHooksConfig(t, tt.hooks)
+			ran := recordScripts(t)
 
-			// When runInstall=false, should not error (skips install)
-			if !tt.runInstall && err != nil {
-				t.Errorf("unexpected error when runInstall=false: %v", err)
+			if err := RunPostAdd(tmpDir, tt.runInstall); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// Every hook runs in the project directory it was given, so check
+			// that alongside the commands themselves.
+			var cmds []string
+			for _, r := range ran() {
+				cmds = append(cmds, r.cmd)
+				if r.dir != tmpDir {
+					t.Errorf("%q ran in %q, want the project path %q", r.cmd, r.dir, tmpDir)
+				}
+			}
+
+			if !slices.Equal(cmds, tt.wantRan) {
+				t.Errorf("commands ran %v, want %v", cmds, tt.wantRan)
 			}
 		})
 	}


### PR DESCRIPTION
`HooksConfig.SkipPostAdd` was defined, settable in `~/.lnpm/config.yaml`, and
round-tripped through `lnpm config --edit` — but nothing ever read it. A user
setting `hooks.skip_post_add: true` and expecting `lnpm add --install` to stop
running the install step saw no change at all.

Wired up rather than deleted, per the issue's recommendation: the field has a
documented purpose, a natural implementation matching the existing `SkipPrepare`
pattern, and is already exposed in the config file, so removing it would break
anyone who had set it.

## Change

- `RunPostAdd` now checks `cfg.Hooks.SkipPostAdd` after loading config and
  returns early, mirroring `RunPrepare`. It sits before both the custom-hook
  branch and the default install, so it suppresses both.
- The `runInstall` gate stays first and unchanged — `skip_post_add` suppresses
  the hook even when `--install` was requested, since it is an explicit user
  override.

The gates are kept separate rather than combined as in `RunPrepare`, so each
emits its own debug reason.

## The test seam

`runScriptFn` is a variable alias for `runScript`, following this repo's
precedent for seaming an already-existing function (`createDirSymlinkFn` in
`internal/link/link.go`): the function survives under its own name, the seam is a
separately-named alias, and non-reassignment is documented.

Only `RunPostAdd` dispatches through it. `RunCustom` calls `runScript` directly —
it runs a user-supplied command that `TestRunCustom` deliberately executes for
real, and routing it through the alias would widen mutable dispatch over
arbitrary shell execution for no test that needs it.

The seam exists for one reason: the post-add path ends in a real package-manager
install, and **no test may ever start one** — including a revert check running
with the fix removed. All eight `TestRunPostAdd` cases install the recorder
before calling `RunPostAdd`, so nothing executes under revert or under mutation.

## Tests

`TestRunPostAdd` grew from 2 to 8 cases, covering all three acceptance criteria
including `runInstall=false` paired with `skip_post_add: true` — the "regardless"
half of criterion 3. Every recorded script's working directory is asserted, which
was mutation-checked: pointing the install at `"."` instead of the project path
fails the suite.

Two cases fail with the fix reverted; the other six pin pre-existing behaviour
for criteria 2 and 3 and pass either way, which is the correct shape for
"unchanged behaviour" criteria.

Gates: `go test ./...` under `umask 022`, `go vet`, `golangci-lint`, `gofmt`,
plus `windows/amd64` build and `windows/amd64`, `darwin/arm64`, `linux/arm64` vet.

## Noticed, not fixed

- `config.Get()` swallows its load error, so a malformed `~/.lnpm/config.yaml`
  silently yields defaults — a typo'd `skip_post_add` produces exactly the
  "nothing happened" symptom this issue was about.
- `runScript`'s error hint says "To skip this script, use --skip-hooks", but it
  also serves the post-add and custom-hook paths where that flag does not apply.
- `TestRunPrepare` skips entirely when `npm` is absent, so a runner without Node
  exercises none of the prepare-hook behaviour rather than failing.

Closes #171