### PR TITLE
Correct status, add and push descriptions, and fold a stray changelog block into 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,7 +193,6 @@
 * improve perf by using hard links ([465b64b](https://github.com/pedrosousa13/lnpm/commit/465b64bb73c22e7897dfe2cc116fb8ab4d0b1002))
 * lnpm update command ([743e09f](https://github.com/pedrosousa13/lnpm/commit/743e09fbc0e2f197456db49632e480ca2e6d4816))
 
-## [Unreleased]
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ lnpm push
 | `lnpm remove <pkg>` | Remove linked package |
 | `lnpm pull [pkg...]` | Sync linked packages with the store (all of them when no name is given) |
 | `lnpm push` | Push changes to all linked projects |
-| `lnpm status` | Show current project's links |
+| `lnpm status` | Show all published packages and active links across every project |
 | `lnpm list` | List this project's linked packages (`--store` lists the store, `--projects` lists consumers) |
 | `lnpm check` | Fail if package.json still has lnpm references (pre-publish guard) |
 | `lnpm doctor` | Diagnose issues |
@@ -320,7 +320,7 @@ lnpm publish    # Automatically builds TypeScript → dist/
 
 # In your app
 cd ~/code/my-app
-lnpm add my-library   # Links and runs npm install
+lnpm add my-library   # Links only (pass --install to also run npm install)
 
 # Make changes to library
 cd ~/code/my-library
@@ -367,7 +367,7 @@ Debug output goes to stderr with timestamps, useful for diagnosing slow operatio
 1. **Publish** — Selects files with lnpm's own filtering (see [File Filtering](#file-filtering)), strips lifecycle scripts (`prepare`/`prepublish`), resolves `workspace:` dependency specifiers to versions npm can install (see [Monorepo Support](#monorepo-support)), then reflinks or copies to `~/.lnpm/store/{name}/{hash}/`
 2. **Add** — Creates reflinks or hard links from store to `project/.lnpm/{package}/`, updates package.json to `file:.lnpm/{package}`
 3. **Symlink** — Links `node_modules/{package}` → `.lnpm/{package}`
-4. **Push** — Updates store and re-links changed files
+4. **Push** — Updates store and re-links all files to consuming projects
 5. **Auto .gitignore** — Optionally manages `.lnpm/` in `.gitignore` (enabled by default)
 
 **Note:** `lnpm add` does NOT run `npm install` automatically (matches yalc) — pass `--install` or run it yourself if you need to resolve peer dependencies. `lnpm remove`, however, runs your package manager's install afterward to restore the removed dependency.


### PR DESCRIPTION
Four small, independent factual fixes. Documentation only — no Go source touched.

| Where | Before | After |
| --- | --- | --- |
| `README.md` commands table | `Show current project's links` | `Show all published packages and active links across every project` |
| `README.md` walkthrough | `# Links and runs npm install` | `# Links only (pass --install to also run npm install)` |
| `README.md` how-it-works | `re-links changed files` | `re-links all files to consuming projects` |
| `CHANGELOG.md` | stray `## [Unreleased]` between `[1.2.0]` and `[1.1.1]` | header removed; its subsections fall under `[1.2.0]` |

## Every claim was re-verified against current code, and one was stale

The brief closes by saying its line numbers are hints as of filing, not authority, and that every claim must be verified before being documented. That mattered — **the issue's stated mechanism for the push fix no longer exists.**

The issue says `Linker.Link` does `os.RemoveAll(lnpmPath)` followed by a full re-create. The relink-atomicity work has since replaced that: the package is built in a temp directory and rename-swapped into place, with the previous directory renamed aside rather than deleted first. The only remaining `RemoveAll(lnpmPath)` calls are in unlink paths.

The *conclusion* still holds, for a better reason than the issue gave. `Link` materialises every entry of its `files` slice into a fresh temp directory with no comparison against what is already linked — and because the rename-swap means the destination starts empty by construction, incremental reuse is structurally impossible today, not merely unimplemented. (#193, which would make it incremental, is still open.) The new wording describes the current implementation rather than transcribing the issue's proposed sentence.

All four line-number hints were stale; all four claims were confirmed accurate against the code as it stands.

## Verification

The four acceptance greps all return nothing:

```
grep -n "Show current project's links" README.md
grep -n "Links and runs npm install" README.md
grep -n "re-links changed files" README.md
grep -n "## \[Unreleased\]" CHANGELOG.md
```

`status --help` and `add --help` were checked against the new wording and agree. `git show 465b64b --stat` and `git tag --contains 465b64b` confirm the folded changelog content describes v1.2.0 work; the merge is a one-line header deletion, so `[1.1.1]` is untouched and descending version order is preserved. The two blank lines left behind match the file's release-please convention.

`ARCHITECTURE.md` is unchanged, per acceptance criterion 5 — its "New in v1.2.0" reflink caption is correct.

Gates: `go test ./...` under `umask 022`, `go vet`, `golangci-lint`, `gofmt` — all clean. Cross-compile checks were not run, since no Go source was touched.

## Noticed, deliberately not fixed

Three places where the new prose is less precise than it could be without being wrong. Each mirrors wording that already exists elsewhere in the docs, and tightening them is outside this issue's four criteria:

- The status row omits the additional "Current Project" section `RunStatus` prints when the cwd has a lockfile. `ARCHITECTURE.md` omits it too.
- The add comment reads as though `--install` alone gates the install; `pure` also suppresses it, and the multi-package path additionally requires `added > 0`. The existing Note further down the README is worded the same way.
- Push skips projects added with `--link` (`IsLiveLinked`), so it does not relink literally every consumer. The "all" attaches to *files*, so the sentence is not false, but a reader could take it either way — and the pre-existing table row has the same gap.

Also pre-existing: `README.md` step 2 omits the parallel-copy fallback, the troubleshooting section carries an undated "Fixed in latest version" claim, and `CHANGELOG.md` mixes release-please and Keep-a-Changelog conventions — now visible within one entry. Normalising that is doc restructuring, explicitly out of scope.

Closes #203