### PR TITLE
Align build-time ldflags and surface commit and date in --version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,8 +22,8 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X main.Version={{.Version}}
-      - -X main.Commit={{.Commit}}
+      - -X main.Version=v{{.Version}}
+      - -X main.Commit={{.ShortCommit}}
       - -X main.Date={{.Date}}
 
 archives:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 
 # Build variables
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-LDFLAGS := -ldflags "-X main.Version=$(VERSION)"
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
+DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")
+LDFLAGS := -ldflags "-X main.Version=$(VERSION) -X main.Commit=$(COMMIT) -X main.Date=$(DATE)"
 BINARY := lnpm
 BUILD_DIR := bin
 

--- a/cmd/lnpm/main.go
+++ b/cmd/lnpm/main.go
@@ -50,7 +50,7 @@ func pickVersion(stamped string, info *debug.BuildInfo, ok bool) string {
 }
 
 func main() {
-	cli.SetVersion(resolveVersion())
+	cli.SetVersion(resolveVersion(), Commit, Date)
 	if err := cli.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pedrosousa13/lnpm/internal/debug"
@@ -11,13 +12,40 @@ import (
 
 var updateResult <-chan *update.Result
 
-var version = "dev"
+// Build stamps, mirroring the ldflags targets in cmd/lnpm. The placeholder
+// values mark a binary that was never stamped at build time.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
 
-// SetVersion sets the CLI version (called from main)
-func SetVersion(v string) {
-	version = v
-	rootCmd.Version = v
-	rootCmd.SetVersionTemplate(fmt.Sprintf("lnpm version %s\n", v))
+// SetVersion sets the CLI version and build stamps (called from main)
+func SetVersion(v, c, d string) {
+	version, commit, date = v, c, d
+	applyVersion()
+}
+
+// applyVersion pushes the current build stamps onto the root command. Both
+// init and SetVersion go through here so the two can never report differently.
+func applyVersion() {
+	rootCmd.Version = version
+	rootCmd.SetVersionTemplate(versionTemplate(version, commit, date))
+}
+
+// versionTemplate renders the --version output. Commit and date are omitted
+// when the binary carries no build stamp, rather than printing placeholders
+// that answer nobody's question about which commit a binary came from.
+func versionTemplate(ver, sha, builtAt string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "lnpm version %s\n", ver)
+	if sha != "" && sha != "none" {
+		fmt.Fprintf(&b, "commit: %s\n", sha)
+	}
+	if builtAt != "" && builtAt != "unknown" {
+		fmt.Fprintf(&b, "built:  %s\n", builtAt)
+	}
+	return b.String()
 }
 
 var rootCmd = &cobra.Command{
@@ -64,7 +92,7 @@ func Execute() error {
 }
 
 func init() {
-	rootCmd.SetVersionTemplate(fmt.Sprintf("lnpm version %s\n", version))
+	applyVersion()
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Enable debug logging")
 
 	// Add subcommands

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+// templateAfterInit records the root command's version template as the package
+// init left it, before any test mutates the build stamps.
+var templateAfterInit string
+
+func TestMain(m *testing.M) {
+	templateAfterInit = rootCmd.VersionTemplate()
+	os.Exit(m.Run())
+}
+
+func TestVersionTemplateShowsCommitAndDateWhenStamped(t *testing.T) {
+	got := versionTemplate("v1.11.0", "abc1234", "2026-08-20T10:00:00Z")
+
+	want := "lnpm version v1.11.0\ncommit: abc1234\nbuilt:  2026-08-20T10:00:00Z\n"
+	if got != want {
+		t.Fatalf("versionTemplate() = %q, want %q", got, want)
+	}
+}
+
+func TestVersionTemplateOmitsCommitAndDateWhenUnstamped(t *testing.T) {
+	got := versionTemplate("dev", "none", "unknown")
+
+	want := "lnpm version dev\n"
+	if got != want {
+		t.Fatalf("versionTemplate() = %q, want %q", got, want)
+	}
+}
+
+func TestVersionTemplateOmitsEmptyCommitAndDate(t *testing.T) {
+	got := versionTemplate("dev", "", "")
+
+	want := "lnpm version dev\n"
+	if got != want {
+		t.Fatalf("versionTemplate() = %q, want %q", got, want)
+	}
+}
+
+func TestSetVersionAppliesTemplateToRootCommand(t *testing.T) {
+	restoreBuildInfo(t)
+
+	SetVersion("v1.11.0", "abc1234", "2026-08-20T10:00:00Z")
+
+	if rootCmd.Version != "v1.11.0" {
+		t.Errorf("rootCmd.Version = %q, want %q", rootCmd.Version, "v1.11.0")
+	}
+	want := "lnpm version v1.11.0\ncommit: abc1234\nbuilt:  2026-08-20T10:00:00Z\n"
+	if got := rootCmd.VersionTemplate(); got != want {
+		t.Errorf("rootCmd.VersionTemplate() = %q, want %q", got, want)
+	}
+}
+
+// The package init applies the same template as SetVersion, so an unstamped
+// binary that never reaches SetVersion still prints the agreed shape.
+func TestInitAppliesUnstampedVersionTemplate(t *testing.T) {
+	want := "lnpm version dev\n"
+	if templateAfterInit != want {
+		t.Errorf("version template after init = %q, want %q", templateAfterInit, want)
+	}
+}
+
+// restoreBuildInfo puts the package-level build stamps and the root command's
+// version state back after a test mutates them.
+//
+// Don't use t.Parallel() in callers - this helper swaps the process-wide
+// version/commit/date vars and rootCmd's version state, so a caller must also
+// not run alongside a test that does.
+func restoreBuildInfo(t *testing.T) {
+	t.Helper()
+	prevVersion, prevCommit, prevDate := version, commit, date
+	prevCmdVersion, prevTemplate := rootCmd.Version, rootCmd.VersionTemplate()
+	t.Cleanup(func() {
+		version, commit, date = prevVersion, prevCommit, prevDate
+		rootCmd.Version = prevCmdVersion
+		rootCmd.SetVersionTemplate(prevTemplate)
+	})
+}


### PR DESCRIPTION
`make build` and a real release binary reported `--version` in two different
shapes, and two build-time variables were injected and then thrown away.

## Two decisions the brief left open

The issue deliberately leaves both to the implementer. Both were put to the
maintainer and decided before any code was written.

**Version format: `v`-prefixed.** The brief frames this as two build paths, but
there are three sources of the version string. The `go install` fallback
(`pickVersion`) returns Go's embedded module version, which is always
`v`-prefixed and gated by `semver.IsValid`, which requires the prefix. The
Makefile's `git describe` is `v`-prefixed too. Only GoReleaser's `{{.Version}}`
was bare — so `v`-prefixed makes all three agree by changing one line, where bare
would have required stripping in the `go install` path that this brief puts out
of scope as #143's territory.

**`Commit`/`Date`: surfaced, not removed** — per the issue's own rationale that
"which commit is this binary from" had no answer from `--version` alone.

## Change

- `Makefile` derives and injects `COMMIT` and `DATE` alongside `VERSION`, keeping
  the existing `?=` override-ability and fallback shape.
- `.goreleaser.yaml` injects `main.Version=v{{.Version}}` and switches
  `{{.Commit}}` to `{{.ShortCommit}}` — a 40-char SHA beside the Makefile's
  7-char one is the exact inconsistency AC 1 targets, and the issue itself names
  `git rev-parse --short HEAD` for the Makefile side.
- `internal/cli/root.go` gains `applyVersion()`, the single place that touches
  `rootCmd`'s version state. The two sites that previously set the template
  separately — `SetVersion` and `init()` — now both route through it, so they
  cannot drift again. That drift is what the issue was about, so updating both in
  parallel would have left the same trap.
- `versionTemplate` is a pure function, so the formatting is testable without
  touching the global `rootCmd`.

**`pickVersion` is byte-identical to `main`** — verified in review. It deliberately
rejects pseudo-versions so a local build cannot look like a release to the
updater, and none of that changed.

## Unstamped binaries omit the extra lines

A `go install` or plain `go build` binary has no stamp. Rather than printing
`commit: none` / `built: unknown`, those lines are omitted entirely — a
placeholder does not answer the question the vars exist to answer, it just adds a
line every consumer has to learn to ignore. Unstamped builds print exactly the
one line they print today.

## Verified output

Makefile-equivalent build:

```
lnpm version v1.12.0-53-g7079f81-dirty
commit: 7079f81
built:  2026-08-20T10:54:15Z
```

`goreleaser build --snapshot --single-target --clean`:

```
lnpm version v1.12.1-next
commit: 7079f81
built:  2026-08-20T10:54:29Z
```

Same three-line shape, same `v` prefix, same short-SHA form. Only the version
number differs.

Review separately confirmed that `v{{.Version}}` yields one `v`, not two —
GoReleaser's `{{.Version}}` is the tag with the `v` already stripped, unlike
`{{.Tag}}` — and that the updater's `TrimPrefix` handling in
`internal/cli/update.go` and `internal/update/update.go` stays safe in both
directions under the prefix change.

## Tests

New `internal/cli/root_test.go` covers the stamped and unstamped shapes, that
`SetVersion` applies the template to the root command, and that `init()` applies
it too. Verified by mutation rather than assertion alone: four mutants were
applied, and every test kills at least one.

One of those tests was originally hollow — it called `applyVersion()` itself and
asserted the result, a tautology that never observed `init()` and survived the
mutant it was meant to catch. It was rewritten to capture the template in
`TestMain`, before any test can mutate it, and now fails against both that mutant
and a second one removing the `init()` call entirely.

Gates: `go test ./...` under `umask 022`, `go vet`, `golangci-lint`, `gofmt`,
plus `windows/amd64` build and `windows/amd64`, `darwin/arm64`, `linux/arm64` vet.

## Not verifiable here

**`make build` was never executed — `make` is not installed on the machine this
was developed on.** The Makefile's ldflags were verified by computing `VERSION`,
`COMMIT` and `DATE` with the exact shell expressions the Makefile uses and passing
the resulting `-ldflags` string to a direct `go build`. That proves the ldflags
produce the intended stamps; it does **not** prove GNU Make parses the new lines
correctly. They mirror the existing `VERSION ?=` line's shape exactly, so the risk
is low, but it is unverified and worth a glance from anyone who has `make`.

Also unverified: the real release path, where `{{.Version}}` is a clean tag rather
than a snapshot `-next` string, and non-amd64 GoReleaser targets.

Closes #177