### PR TITLE
Fail workspace expansion when a glob pattern will not parse

### DIFF
--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -2,6 +2,8 @@ package workspace
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,6 +32,18 @@ func Detect(startPath string) (*Workspace, error) {
 	current := startPath
 	for {
 		ws, err := detectWorkspaceAt(current)
+		// A malformed glob pattern is a config error, not a "no workspace
+		// here" signal. Walking past it would end in "no workspace found",
+		// which hides the offending pattern from the user, and docs/adr/0001
+		// requires a malformed pattern to abort naming the pattern. Every
+		// other failure keeps the existing walk-up behaviour.
+		//
+		// doublestar.ErrBadPattern is path.ErrBadPattern, so this guard would
+		// also catch a bad-pattern error raised by path.Match anywhere under
+		// detectWorkspaceAt. Nothing under there calls path.Match today.
+		if errors.Is(err, doublestar.ErrBadPattern) {
+			return nil, err
+		}
 		if err == nil && ws != nil {
 			return ws, nil
 		}
@@ -156,6 +170,10 @@ func parsePackageJSONWorkspace(root, path string) (*Workspace, error) {
 // expandGlobs expands workspace glob patterns to actual package directories.
 // Patterns prefixed with "!" are negations: they are collected while the
 // included patterns are expanded, then subtracted from the result.
+//
+// A pattern that will not parse fails the whole expansion, includes and
+// negations alike: a swallowed negation failure publishes the package the
+// config excluded, which docs/adr/0001 classifies as a bug.
 func expandGlobs(root string, patterns []string) ([]string, error) {
 	var packages []string
 	var negations []string
@@ -168,10 +186,14 @@ func expandGlobs(root string, patterns []string) ([]string, error) {
 			continue
 		}
 
-		// Expand glob
+		// Expand glob. The only failure Glob can report here is a malformed
+		// pattern, so this aborts on a config typo and never on a transient
+		// filesystem condition. An include failure fails closed, which
+		// docs/adr/0001 leaves open, but it follows the negation loop's rule
+		// so the two are handled alike.
 		matches, err := doublestar.Glob(os.DirFS(root), pattern)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("failed to expand workspace pattern %q: %w", pattern, err)
 		}
 
 		for _, match := range matches {
@@ -198,7 +220,7 @@ func expandGlobs(root string, patterns []string) ([]string, error) {
 	for _, pattern := range negations {
 		matches, err := doublestar.Glob(os.DirFS(root), pattern)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("failed to expand workspace pattern %q: %w", "!"+pattern, err)
 		}
 
 		for _, match := range matches {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -105,6 +106,80 @@ func TestExpandGlobsSkipsDirectoriesWithoutPackageJSON(t *testing.T) {
 	}
 
 	assertPackages(t, packages, []string{pkgA})
+}
+
+func TestExpandGlobsMalformedNegationFailsAndKeepsNegatedPackageOut(t *testing.T) {
+	root := t.TempDir()
+	writePackage(t, root, "packages/public-api")
+	writePackage(t, root, "packages/internal-secret")
+
+	packages, err := expandGlobs(root, []string{"packages/*", "!packages/[internal"})
+	if err == nil {
+		t.Fatalf("Expected an error for the malformed negation, got nil and packages %v", packages)
+	}
+	if !strings.Contains(err.Error(), "packages/[internal") {
+		t.Errorf("Expected the error to name the offending pattern, got: %v", err)
+	}
+	if len(packages) != 0 {
+		t.Errorf("Expected no packages alongside the error, got %v", packages)
+	}
+}
+
+func TestExpandGlobsMalformedIncludeFails(t *testing.T) {
+	root := t.TempDir()
+	writePackage(t, root, "packages/public-api")
+
+	packages, err := expandGlobs(root, []string{"packages/[bad"})
+	if err == nil {
+		t.Fatalf("Expected an error for the malformed include, got nil and packages %v", packages)
+	}
+	if !strings.Contains(err.Error(), "packages/[bad") {
+		t.Errorf("Expected the error to name the offending pattern, got: %v", err)
+	}
+}
+
+func TestDetectPackageJSONMalformedPatternReturnsError(t *testing.T) {
+	root := t.TempDir()
+	writePackage(t, root, "packages/public-api")
+	writePackage(t, root, "packages/internal-secret")
+
+	manifest := `{"name":"root","workspaces":["packages/*","!packages/[internal"]}`
+	if err := os.WriteFile(filepath.Join(root, "package.json"), []byte(manifest), 0644); err != nil {
+		t.Fatalf("Failed to write package.json: %v", err)
+	}
+
+	ws, err := Detect(root)
+	if err == nil {
+		t.Fatalf("Expected an error for the malformed pattern, got nil and workspace %+v", ws)
+	}
+	if !strings.Contains(err.Error(), "packages/[internal") {
+		t.Errorf("Expected the error to name the offending pattern, got: %v", err)
+	}
+	if ws != nil {
+		t.Errorf("Expected no workspace alongside the error, got %+v", ws)
+	}
+}
+
+func TestDetectPNPMWorkspaceMalformedPatternReturnsError(t *testing.T) {
+	root := t.TempDir()
+	writePackage(t, root, "packages/public-api")
+	writePackage(t, root, "packages/internal-secret")
+
+	yaml := "packages:\n  - 'packages/*'\n  - '!packages/[internal'\n"
+	if err := os.WriteFile(filepath.Join(root, "pnpm-workspace.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatalf("Failed to write pnpm-workspace.yaml: %v", err)
+	}
+
+	ws, err := Detect(root)
+	if err == nil {
+		t.Fatalf("Expected an error for the malformed pattern, got nil and workspace %+v", ws)
+	}
+	if !strings.Contains(err.Error(), "packages/[internal") {
+		t.Errorf("Expected the error to name the offending pattern, got: %v", err)
+	}
+	if ws != nil {
+		t.Errorf("Expected no workspace alongside the error, got %+v", ws)
+	}
 }
 
 func TestDetectPNPMWorkspaceExcludesNegatedPackage(t *testing.T) {

--- a/tests/e2e/monorepo_test.go
+++ b/tests/e2e/monorepo_test.go
@@ -178,3 +178,36 @@ func TestWorkspaceDependencyResolution(t *testing.T) {
 		t.Fatalf("expected node to resolve @ws-deps/lib to \"lib-v1+util-v1\", got %q", got)
 	}
 }
+
+// TestPublishAllRejectsMalformedWorkspacePattern proves that a workspace glob
+// that will not parse stops `publish --all` outright instead of publishing the
+// package the config tried to exclude. The store is checked afterwards so a
+// silent partial publish cannot pass as a failure.
+func TestPublishAllRejectsMalformedWorkspacePattern(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	store := newStore(t)
+
+	writeFile(t, filepath.Join(root, "package.json"),
+		`{"name":"root","private":true,"workspaces":["packages/*","!packages/[internal"]}`)
+	writeFile(t, filepath.Join(root, "packages", "public-api", "package.json"),
+		`{"name":"e2e-public-api","version":"1.0.0"}`)
+	writeFile(t, filepath.Join(root, "packages", "internal-secret", "package.json"),
+		`{"name":"e2e-internal-secret","version":"1.0.0"}`)
+
+	out, err := runLNPMErr(t, store, root, "publish", "--all")
+	if err == nil {
+		t.Fatalf("expected publish --all to exit non-zero for a malformed pattern, output:\n%s", out)
+	}
+	if !strings.Contains(out, "packages/[internal") {
+		t.Errorf("expected the failure to name the offending pattern, output:\n%s", out)
+	}
+
+	status := runLNPM(t, store, root, "status")
+	for _, name := range []string{"e2e-internal-secret", "e2e-public-api"} {
+		if strings.Contains(status, name) {
+			t.Errorf("expected nothing published, but %s is in the store:\n%s", name, status)
+		}
+	}
+}


### PR DESCRIPTION
`expandGlobs` discarded glob failures in both its include and negation loops, so it never returned a non-nil error despite its `([]string, error)` signature. The two discards looked symmetric but were not: a swallowed **include** failure publishes fewer packages and fails closed; a swallowed **negation** failure publishes the package the config explicitly excluded, into a shared store where consuming projects can link it.

Reproduced in triage, on a two-package workspace:

| patterns | error | packages |
| --- | --- | --- |
| `["packages/*", "!packages/internal-secret"]` | `nil` | `[public-api]` — correct |
| `["packages/*", "!packages/[internal"]` | `nil` | **`[internal-secret public-api]`** |

This is precisely what `docs/adr/0001-swallowed-errors-that-widen-a-publish-are-bugs.md` classifies as a bug rather than a case-by-case judgement, which is what makes the hard-fail the ADR-aligned choice rather than merely the defensible one.

## The fix

Both loops return a wrapped error naming the offending pattern. One rule for both directions, per the ADR's explicit rejection of fixing only the negation side.

## The brief's own premise was wrong, and that changed the shape

The issue's Agent Brief asserted that the error plumbing already existed and was merely unused — *"workspace detection propagates theirs"* — and instructed: *"No signature changes anywhere. If you find yourself editing a caller's error handling, stop and re-check fact 2."*

**Fact 2 is false.** `Detect` does not propagate. On `main` it reads `if err == nil && ws != nil { return ws, nil }`, discards the error, walks to the parent, and ends at `return nil, nil`.

With `expandGlobs` alone fixed, `publish --all` would still have exited non-zero — but via `"no workspace found. --all requires a monorepo with workspaces configured"`, never naming the pattern. Acceptance criterion 5 would have passed **by accident** while criteria 1 and 3 failed, since AC1 is worded at exactly that layer ("causes workspace *detection* to return an error") and AC3 requires the error to name the pattern.

So `Detect` gained a narrowly guarded early return:

```go
if errors.Is(err, doublestar.ErrBadPattern) {
    return nil, err
}
```

`errors.Is` is necessary rather than idiomatic here — `expandGlobs` wraps with `%w`, so `==` would never fire.

**Why this is the ADR line and not a half-measure:** ADR-0001's Consequences section requires that a malformed pattern "aborts the operation **and names the pattern**", which is unreachable through the walk-up. Confining the guard to `ErrBadPattern` preserves the existing walk-past behaviour for every fail-closed failure — unreadable `package.json`, bad YAML — which the ADR explicitly leaves as open questions.

**Blast radius:** two call sites, `internal/cli/publish.go:36` (`--all` only) and `internal/pack/workspacedeps.go:144` (only when a `workspace:*` dep exists). Both already treat a nil workspace as an error, so a project beneath an ancestor with a broken config now gets a *better* message rather than a new failure.

No signatures changed. `parsePnpmWorkspace`, `parsePackageJSONWorkspace` and `publishAll` are byte-for-byte unchanged.

## The decision rests on a re-derived fact

The hard failure is only safe because the glob call cannot fail on a transient condition. Verified against the vendored `doublestar/v4 v4.10.0` in the module cache, in code rather than from the doc comment: every I/O path funnels through `forwardErrIfFailOnIOErrors`, every not-exist path through `handlePatternNotExist`, and both return `nil` unless flags set only by `WithFailOnIOErrors` / `WithFailOnPatternNotExist`. This codebase passes no options at either call site, so the only escaping error is `ErrBadPattern` — deterministic, on a config typo.

## Tests

Four white-box tests plus one e2e. Each was confirmed to fail against the current code **for the right reason** — an assertion on the returned error or package list, never a setup failure:

```
workspace_test.go:118: Expected an error for the malformed negation, got nil and packages [.../internal-secret .../public-api]
workspace_test.go:136: Expected an error for the malformed include, got nil and packages []
workspace_test.go:155: Expected an error for the malformed pattern, got nil and workspace &{... Type:npm Packages:[internal-secret public-api]}
workspace_test.go:177: Expected an error for the malformed pattern, got nil and workspace &{... Type:pnpm Packages:[internal-secret public-api]}
```

Both config formats are covered, as the brief requires. The e2e test runs the compiled binary against a throwaway store, asserts a non-zero exit, that the output names `packages/[internal`, and then runs `lnpm status` and asserts **neither package is in the store** — so it proves nothing was published, not merely that the command failed. Pre-fix it showed the bug end to end: both packages published, exit 0.

Existing workspace and negation tests pass unchanged — `--numstat` on both test files is additions only, zero deletions.

Gates: `go test ./...` under `umask 022`, `go vet`, `golangci-lint`, `gofmt`, plus `windows/amd64` build and `windows/amd64`, `darwin/arm64`, `linux/arm64` vet.

## Noticed, not fixed

- **`Detect` still swallows every remaining `detectWorkspaceAt` error** — an unreadable or unparseable `package.json` / `pnpm-workspace.yaml` silently walks past to the parent and ends at `(nil, nil)`. Fail-closed, so ADR-0001 leaves it a judgement call, but it is the same class as #246 and is not currently tracked. Probably worth filing.
- `ListPackages` swallows per-member read/parse errors — already #246, untouched and byte-identical here.
- `Detect`'s "no workspace here" and "error here" remain indistinguishable to callers; `internal/pack/workspacedeps.go` carries a comment acknowledging that `(nil, nil)` is its own failure mode in that context.

Closes #241