### PR TITLE
Assert permissions against a reference create instead of a literal mode

### DIFF
--- a/internal/db/db_permissions_test.go
+++ b/internal/db/db_permissions_test.go
@@ -126,7 +126,27 @@ func TestOpen_DBDirectoryPermissions(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
-	t.Setenv("LNPM_STORE", tmpDir)
+	// Point the store at a path that does not exist yet, so the directory under
+	// test is the one initDB creates rather than the one t.TempDir() creates.
+	// The singleton has to be reset for initDB to run at all.
+	storeDir := filepath.Join(tmpDir, "store")
+	t.Setenv("LNPM_STORE", storeDir)
+	ResetForTesting()
+	defer ResetForTesting()
+
+	// Reference directory, created with the same mode argument initDB uses.
+	// Comparing against it pins the relationship the code is responsible for -
+	// the mode a plain os.MkdirAll(path, 0755) yields here - instead of a
+	// literal that only holds under a permissive umask. A Chmod after creation
+	// would ignore the umask and force 0755, and this comparison catches that.
+	refDir := filepath.Join(tmpDir, "reference")
+	if err := os.MkdirAll(refDir, 0755); err != nil {
+		t.Fatalf("Failed to create reference dir: %v", err)
+	}
+	refInfo, err := os.Stat(refDir)
+	if err != nil {
+		t.Fatalf("Failed to stat reference dir: %v", err)
+	}
 
 	// Open database
 	db, err := GetDB()
@@ -138,16 +158,14 @@ func TestOpen_DBDirectoryPermissions(t *testing.T) {
 	}()
 
 	// Check db directory permissions
-	dbDir := tmpDir
-	info, err := os.Stat(dbDir)
+	info, err := os.Stat(storeDir)
 	if err != nil {
 		t.Fatalf("Failed to stat db directory: %v", err)
 	}
 
-	mode := info.Mode() & 0777
-	expectedMode := os.FileMode(0755)
-	if mode != expectedMode {
-		t.Errorf("Expected db directory permissions %o, got %o", expectedMode, mode)
+	if mode := info.Mode().Perm(); mode != refInfo.Mode().Perm() {
+		t.Errorf("Expected db directory permissions %o (as os.MkdirAll(path, 0755) yields under this umask), got %o",
+			refInfo.Mode().Perm(), mode)
 	}
 }
 

--- a/internal/link/link_permissions_test.go
+++ b/internal/link/link_permissions_test.go
@@ -1,13 +1,65 @@
 package link
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/pack"
 )
+
+// referenceSeq gives every reference artifact a path of its own. Naming them
+// after the mode instead would make a second call with a read-only mode reopen
+// the first call's artifact, which fails outright for a file: os.WriteFile
+// opens O_WRONLY, and 0444 is not writable.
+var referenceSeq atomic.Uint64
+
+// referenceDirMode returns the permission bits os.MkdirAll(path, mode) actually
+// produces inside dir under the process umask.
+//
+// Permission assertions compare against this rather than against mode itself,
+// because mode is only what the caller asked for: creation applies the umask, so
+// os.MkdirAll(path, 0755) yields 0755 under umask 022 and 0700 under umask 0077.
+// Asserting the literal pins one umask and makes the suite unrunnable under any
+// other. Asserting the reference pins the relationship the linker is actually
+// responsible for - "the mode a plain create with this argument yields here" -
+// and still fails if creation stops respecting the umask, which is exactly the
+// bug shape a Chmod after creation produces, since Chmod is not masked.
+//
+// These helpers live here rather than in link_umask_unix_test.go because they
+// use only os, and the tests calling them are compiled on every platform even
+// though they skip on Windows.
+func referenceDirMode(t *testing.T, dir string, mode os.FileMode) os.FileMode {
+	t.Helper()
+	ref := filepath.Join(dir, fmt.Sprintf(".reference-dir-%o-%d", mode.Perm(), referenceSeq.Add(1)))
+	if err := os.MkdirAll(ref, mode); err != nil {
+		t.Fatalf("Failed to create reference directory: %v", err)
+	}
+	info, err := os.Stat(ref)
+	if err != nil {
+		t.Fatalf("Failed to stat reference directory: %v", err)
+	}
+	return info.Mode().Perm()
+}
+
+// referenceFileMode is referenceDirMode's counterpart for files: the permission
+// bits os.WriteFile(path, data, mode) actually produces inside dir under the
+// process umask.
+func referenceFileMode(t *testing.T, dir string, mode os.FileMode) os.FileMode {
+	t.Helper()
+	ref := filepath.Join(dir, fmt.Sprintf(".reference-file-%o-%d", mode.Perm(), referenceSeq.Add(1)))
+	if err := os.WriteFile(ref, []byte("reference"), mode); err != nil {
+		t.Fatalf("Failed to create reference file: %v", err)
+	}
+	info, err := os.Stat(ref)
+	if err != nil {
+		t.Fatalf("Failed to stat reference file: %v", err)
+	}
+	return info.Mode().Perm()
+}
 
 // TestLink_ReadOnlyDestination tests linking to read-only destination
 func TestLink_ReadOnlyDestination(t *testing.T) {
@@ -142,6 +194,8 @@ func TestLink_DirectoryPermissions(t *testing.T) {
 		t.Fatalf("Failed to link: %v", err)
 	}
 
+	expectedMode := referenceDirMode(t, tmpDir, 0755)
+
 	// Check .lnpm directory permissions
 	lnpmDir := filepath.Join(projectDir, ".lnpm")
 	info, err := os.Stat(lnpmDir)
@@ -149,10 +203,8 @@ func TestLink_DirectoryPermissions(t *testing.T) {
 		t.Fatalf("Failed to stat .lnpm dir: %v", err)
 	}
 
-	mode := info.Mode() & 0777
-	expectedMode := os.FileMode(0755)
-	if mode != expectedMode {
-		t.Errorf("Expected .lnpm mode %o, got %o", expectedMode, mode)
+	if mode := info.Mode().Perm(); mode != expectedMode {
+		t.Errorf("Expected .lnpm mode %o (as os.MkdirAll(path, 0755) yields under this umask), got %o", expectedMode, mode)
 	}
 
 	// Check nested directory permissions
@@ -162,9 +214,8 @@ func TestLink_DirectoryPermissions(t *testing.T) {
 		t.Fatalf("Failed to stat nested dir: %v", err)
 	}
 
-	mode = info.Mode() & 0777
-	if mode != expectedMode {
-		t.Errorf("Expected nested dir mode %o, got %o", expectedMode, mode)
+	if mode := info.Mode().Perm(); mode != expectedMode {
+		t.Errorf("Expected nested dir mode %o (as os.MkdirAll(path, 0755) yields under this umask), got %o", expectedMode, mode)
 	}
 }
 
@@ -198,17 +249,10 @@ func TestLink_PackageDirectoryRespectsUmask(t *testing.T) {
 	}
 	fileInfos := pack.FileInfoFromStore(storeDir, files)
 
-	// Reference directory, created the way Link used to create the package
-	// directory. Comparing against it pins umask-relative behaviour rather
-	// than a hardcoded mode.
-	refDir := filepath.Join(tmpDir, "reference")
-	if err := os.MkdirAll(refDir, 0755); err != nil {
-		t.Fatalf("Failed to create reference dir: %v", err)
-	}
-	refInfo, err := os.Stat(refDir)
-	if err != nil {
-		t.Fatalf("Failed to stat reference dir: %v", err)
-	}
+	// Reference mode, from a directory created the way Link used to create the
+	// package directory. Comparing against it pins umask-relative behaviour
+	// rather than a hardcoded mode.
+	expectedMode := referenceDirMode(t, tmpDir, 0755)
 
 	linker := New(projectDir)
 	if _, err := linker.Link("test-pkg", storeDir, fileInfos); err != nil {
@@ -220,9 +264,9 @@ func TestLink_PackageDirectoryRespectsUmask(t *testing.T) {
 		t.Fatalf("Failed to stat package dir: %v", err)
 	}
 
-	if pkgInfo.Mode().Perm() != refInfo.Mode().Perm() {
+	if pkgInfo.Mode().Perm() != expectedMode {
 		t.Errorf("Expected .lnpm/test-pkg mode %o (as os.MkdirAll(path, 0755) yields under this umask), got %o",
-			refInfo.Mode().Perm(), pkgInfo.Mode().Perm())
+			expectedMode, pkgInfo.Mode().Perm())
 	}
 }
 
@@ -268,10 +312,9 @@ func TestLink_NodeModulesPermissions(t *testing.T) {
 		t.Fatalf("Failed to stat node_modules: %v", err)
 	}
 
-	mode := info.Mode() & 0777
-	expectedMode := os.FileMode(0755)
-	if mode != expectedMode {
-		t.Errorf("Expected node_modules mode %o, got %o", expectedMode, mode)
+	expectedMode := referenceDirMode(t, tmpDir, 0755)
+	if mode := info.Mode().Perm(); mode != expectedMode {
+		t.Errorf("Expected node_modules mode %o (as os.MkdirAll(path, 0755) yields under this umask), got %o", expectedMode, mode)
 	}
 
 	// Check symlink exists
@@ -323,10 +366,9 @@ func TestLink_ScopedPackageDirectoryPermissions(t *testing.T) {
 		t.Fatalf("Failed to stat @org dir: %v", err)
 	}
 
-	mode := info.Mode() & 0777
-	expectedMode := os.FileMode(0755)
-	if mode != expectedMode {
-		t.Errorf("Expected @org dir mode %o, got %o", expectedMode, mode)
+	expectedMode := referenceDirMode(t, tmpDir, 0755)
+	if mode := info.Mode().Perm(); mode != expectedMode {
+		t.Errorf("Expected @org dir mode %o (as os.MkdirAll(path, 0755) yields under this umask), got %o", expectedMode, mode)
 	}
 }
 
@@ -481,7 +523,22 @@ func TestLink_PreservesVariousPermissions(t *testing.T) {
 		t.Fatalf("Failed to link: %v", err)
 	}
 
-	// Verify each file's permissions
+	// Verify each file's permissions.
+	//
+	// The fixture above is written with os.WriteFile(path, data, tc.mode), so it
+	// is masked by the umask exactly as the reference is, and the two degrade
+	// together: under umask 0077 the 0755 case and its reference both land at
+	// 0700, and this loop cannot see an executable bit being stripped. What it
+	// does pin is that the linked file carries the store file's *actual* mode.
+	// copyFile chmods to srcInfo.Mode() for that reason; were it to use the
+	// recorded pack.FileEntryData.Mode instead, the 0644 case would meet a 0600
+	// reference under umask 0077 and fail here.
+	//
+	// The separate guarantee - that a mode survives a restrictive umask at all -
+	// belongs to TestCopyFile_PreservesModeUnderRestrictiveUmask, which calls
+	// copyFile directly. It has to: store and project share one temp directory
+	// here, so Link hard links and the linked file shares the store entry's
+	// inode rather than being copied.
 	for _, tc := range testCases {
 		linkedFile := filepath.Join(projectDir, ".lnpm", "perm-pkg", tc.name)
 		info, err := os.Stat(linkedFile)
@@ -490,9 +547,10 @@ func TestLink_PreservesVariousPermissions(t *testing.T) {
 			continue
 		}
 
-		actualMode := info.Mode() & 0777
-		if actualMode != tc.mode {
-			t.Errorf("File %s: expected mode %o, got %o", tc.name, tc.mode, actualMode)
+		expectedMode := referenceFileMode(t, tmpDir, tc.mode)
+		if actualMode := info.Mode().Perm(); actualMode != expectedMode {
+			t.Errorf("File %s: expected mode %o (as os.WriteFile(path, data, %o) yields under this umask), got %o",
+				tc.name, expectedMode, tc.mode, actualMode)
 		}
 	}
 }


### PR DESCRIPTION
Four permission tests in `internal/link` asserted literal `0755`/`0644`/`0640` and failed under `umask 077` — so the suite could not be run under a restrictive umask, which is the only condition where a whole class of bug is detectable. That class is real: #137's first cut used `os.Chmod` to restore a mode `os.MkdirAll` had set, and because `Chmod` ignores umask while `MkdirAll` respects it, the result was a world-readable directory under `umask 077` and identical output under `umask 022`. CI runs at 022, so it would have passed silently.

Test-only change. No production file is in the commit.

## The conversion

Each assertion now compares against a reference directory or file created in the same temp directory with the same mode argument — pinning the relationship the code is actually responsible for ("the same mode a plain `MkdirAll`/`WriteFile` would produce here") rather than an absolute value that only holds at one umask. Factored into `referenceDirMode` / `referenceFileMode`, and the pre-existing `TestLink_PackageDirectoryRespectsUmask` was moved onto the shared helper rather than left as a hand-rolled copy.

Each reference gets a unique path via an atomic counter. Naming them after the mode would make a second call with a read-only mode reopen the first call's artifact, which fails outright for a file — `os.WriteFile` opens `O_WRONLY` and `0444` is not writable. That trap was demonstrated rather than reasoned about:

```
old, call 1: <nil>
old, call 2: open .../.reference-file-444: permission denied
new, call 1: <nil>
new, call 2: <nil>
```

## Verified by mutation, because "stopped asserting" is not a fix

The acceptance criterion that separates a real fix from a weakened test is that the tests must still **fail** when creation ignores umask. Seven mutations were applied to production code under `umask 077`, each reverted afterwards:

| | Mutation | Result |
|---|---|---|
| M1 | `Chmod(parentDir, 0755)` after `MkdirAll` in `Link` | FAIL |
| M2 | `Chmod(filepath.Dir(dstPath), 0755)` in link worker | FAIL |
| M3 | `Chmod(nodeModulesDir, 0755)` in `createNodeModulesSymlink` | FAIL |
| M4 | `Chmod(filepath.Dir(linkPath), 0755)` scope dir | FAIL |
| M5 | `Chmod(dstPath, f.Mode)` after materialising | FAIL (3 of 4 cases; the `0600` case correctly silent) |
| M6 | `Chmod(path, 0755)` after `os.Mkdir` in `newTempDir` | FAIL |
| M7 | `Chmod(storePath, 0755)` after `MkdirAll` in `initDB` | FAIL |

Seven for seven. All were re-run after the helper renaming rather than only the affected ones.

Review separately confirmed the teeth **structurally**, without re-running: every reference is an independent `os.MkdirAll`/`os.WriteFile` inside the test, never the code under test, always in the same directory. No assertion compares an artifact against itself.

```
( umask 077; go test ./internal/link/... ./internal/db/... )  ok
( umask 022; ... )  ok
( umask 002; ... )  ok
```

## `internal/db` — the test was asserting nothing at all

The issue asked whether `TestOpen_DBDirectoryPermissions` warranted the same treatment. It turned out to be worse than a hardcoded literal.

It set `LNPM_STORE` to `t.TempDir()` and then stat'd `t.TempDir()` itself. `initDB`'s `os.MkdirAll(storePath, 0755)` is a no-op on an existing directory, so the test measured **Go's `testing` package** — whose per-call `TempDir` subdirectory is created with `os.Mkdir(dir, 0777)` and therefore lands at exactly `0777 &^ umask`. That is why the project convention was pinned to `022` specifically rather than "anything permissive": at 002 it read `775`, at 077 `700`, and only 022 gave the `755` it expected.

It was also the only test in the file without `ResetForTesting`. It passed only because the preceding test's `defer ResetForTesting()` happened to clear the `sync.Once`, and it leaked the singleton forward into `TestConcurrentAccess_WithPermissions`, whose leading `ResetForTesting()` exists to compensate.

It now points `LNPM_STORE` at a non-existent subdirectory so `initDB` genuinely creates the directory under test, resets the singleton like its neighbours, and compares against a reference.

## The `umask 022` convention can be relaxed — but not retired outright

`( umask 002; go test ./... )` now passes, so this machine's natural umask works and the wrapper subshell is no longer needed day to day.

`( umask 077; go test ./... )` still fails in exactly four places, all the same hardcoded-literal shape and all taking the same fix:

```
internal/gitignore  TestEnsureInGitignore_TempFilePermissions
internal/gitignore  TestRemoveFromGitignore_PreservesPermissions
internal/store      TestStore_DestinationDirCreation
internal/store      TestGetStorePath_Permissions
```

Those four are the only remaining blockers to a fully umask-agnostic suite. They are out of scope here — the issue names `internal/link` and `internal/db` and nothing else — and are a clean follow-up.

The convention appears in no tracked doc, CI file, or Makefile, so there is nothing in-repo to update.

## Noticed, not fixed

- The four blockers above.
- `TestOpen_StorePathPermissions`, next door in `internal/db`, still stats `tmpDir` and still lacks `ResetForTesting` — the same defect shape. Left alone under surgical-changes discipline; its writable-bit assertion is umask-independent, so it is not currently wrong.
- `TestLink_PreservesVariousPermissions` never exercises `copyFile`: store and project share one temp directory, so `Link` hard links and the linked file shares the store entry's inode. Its mode is equal by construction rather than by preservation. The copy path is covered by `TestCopyFile_PreservesModeUnderRestrictiveUmask`, and a comment now records this so the `0700` reading under a restrictive umask is not misread as a coverage gap.

Closes #234