### PR TITLE
De-duplicate the version-mismatch error and drop the ST1005 exclusion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,21 +39,3 @@ linters:
       # against, and because narrowing it is a separate piece of work. errcheck
       # remains active for every call that does not match the names above.
       - std-error-handling
-
-    rules:
-      # ST1005 ("error strings should not end with punctuation") reached this
-      # repo only because v2 merged stylecheck into the default-enabled
-      # staticcheck. It flags one message, duplicated verbatim at two call
-      # sites (internal/cli/add.go:90 and :276): a multi-sentence user-facing
-      # string that needs rewording, and ideally de-duplicating, rather than a
-      # mechanical trailing-period strip.
-      #
-      # This rule suppresses ST1005 for internal/cli/add.go as a whole, not
-      # just those two lines, so a new punctuation-terminated error string
-      # added to this file would also go unreported. Only ST1005 is affected —
-      # every other staticcheck check still applies here.
-      # Follow-up: reword the message, de-duplicate it, and drop this rule.
-      - path: internal/cli/add\.go
-        linters:
-          - staticcheck
-        text: "ST1005:"

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -106,7 +106,7 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 				return
 			}
 			if version != "" && pkg.Version != version {
-				result.err = fmt.Errorf("version %s of %s not found in store (latest published is %s). Re-publish %s to update.", version, name, pkg.Version, name)
+				result.err = versionNotInStoreError(version, name, pkg.Version)
 				results <- result
 				return
 			}
@@ -413,7 +413,7 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useL
 		return fmt.Errorf("package %s not found in store. Did you run 'lnpm publish' in the package directory?", name)
 	}
 	if version != "" && pkg.Version != version {
-		return fmt.Errorf("version %s of %s not found in store (latest published is %s). Re-publish %s to update.", version, name, pkg.Version, name)
+		return versionNotInStoreError(version, name, pkg.Version)
 	}
 
 	if useLink {
@@ -561,6 +561,24 @@ func parsePackageSpec(spec string) (name, version string) {
 		return spec[:idx], spec[idx+1:]
 	}
 	return spec, ""
+}
+
+// versionNotInStoreError reports that the store holds a different version of
+// name than the one the user asked for, shared by the parallel and the
+// single-package add paths so both tell the user the same thing.
+//
+// The parameters are declared in the order the message reads them. All three
+// are plain strings, so a caller that swaps two still compiles and quietly
+// produces a message that lies about which version is which; keeping
+// declaration order and interpolation order identical is what makes such a
+// swap visible at the call site.
+//
+// The remedy is a trailing parenthetical rather than a second sentence: the
+// parallel path wraps this error as "<spec>: %w", so the string has to compose
+// as a clause, and a terminal period would read badly there as well as trip
+// staticcheck's ST1005.
+func versionNotInStoreError(requested, name, stored string) error {
+	return fmt.Errorf("version %s of %s not found in store (latest published is %s; re-publish %s to update)", requested, name, stored, name)
 }
 
 // packageJSONDeps is what reading package.json tells us about a dependency


### PR DESCRIPTION
#178 committed the repo's first `.golangci.yml` and reached a clean run by scoping out two staticcheck ST1005 findings in `internal/cli/add.go`. That exclusion was deliberate config debt; this pays it off.

## The reword

```
- "version %s of %s not found in store (latest published is %s). Re-publish %s to update."
+ "version %s of %s not found in store (latest published is %s; re-publish %s to update)"
```

The issue is explicit that a mechanical trailing-period strip was *not* wanted — `"...Re-publish %s to update"` reads worse, and ST1005's real intent is that error strings compose cleanly when a caller wraps them. The parallel add path wraps this as `"%s: %w"`, so it has to read as a clause:

```
left-pad@1.2.0: version 1.2.0 of left-pad not found in store (latest published is 1.3.0; re-publish left-pad to update)
```

**ST1005's actual rule was determined empirically, not guessed** — ten candidate strings probed against the linter. It fires on exactly four terminal runes: `.`, `:`, `!`, `\n`. It does **not** fire on `?` (confirming the triage correction about the neighbouring message) nor on `)`. Interior periods are never examined, only the final rune. That is what made the parenthetical restructure available.

## The de-duplication

The brief calls this "arguably the more valuable half". The string now lives once, in `versionNotInStoreError`, modelled on the existing `insufficientPrivilegesError` in `internal/cli/update.go` — the package already had exactly this shape for exactly this reason, and its doc comment likewise justifies its deviation from the `failed to X: %w` convention.

Review caught a hazard in the first cut: the helper declared `(name, requested, stored)` but interpolated `(requested, name, stored, name)`. Three untyped strings whose declaration order disagreed with the message meant `versionNotInStoreError(name, pkg.Version, version)` would compile cleanly and produce a message that lies about which version is which — uncatchable by the compiler, and by any test, since nothing asserts on the string. The signature now reads in message order, which is also **exactly the argument order the original inline `fmt.Errorf` used**, so the extraction permutes nothing relative to the code it replaces. The doc comment records why, so a later tidy-up does not reintroduce it.

Rendering was verified byte-identical before and after the reorder by calling the real function, not by inspection.

## The debt is paid, not relocated

The exclusion rule and its explanatory comment are gone from `.golangci.yml`. The whole `exclusions.rules` key was dropped rather than left as an empty list — in golangci-lint v2 those are behaviourally identical, and an empty list with no comment is dead config. The `std-error-handling` preset is untouched, per the brief.

```
$ golangci-lint run ./...
0 issues.
```

That is the acceptance criterion that matters, and it holds **with the rule absent**. No `//nolint` or `//lint:ignore` was added to compensate — verified repo-wide.

Removing the exclusion also retires a risk its own deleted comment admitted: it suppressed ST1005 for all of `add.go`, not just those two lines, so any new punctuation-terminated error string in that file would have gone unreported.

## Untouched, as scoped

The question-mark message at `add.go:413` is byte-identical to `main` — ST1005 does not flag it, and the triage correction says to leave it. No other error string in the codebase changed. No test asserts on the reworded message (verified independently by review across tests, docs and `.planning/`); the two `tests/pull*_test.go` assertions pin a different message from `internal/cli/pull.go`, in an unchanged file.

Gates: `go test ./...` under `umask 022`, `go vet`, `golangci-lint`, `gofmt`, plus `windows/amd64` build and `windows/amd64`, `darwin/arm64`, `linux/arm64` vet.

## Noticed, not fixed

`internal/cli/pull.go:93` builds a structurally similar "not found in store" message with its own remedial hint, near-duplicating `add.go:413`'s wording with different punctuation and casing. Consolidating them is the natural next increment, but both are out of scope here and neither trips the linter — and two tests pin `pull.go`'s wording, so it is not a free change.

Closes #230