### PR TITLE
Reclaim temp directories left by an interrupted publish or relink

### DIFF
--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/pedrosousa13/lnpm/internal/db"
+	"github.com/pedrosousa13/lnpm/internal/link"
 	"github.com/pedrosousa13/lnpm/internal/store"
 )
 
@@ -48,17 +50,22 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 	// Find packages to remove
 	var packagesToRemove []*db.Package
 	var linksToRemove []linkToRemove
+	// Project directories still on disk, deduplicated: the temp-directory sweep
+	// reads each one once, however many packages are linked into it.
+	projectPaths := make(map[string]struct{})
 
 	for _, pkg := range packages {
 		links, _ := database.GetLinksForPackage(pkg.ID)
 
 		// Check for orphaned links
-		for _, link := range links {
-			proj, _ := database.GetProjectByID(link.ProjectID)
+		// Named lnk, not link, so it does not shadow the link package the
+		// temp-directory sweep below calls into.
+		for _, lnk := range links {
+			proj, _ := database.GetProjectByID(lnk.ProjectID)
 			if proj == nil {
 				linksToRemove = append(linksToRemove, linkToRemove{
 					packageID: pkg.ID,
-					projectID: link.ProjectID,
+					projectID: lnk.ProjectID,
 					reason:    "project not found in database",
 				})
 				continue
@@ -67,10 +74,12 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 			if _, err := os.Stat(proj.Path); os.IsNotExist(err) {
 				linksToRemove = append(linksToRemove, linkToRemove{
 					packageID:   pkg.ID,
-					projectID:   link.ProjectID,
+					projectID:   lnk.ProjectID,
 					projectPath: proj.Path,
 					reason:      "project directory no longer exists",
 				})
+			} else {
+				projectPaths[proj.Path] = struct{}{}
 			}
 		}
 
@@ -121,44 +130,205 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 		fmt.Println()
 
 		if !dryRun {
-			if !confirm("Permanently delete these package(s) from the store?", yes) {
-				fmt.Println("Aborted.")
-				return nil
+			if confirm("Permanently delete these package(s) from the store?", yes) {
+				removePackages(database, storeRoot, packagesToRemove)
+			} else {
+				// Declining skips deleting packages and nothing else. The
+				// temp-directory sweep below asks its own question, about a
+				// different kind of thing, and coupling the two would mean a
+				// user who says no here never learns those directories exist —
+				// which is most of what makes them a problem, since no other
+				// command mentions them.
+				fmt.Println("Skipped deleting packages.")
 			}
-			removed := 0
-			var freed int64
-			for _, pkg := range packagesToRemove {
-				// Remove from store, but only if the recorded path is actually
-				// inside the store root (guards against a poisoned DB entry).
-				if pkg.StorePath != "" {
-					if isWithinStore(storeRoot, pkg.StorePath) {
-						// The entry is invalidated before its tree is removed,
-						// so an interrupted removal leaves something the store
-						// reports as absent rather than a truncated package.
-						if err := store.RemoveEntry(pkg.StorePath); err != nil {
-							// Keep the database row: it is the only record of
-							// the entry left to delete, and gc can be re-run.
-							fmt.Printf("  %s Failed to remove %s: %v\n", iconWarn(), pkg.Name, err)
-							continue
-						}
-					} else {
-						fmt.Printf("  ⚠ Skipping %s: store path %q is outside the store root\n", pkg.Name, pkg.StorePath)
-					}
-				}
-				// Remove from database
-				_ = database.DeletePackage(pkg.ID)
-				removed++
-				freed += pkg.TotalSize
-			}
-			fmt.Printf("%s Removed %d package(s), freed %s\n", iconOK(), removed, formatSize(freed))
 		}
 	}
 
-	if len(packagesToRemove) == 0 && len(linksToRemove) == 0 {
+	// Reclaim the temp directories an interrupted publish or relink left behind.
+	//
+	// This runs here, inside the window where the database handle is still open,
+	// and that ordering is the entire safety argument rather than an incidental
+	// detail. bolt.Open takes an exclusive OS file lock on the database file and
+	// holds it until Close, and every path that creates one of these directories
+	// — publish, add, push — opens the database before it touches the store or a
+	// project. So while gc holds the handle no other lnpm process can be
+	// mid-write, and a temp directory seen here has no live writer by
+	// construction. That is why no age threshold, pid file or lock file is
+	// needed: the invariant already exists and the OS already enforces it.
+	//
+	// Moving this after a Close would void the guarantee in silence, and let the
+	// sweep delete the temp directory of a relink that started in the meantime —
+	// exactly the half-written package #137 removed. reapTempDirs re-checks the
+	// lock so such a reordering fails loudly instead.
+	sortedProjects := make([]string, 0, len(projectPaths))
+	for path := range projectPaths {
+		sortedProjects = append(sortedProjects, path)
+	}
+	sort.Strings(sortedProjects)
+	tempDirsFound, err := reapTempDirs(database, s, sortedProjects, dryRun, yes)
+	if err != nil {
+		return err
+	}
+
+	if len(packagesToRemove) == 0 && len(linksToRemove) == 0 && tempDirsFound == 0 {
 		fmt.Printf("%s Nothing to clean up\n", iconOK())
 	}
 
 	return nil
+}
+
+// removePackages deletes each package's store entry and then its database row.
+// It is a function rather than an inline block so gc can decline it and still go
+// on to sweep temp directories, which is a separate decision.
+func removePackages(database *db.DB, storeRoot string, packagesToRemove []*db.Package) {
+	removed := 0
+	var freed int64
+	for _, pkg := range packagesToRemove {
+		// Remove from store, but only if the recorded path is actually
+		// inside the store root (guards against a poisoned DB entry).
+		if pkg.StorePath != "" {
+			if isWithinStore(storeRoot, pkg.StorePath) {
+				// The entry is invalidated before its tree is removed,
+				// so an interrupted removal leaves something the store
+				// reports as absent rather than a truncated package.
+				if err := store.RemoveEntry(pkg.StorePath); err != nil {
+					// Keep the database row: it is the only record of
+					// the entry left to delete, and gc can be re-run.
+					fmt.Printf("  %s Failed to remove %s: %v\n", iconWarn(), pkg.Name, err)
+					continue
+				}
+			} else {
+				fmt.Printf("  ⚠ Skipping %s: store path %q is outside the store root\n", pkg.Name, pkg.StorePath)
+			}
+		}
+		// Remove from database
+		_ = database.DeletePackage(pkg.ID)
+		removed++
+		freed += pkg.TotalSize
+	}
+	fmt.Printf("%s Removed %d package(s), freed %s\n", iconOK(), removed, formatSize(freed))
+}
+
+// tempDirToReap is one temp directory the sweep found, flattened from the two
+// surfaces so gc reports them in one list.
+type tempDirToReap struct {
+	path string
+	size int64
+	// note says what the directory held. Reporting that is the point of the
+	// sweep: these directories are invisible to every other command, so gc is
+	// the only place a user can learn real content is sitting there.
+	note string
+}
+
+// tempDirNote describes what a project-side temp entry held.
+//
+// Retired means an interrupted swap renamed the *previous* .lnpm/{package}
+// aside, so it holds what was linked before rather than something half-written.
+// What that is depends on which write path made it: Link populates a directory,
+// so a retired directory is a complete copy of the package; LinkSource makes a
+// link to a source directory, so a retired link is a link and holds no copy of
+// anything. Saying "complete copy of the previous package" about a zero-byte
+// link would be plainly false, and a false statement in the one place these
+// directories are ever reported is worse than no statement.
+func tempDirNote(retired, isLink bool) string {
+	switch {
+	case retired && isLink:
+		return "link to the previously linked source directory"
+	case retired:
+		return "complete copy of the previous package"
+	case isLink:
+		return "link to a source directory, from an interrupted relink"
+	default:
+		return "incomplete"
+	}
+}
+
+// reapTempDirs reclaims the temp directories an interrupted publish or relink
+// left in the store and in the given projects, and reports how many it found.
+// It reports what it found rather than what it removed so a dry run, which finds
+// them and removes nothing, still counts as having something to clean up.
+//
+// It must be called while database is open. See the comment at its call site for
+// why that ordering, and not an age threshold, is what makes the sweep safe.
+func reapTempDirs(database *db.DB, s *store.Store, projectPaths []string, dryRun, yes bool) (int, error) {
+	if !database.LockHeld() {
+		// Refuse rather than sweep: without the database lock another process
+		// may be populating one of these directories right now.
+		return 0, fmt.Errorf("refusing to reclaim temp directories: the database lock is not held")
+	}
+
+	var found []tempDirToReap
+	unreadable := 0
+
+	// Both finders count the directories they could not read instead of failing.
+	// Per ADR-0001 the direction is what decides: skipping one narrows what the
+	// sweep reclaims and leaves the bytes for the next run, where aborting would
+	// abandon every other project as well. gc is the command a user reaches for
+	// when something is already wrong, so it has to keep working on what it can
+	// still read — but the count is reported rather than only logged, because
+	// these directories being invisible is half of what the sweep exists to fix.
+	storeTemps, storeUnreadable := s.FindTempDirs()
+	unreadable += storeUnreadable
+	for _, t := range storeTemps {
+		found = append(found, tempDirToReap{
+			path: t.Path,
+			size: t.Size,
+			note: tempDirNote(false, false),
+		})
+	}
+
+	for _, projectPath := range projectPaths {
+		entries, projectUnreadable := link.FindTempEntries(projectPath)
+		unreadable += projectUnreadable
+		for _, e := range entries {
+			found = append(found, tempDirToReap{
+				path: e.Path,
+				size: e.Size,
+				note: tempDirNote(e.Retired, e.Link),
+			})
+		}
+	}
+
+	if unreadable > 0 {
+		fmt.Printf("%s Could not scan %d director(ies) for temp directories; re-run gc once they are readable\n", iconWarn(), unreadable)
+	}
+
+	if len(found) == 0 {
+		return 0, nil
+	}
+	total := len(found)
+
+	fmt.Printf("Found %d temp director(ies) left by an interrupted publish or relink:\n", len(found))
+	var totalSize int64
+	for _, t := range found {
+		fmt.Printf("  - %s (%s, %s)\n", t.path, formatSize(t.size), t.note)
+		totalSize += t.size
+	}
+	fmt.Printf("Total size: %s\n", formatSize(totalSize))
+	fmt.Println()
+
+	if dryRun {
+		return total, nil
+	}
+	if !confirm("Permanently delete these temp director(ies)?", yes) {
+		fmt.Println("Skipped reclaiming temp directories.")
+		return total, nil
+	}
+
+	removed := 0
+	var freed int64
+	for _, t := range found {
+		// RemoveAll does not follow links, so a leftover from LinkSource loses
+		// the link and not the source directory it points at.
+		if err := os.RemoveAll(t.path); err != nil {
+			fmt.Printf("  %s Failed to remove %s: %v\n", iconWarn(), t.path, err)
+			continue
+		}
+		removed++
+		freed += t.size
+	}
+	fmt.Printf("%s Reclaimed %d temp director(ies), freed %s\n", iconOK(), removed, formatSize(freed))
+	return total, nil
 }
 
 type linkToRemove struct {

--- a/internal/cli/gc_test.go
+++ b/internal/cli/gc_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pedrosousa13/lnpm/internal/config"
 	"github.com/pedrosousa13/lnpm/internal/db"
+	"github.com/pedrosousa13/lnpm/internal/store"
 )
 
 // newGCStore points lnpm at a fresh store and database, and returns the store
@@ -18,6 +20,17 @@ func newGCStore(t *testing.T) (string, *db.DB) {
 	t.Setenv("LNPM_STORE", base)
 	db.ResetForTesting()
 	t.Cleanup(db.ResetForTesting)
+
+	// gc deletes things. Prove the override took effect before any of these
+	// tests reaches a RemoveAll, rather than trusting that it did: a test that
+	// silently ran against the real store would destroy a real user's packages.
+	resolved, err := config.GetStorePath()
+	if err != nil {
+		t.Fatalf("resolve store path: %v", err)
+	}
+	if resolved != base {
+		t.Fatalf("store path is %s, not the temp directory %s - refusing to run gc", resolved, base)
+	}
 
 	database, err := db.GetDB()
 	if err != nil {
@@ -81,5 +94,442 @@ func TestRunGCReportsEntryRemovalFailure(t *testing.T) {
 	}
 	if len(packages) != 1 {
 		t.Errorf("RunGC dropped the database row for an entry it failed to remove, %d package(s) left", len(packages))
+	}
+}
+
+// seedTempDir creates dir with one file in it, standing in for a temp directory
+// an interrupted publish or relink left behind.
+func seedTempDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("seed %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index.js"), []byte("payload"), 0644); err != nil {
+		t.Fatalf("seed %s: %v", dir, err)
+	}
+}
+
+// seedLinkedProject registers a project in the database with one package linked
+// into it, so gc sweeps the project the way it does in production, and returns
+// the project directory as the database records it.
+//
+// It returns the database's path and not the one handed to it, because those two
+// are not always the same string. InsertProject stores normalizePath's result,
+// which is filepath.EvalSymlinks, and on Windows EvalSymlinks expands an 8.3
+// short name: a temp directory that arrives as C:\Users\RUNNER~1\... is recorded
+// as C:\Users\runneradmin\... . gc reads project paths back out of the database,
+// so that longer spelling is what it prints. Seeding files under the returned
+// path keeps the test's idea of where things are and gc's idea in the same form.
+func seedLinkedProject(t *testing.T, database *db.DB, storeRoot string) string {
+	t.Helper()
+
+	project := t.TempDir()
+	proj := &db.Project{Path: project, Name: "consumer"}
+	if err := database.InsertProject(proj); err != nil {
+		t.Fatalf("insert project: %v", err)
+	}
+	pkg := &db.Package{
+		Name:        "linked-pkg",
+		Version:     "1.0.0",
+		ContentHash: "0123456789abcdef",
+		StorePath:   filepath.Join(storeRoot, "linked-pkg", "0123456789abcdef"),
+	}
+	if err := database.InsertPackage(pkg); err != nil {
+		t.Fatalf("insert package: %v", err)
+	}
+	if err := database.InsertLink(&db.Link{PackageID: pkg.ID, ProjectID: proj.ID, LinkType: "hardlink"}); err != nil {
+		t.Fatalf("insert link: %v", err)
+	}
+	// InsertProject rewrites proj.Path in place with the normalized form.
+	return proj.Path
+}
+
+// resolvePath returns path with any 8.3 short name or symlink along it expanded,
+// so two spellings of one location compare equal.
+//
+// The store side and the project side of gc's report reach it by different
+// routes and are not normalized alike: a project path is stored through
+// db.normalizePath, which calls filepath.EvalSymlinks, while the store path is
+// whatever LNPM_STORE holds, returned by config.GetStorePath untouched. On
+// Windows those two produce different spellings of the same directory. Resolving
+// both sides of a comparison is what makes the assertion independent of which
+// route a path took, rather than correct only as long as today's routes stay put.
+//
+// EvalSymlinks needs the path to exist, and these assertions run after gc has
+// removed the directories, so this walks up to the deepest ancestor that is still
+// there and rejoins the rest. On Unix it is an ordinary symlink resolution.
+func resolvePath(path string) string {
+	rest := ""
+	for cur := filepath.Clean(path); ; {
+		if resolved, err := filepath.EvalSymlinks(cur); err == nil {
+			return filepath.Join(resolved, rest)
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return filepath.Clean(path)
+		}
+		rest = filepath.Join(filepath.Base(cur), rest)
+		cur = parent
+	}
+}
+
+// reportedTempDirs parses gc's temp-directory report into a map from each listed
+// directory, resolved, to the note saying what it held.
+//
+// It matches whole paths rather than looking for one as a substring of the
+// output. That is deliberately stricter: a substring test cannot tell the entry
+// it wants from a longer path that merely contains it, and a basename test could
+// not tell .lnpm/.tmp-c0ffee from .lnpm/@org/.tmp-c0ffee at all.
+//
+// The report lines are "  - <path> (<size>, <note>)". formatSize never emits a
+// comma, so the first ", " after the size separates the two.
+func reportedTempDirs(t *testing.T, out string) map[string]string {
+	t.Helper()
+
+	reported := map[string]string{}
+	for _, line := range strings.Split(out, "\n") {
+		body, ok := strings.CutPrefix(strings.TrimRight(line, "\r"), "  - ")
+		if !ok {
+			continue
+		}
+		open := strings.LastIndex(body, " (")
+		if open < 0 || !strings.HasSuffix(body, ")") {
+			continue
+		}
+		path := body[:open]
+		details := body[open+2 : len(body)-1]
+		comma := strings.Index(details, ", ")
+		if comma < 0 {
+			// An orphaned-package or orphaned-link line, not a temp directory.
+			continue
+		}
+		reported[resolvePath(path)] = details[comma+2:]
+	}
+	return reported
+}
+
+// assertReclaimReported fails unless gc listed path with the expected note.
+func assertReclaimReported(t *testing.T, out, path, wantNote string) {
+	t.Helper()
+
+	reported := reportedTempDirs(t, out)
+	note, ok := reported[resolvePath(path)]
+	if !ok {
+		t.Errorf("gc did not report %s; it reported %v\nfull output:\n%s", path, reported, out)
+		return
+	}
+	if note != wantNote {
+		t.Errorf("gc reported %s as %q, want %q", path, note, wantNote)
+	}
+}
+
+// TestRunGCReclaimsOrphanedTempDirs covers all three shapes at once: the store's
+// in-progress directory, the project's in-progress directory (inside a scope
+// directory, which a one-level sweep would miss), and the retired directory an
+// interrupted swap leaves holding a complete copy of the previous package.
+//
+// It also seeds a package whose name begins with a dot. ListLinked hides every
+// dot-prefixed entry, so a sweep written against that filter rather than against
+// the temp-name convention would delete a real package here.
+func TestRunGCReclaimsOrphanedTempDirs(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	project := seedLinkedProject(t, database, storeRoot)
+
+	storeTemp := filepath.Join(storeRoot, "linked-pkg", ".0123456789abcdef.tmp-4242")
+	projectTemp := filepath.Join(project, ".lnpm", ".tmp-deadbeef")
+	scopedTemp := filepath.Join(project, ".lnpm", "@org", ".tmp-c0ffee")
+	retiredTemp := filepath.Join(project, ".lnpm", "@org", ".tmp-c0ffee.old")
+	for _, dir := range []string{storeTemp, projectTemp, scopedTemp, retiredTemp} {
+		seedTempDir(t, dir)
+	}
+
+	keep := []string{
+		filepath.Join(project, ".lnpm", "ordinary-pkg"),
+		filepath.Join(project, ".lnpm", ".hidden-pkg"),
+		filepath.Join(project, ".lnpm", "@org", "scoped-pkg"),
+	}
+	for _, dir := range keep {
+		seedTempDir(t, dir)
+	}
+
+	out := captureStdout(t, func() {
+		if err := RunGC(false, "", false, true); err != nil {
+			t.Errorf("RunGC() error = %v", err)
+		}
+	})
+
+	for _, dir := range []string{storeTemp, projectTemp, scopedTemp, retiredTemp} {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Errorf("RunGC left %s behind (stat err = %v)", dir, err)
+		}
+	}
+	for _, dir := range keep {
+		if _, err := os.Stat(dir); err != nil {
+			t.Errorf("RunGC removed %s, which is a package and not a temp directory: %v", dir, err)
+		}
+	}
+	// The scope directory must survive a temp directory inside it being taken.
+	if _, err := os.Stat(filepath.Join(project, ".lnpm", "@org")); err != nil {
+		t.Errorf("RunGC removed the scope directory: %v", err)
+	}
+
+	// gc has to say what it reclaimed: these directories are invisible to every
+	// other command, so silence here means the user never learns they existed.
+	assertReclaimReported(t, out, storeTemp, "incomplete")
+	assertReclaimReported(t, out, projectTemp, "incomplete")
+	assertReclaimReported(t, out, scopedTemp, "incomplete")
+	assertReclaimReported(t, out, retiredTemp, "complete copy of the previous package")
+	if len(reportedTempDirs(t, out)) != 4 {
+		t.Errorf("RunGC reported %v, want exactly the four seeded temp directories", reportedTempDirs(t, out))
+	}
+	if strings.Contains(out, "Nothing to clean up") {
+		t.Errorf("RunGC reported nothing to clean up while reclaiming temp directories, output was:\n%s", out)
+	}
+}
+
+// TestRunGCReportsARetiredDirectoryAsACompletePackage pins the distinction that
+// makes the retired shape worth reporting separately: it is not wasted space,
+// it is a complete copy of the package that was linked before the interrupted
+// relink, and the user has no other way to discover it.
+func TestRunGCReportsARetiredDirectoryAsACompletePackage(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	project := seedLinkedProject(t, database, storeRoot)
+
+	inProgress := filepath.Join(project, ".lnpm", ".tmp-11aa")
+	retired := filepath.Join(project, ".lnpm", ".tmp-22bb.old")
+	seedTempDir(t, inProgress)
+	seedTempDir(t, retired)
+
+	out := captureStdout(t, func() {
+		if err := RunGC(false, "", false, true); err != nil {
+			t.Errorf("RunGC() error = %v", err)
+		}
+	})
+
+	assertReclaimReported(t, out, retired, "complete copy of the previous package")
+	assertReclaimReported(t, out, inProgress, "incomplete")
+}
+
+// TestRunGCDryRunKeepsOrphanedTempDirs pins that the sweep goes through the same
+// dry-run flow as the rest of gc. The pre-existing --fix-links path deletes
+// orphaned link records before the confirmation guard; this must not repeat it.
+func TestRunGCDryRunKeepsOrphanedTempDirs(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	project := seedLinkedProject(t, database, storeRoot)
+
+	orphan := filepath.Join(project, ".lnpm", ".tmp-abcdef")
+	seedTempDir(t, orphan)
+
+	out := captureStdout(t, func() {
+		if err := RunGC(true, "", false, true); err != nil {
+			t.Errorf("RunGC() error = %v", err)
+		}
+	})
+
+	if _, err := os.Stat(orphan); err != nil {
+		t.Errorf("a dry run removed %s: %v", orphan, err)
+	}
+	assertReclaimReported(t, out, orphan, "incomplete")
+	if strings.Contains(out, "Nothing to clean up") {
+		t.Errorf("a dry run reported nothing to clean up after listing a temp directory, output was:\n%s", out)
+	}
+}
+
+// TestRunGCDeclinedKeepsOrphanedTempDirs pins that reclaiming is confirmed
+// before it happens, like every other destructive step in gc.
+func TestRunGCDeclinedKeepsOrphanedTempDirs(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	project := seedLinkedProject(t, database, storeRoot)
+
+	orphan := filepath.Join(project, ".lnpm", ".tmp-abcdef")
+	seedTempDir(t, orphan)
+
+	// yes=false with a non-interactive stdin is how confirm reports a refusal,
+	// so this is the "the user did not agree" case.
+	captureStdout(t, func() {
+		if err := RunGC(false, "", false, false); err != nil {
+			t.Errorf("RunGC() error = %v", err)
+		}
+	})
+
+	if _, err := os.Stat(orphan); err != nil {
+		t.Errorf("RunGC removed %s without confirmation: %v", orphan, err)
+	}
+}
+
+// TestReapTempDirsRequiresTheDatabaseLock pins the ordering the whole safety
+// argument rests on. The sweep is safe only because gc holds the exclusive
+// database lock across it: every path that creates one of these directories
+// opens the database first, so while the lock is held no temp directory can
+// have a live writer. A future change that closes the database before sweeping
+// would void that silently and let the sweep delete a live relink's temp
+// directory mid-write — the corruption #137 removed. It must fail loudly
+// instead, which is what this asserts.
+func TestReapTempDirsRequiresTheDatabaseLock(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	project := seedLinkedProject(t, database, storeRoot)
+
+	orphan := filepath.Join(project, ".lnpm", ".tmp-abcdef")
+	seedTempDir(t, orphan)
+	storeTemp := filepath.Join(storeRoot, "linked-pkg", ".0123456789abcdef.tmp-1")
+	seedTempDir(t, storeTemp)
+
+	if database.LockHeld() != true {
+		t.Fatalf("LockHeld() = false on an open database")
+	}
+	if err := database.Close(); err != nil {
+		t.Fatalf("close database: %v", err)
+	}
+	if database.LockHeld() != false {
+		t.Errorf("LockHeld() = true after Close")
+	}
+
+	s, err := store.New()
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	var sweepErr error
+	captureStdout(t, func() {
+		_, sweepErr = reapTempDirs(database, s, []string{project}, false, true)
+	})
+	if sweepErr == nil {
+		t.Fatalf("reapTempDirs swept with the database lock released")
+	}
+	if !strings.Contains(sweepErr.Error(), "database lock") {
+		t.Errorf("reapTempDirs error = %v, want it to name the database lock", sweepErr)
+	}
+	for _, dir := range []string{orphan, storeTemp} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Errorf("reapTempDirs removed %s with the lock released: %v", dir, err)
+		}
+	}
+}
+
+// TestRunGCReportsTempDirsWhenPackageDeletionIsDeclined pins that the two
+// prompts are independent decisions. Declining to delete orphaned packages used
+// to return before the sweep ran, so a user who said no there never learned temp
+// directories existed — and no other command would ever have told them.
+func TestRunGCReportsTempDirsWhenPackageDeletionIsDeclined(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	project := seedLinkedProject(t, database, storeRoot)
+
+	// An orphaned package, so the package prompt is reached and declined.
+	orphanEntry := filepath.Join(storeRoot, "orphan-pkg", "aabbccddeeff0011")
+	seedTempDir(t, orphanEntry)
+	if err := database.InsertPackage(&db.Package{
+		Name:        "orphan-pkg",
+		Version:     "1.0.0",
+		ContentHash: "aabbccddeeff0011",
+		StorePath:   orphanEntry,
+	}); err != nil {
+		t.Fatalf("insert package: %v", err)
+	}
+
+	tempDir := filepath.Join(project, ".lnpm", ".tmp-abcdef")
+	seedTempDir(t, tempDir)
+
+	// yes=false with a non-interactive stdin is how confirm reports a refusal,
+	// so both prompts are declined here.
+	out := captureStdout(t, func() {
+		if err := RunGC(false, "", false, false); err != nil {
+			t.Errorf("RunGC() error = %v", err)
+		}
+	})
+
+	if _, ok := reportedTempDirs(t, out)[resolvePath(tempDir)]; !ok {
+		t.Errorf("declining the package prompt suppressed the temp directory report, output was:\n%s", out)
+	}
+	// Both declines must still be honoured.
+	if _, err := os.Stat(tempDir); err != nil {
+		t.Errorf("RunGC removed %s without confirmation: %v", tempDir, err)
+	}
+	if _, err := os.Stat(orphanEntry); err != nil {
+		t.Errorf("RunGC removed %s without confirmation: %v", orphanEntry, err)
+	}
+}
+
+// TestRunGCReportsARetiredLinkAsALink pins that the retired label tracks what
+// the entry actually holds. LinkSource retires a link, which holds no copy of
+// anything, so calling it a complete copy of the previous package would be false.
+func TestRunGCReportsARetiredLinkAsALink(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	project := seedLinkedProject(t, database, storeRoot)
+
+	lnpm := filepath.Join(project, ".lnpm")
+	if err := os.MkdirAll(lnpm, 0755); err != nil {
+		t.Fatalf("create .lnpm: %v", err)
+	}
+	retiredLink := filepath.Join(lnpm, ".tmp-5566.old")
+	if err := os.Symlink(t.TempDir(), retiredLink); err != nil {
+		t.Skipf("cannot create a symlink here: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := RunGC(false, "", false, true); err != nil {
+			t.Errorf("RunGC() error = %v", err)
+		}
+	})
+
+	assertReclaimReported(t, out, retiredLink, "link to the previously linked source directory")
+}
+
+// TestRunGCReportsAPathThatNormalisationRewrote reproduces, on any platform, the
+// divergence that broke the Windows job: the store path and a project path reach
+// gc's report by different routes and only one of them is normalized. A project
+// path is stored through db.normalizePath, which calls filepath.EvalSymlinks,
+// while the store path is whatever LNPM_STORE holds and is never resolved. On
+// Windows the two spellings were an 8.3 short name and its long form; a
+// symlinked project directory produces the same mismatch everywhere.
+//
+// Without this, the only evidence that the assertions tolerate both spellings is
+// a green Windows job, which is a slow and remote way to find out.
+func TestRunGCReportsAPathThatNormalisationRewrote(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+
+	base := t.TempDir()
+	realDir := filepath.Join(base, "real-project")
+	if err := os.MkdirAll(realDir, 0755); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	alias := filepath.Join(base, "alias-project")
+	if err := os.Symlink(realDir, alias); err != nil {
+		t.Skipf("cannot create a symlink here: %v", err)
+	}
+
+	// Registered under the alias; the database records the resolved spelling, and
+	// that is the one gc will print.
+	proj := &db.Project{Path: alias, Name: "consumer"}
+	if err := database.InsertProject(proj); err != nil {
+		t.Fatalf("insert project: %v", err)
+	}
+	if proj.Path == alias {
+		t.Skipf("this platform did not rewrite %s, so there is no divergence to test", alias)
+	}
+	pkg := &db.Package{
+		Name:        "linked-pkg",
+		Version:     "1.0.0",
+		ContentHash: "0123456789abcdef",
+		StorePath:   filepath.Join(storeRoot, "linked-pkg", "0123456789abcdef"),
+	}
+	if err := database.InsertPackage(pkg); err != nil {
+		t.Fatalf("insert package: %v", err)
+	}
+	if err := database.InsertLink(&db.Link{PackageID: pkg.ID, ProjectID: proj.ID, LinkType: "hardlink"}); err != nil {
+		t.Fatalf("insert link: %v", err)
+	}
+
+	// Seeded under the alias, reported under the resolved path.
+	orphan := filepath.Join(alias, ".lnpm", ".tmp-abcdef")
+	seedTempDir(t, orphan)
+
+	out := captureStdout(t, func() {
+		if err := RunGC(false, "", false, true); err != nil {
+			t.Errorf("RunGC() error = %v", err)
+		}
+	})
+
+	assertReclaimReported(t, out, orphan, "incomplete")
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Errorf("RunGC left %s behind (stat err = %v)", orphan, err)
 	}
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -176,6 +176,23 @@ func (db *DB) Close() error {
 	return db.db.Close()
 }
 
+// LockHeld reports whether the exclusive file lock bolt.Open took is still
+// held. bbolt takes it for the whole life of the handle and drops it only in
+// Close, which also clears the path this reads, so an open handle means no
+// other lnpm process can be writing to the store.
+//
+// This exists for callers whose safety rests on that rather than on their own
+// bookkeeping — gc's sweep for temp directories left by an interrupted publish
+// or relink — so they can assert the invariant instead of assuming it, and fail
+// loudly if a later change moves them outside the window where it holds.
+// It takes no lock of its own. db.mu would guard nothing here, because Close
+// does not take it either — so holding it would suggest a synchronisation that
+// does not exist. The callers that matter run on the goroutine that would do the
+// closing.
+func (db *DB) LockHeld() bool {
+	return db.db.Path() != ""
+}
+
 // ResetForTesting resets the singleton instance for testing
 // This should only be used in tests
 func ResetForTesting() {

--- a/internal/fsutil/name.go
+++ b/internal/fsutil/name.go
@@ -1,0 +1,21 @@
+package fsutil
+
+// IsLowerHex reports whether s is a non-empty run of lowercase hex digits.
+//
+// It lives here because both the store and the linker recognise the temporary
+// directories they created by the shape of the name, and both names carry a
+// lowercase hex run: fmt's %x verb over a uint64 in the linker, and pack's
+// content hash in the store. One definition means the two sweeps cannot drift
+// into disagreeing about what counts as one of their own names.
+func IsLowerHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/fsutil/size.go
+++ b/internal/fsutil/size.go
@@ -1,0 +1,38 @@
+package fsutil
+
+import (
+	"io/fs"
+	"path/filepath"
+
+	"github.com/pedrosousa13/lnpm/internal/debug"
+)
+
+// DirSize sums the regular files under dir.
+//
+// Links are counted as themselves rather than followed, so a tree holding a link
+// is not reported as holding whatever the link points at. A tree that cannot be
+// walked in full is reported as far as it was read: callers use this to say how
+// much space removing a directory frees, and an unreadable subdirectory is no
+// reason to withhold the figure entirely.
+func DirSize(dir string) int64 {
+	var total int64
+	// WalkDir does not follow links.
+	err := filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Type() != 0 {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	if err != nil {
+		debug.Logf("fsutil: could not size %s fully: %v", dir, err)
+	}
+	return total
+}

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -241,7 +241,7 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	// aside rather than deleted first, so .lnpm/{package} is missing for a
 	// single rename instead of for as long as a whole package tree takes to
 	// delete, and a failed swap can be rolled back.
-	retiredPath := tempPath + ".old"
+	retiredPath := tempPath + retiredSuffix
 	hadPrevious := false
 	if _, err := os.Lstat(lnpmPath); err == nil {
 		if err := os.Rename(lnpmPath, retiredPath); err != nil {
@@ -338,7 +338,7 @@ func (l *Linker) LinkSource(packageName string, sourcePath string) (LinkType, er
 
 	// Lstat, not Stat, so an existing live link whose source has since moved is
 	// still seen and still renamed aside rather than left in place.
-	retiredPath := tempPath + ".old"
+	retiredPath := tempPath + retiredSuffix
 	hadPrevious := false
 	if _, err := os.Lstat(lnpmPath); err == nil {
 		if err := os.Rename(lnpmPath, retiredPath); err != nil {
@@ -590,6 +590,15 @@ func (l *Linker) ListLinked() ([]string, error) {
 	return packages, nil
 }
 
+// tempPrefix is what every name newTempDir and newTempLink produce begins with,
+// and retiredSuffix is what Link's swap appends to move the previous package
+// aside. They are constants so the sweep in reap.go matches exactly what these
+// two constructors create, rather than a hand-copied guess at it.
+const (
+	tempPrefix    = ".tmp-"
+	retiredSuffix = ".old"
+)
+
 // newTempDir creates a uniquely named directory inside parent and returns its
 // path. The name is dot-prefixed so ListLinked skips it and so the retired-path
 // scheme in Link stays inside the same namespace.
@@ -601,7 +610,7 @@ func (l *Linker) ListLinked() ([]string, error) {
 // since Chmod ignores the umask and would force 0755 unconditionally.
 func newTempDir(parent string) (string, error) {
 	for attempt := 0; attempt < 1000; attempt++ {
-		path := filepath.Join(parent, fmt.Sprintf(".tmp-%x", rand.Uint64()))
+		path := filepath.Join(parent, fmt.Sprintf("%s%x", tempPrefix, rand.Uint64()))
 		err := os.Mkdir(path, 0755)
 		if err == nil {
 			return path, nil
@@ -624,7 +633,7 @@ var createDirSymlinkFn = createDirSymlink
 // skips it and the retired-path scheme stays inside the same namespace.
 func newTempLink(parent, target string) (string, error) {
 	for attempt := 0; attempt < 1000; attempt++ {
-		path := filepath.Join(parent, fmt.Sprintf(".tmp-%x", rand.Uint64()))
+		path := filepath.Join(parent, fmt.Sprintf("%s%x", tempPrefix, rand.Uint64()))
 		err := createDirSymlinkFn(target, path)
 		if err == nil {
 			return path, nil

--- a/internal/link/reap.go
+++ b/internal/link/reap.go
@@ -1,0 +1,128 @@
+package link
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pedrosousa13/lnpm/internal/debug"
+	"github.com/pedrosousa13/lnpm/internal/fsutil"
+)
+
+// TempEntry is one temp entry a project's .lnpm directory still holds.
+type TempEntry struct {
+	// Path is the absolute path of the entry.
+	Path string
+	// Size is how many bytes reclaiming it frees. A link is removed as a link,
+	// so a leftover from LinkSource counts as nothing rather than as its target.
+	Size int64
+	// Retired marks the shape an interrupted swap leaves behind. Link and
+	// LinkSource rename the previous .lnpm/{package} aside under this name
+	// before renaming the replacement into place, so a retired entry holds what
+	// was linked before it rather than something half-written.
+	Retired bool
+	// Link distinguishes LinkSource's shape from Link's. LinkSource makes a link
+	// to a source directory where Link populates a directory of its own, and the
+	// two hold different things — which matters when saying what a retired entry
+	// held, since a retired link is a link and not a copy of anything.
+	Link bool
+}
+
+// FindTempEntries returns the temp entries under projectPath's .lnpm directory,
+// including those inside scope directories, and how many directories it could
+// not read. It only reads; the caller decides whether to remove them.
+//
+// Callers must hold the exclusive database lock. Every path that creates one of
+// these entries opens the database first, so while that lock is held nothing
+// found here can have a live writer. Without it this is a list of directories
+// some other lnpm process may be writing into right now.
+//
+// A directory that cannot be read is counted and skipped rather than returned as
+// a failure. Per ADR-0001 the direction is what matters: skipping narrows what a
+// sweep reclaims, which leaves bytes on disk for the next run, where aborting
+// would abandon every other project and the store sweep that already succeeded.
+// gc is the command a user reaches for when something is already wrong, so it
+// has to keep working on the parts it can still read. The count is reported
+// rather than only logged, because these directories being invisible is half of
+// what this sweep exists to fix.
+//
+// A .lnpm directory that does not exist is neither an entry nor a failure: a
+// project may never have linked anything.
+func FindTempEntries(projectPath string) (entries []TempEntry, unreadable int) {
+	lnpmDir := filepath.Join(projectPath, ".lnpm")
+
+	scopes, err := os.ReadDir(lnpmDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, 0
+		}
+		debug.Logf("link: cannot scan %s for temp entries: %v", lnpmDir, err)
+		return nil, 1
+	}
+
+	dirs := []string{lnpmDir}
+	// Scope directories hold a scoped package's entries, so the temp entries for
+	// @org/name sit one level down rather than at the top. Only "@" directories
+	// are descended into: everything else at the top level is a package, and its
+	// contents belong to the user.
+	for _, scope := range scopes {
+		if scope.IsDir() && strings.HasPrefix(scope.Name(), "@") {
+			dirs = append(dirs, filepath.Join(lnpmDir, scope.Name()))
+		}
+	}
+
+	for _, dir := range dirs {
+		items, err := os.ReadDir(dir)
+		if err != nil {
+			debug.Logf("link: cannot scan %s for temp entries: %v", dir, err)
+			unreadable++
+			continue
+		}
+		for _, item := range items {
+			retired, ok := isTempEntryName(item.Name())
+			if !ok {
+				continue
+			}
+			// Neither constructor makes a regular file: newTempDir makes a
+			// directory and newTempLink a link. Excluding only regular files
+			// keeps LinkSource's leftover in scope without depending on which
+			// mode bits a platform reports for a link to a directory — a
+			// Windows junction among them.
+			if item.Type().IsRegular() {
+				continue
+			}
+			path := filepath.Join(dir, item.Name())
+			// Only a real directory is walked for its size: a link is removed as
+			// a link, so its target is not what is being freed.
+			var size int64
+			if item.IsDir() {
+				size = fsutil.DirSize(path)
+			}
+			entries = append(entries, TempEntry{
+				Path:    path,
+				Size:    size,
+				Retired: retired,
+				Link:    !item.IsDir(),
+			})
+		}
+	}
+	return entries, unreadable
+}
+
+// isTempEntryName reports whether name is one newTempDir or newTempLink
+// produced, and whether it is the retired form the swap derives from it.
+//
+// The match is deliberately narrow. ListLinked hides every dot-prefixed entry,
+// but a package name may legitimately begin with a dot, so "dot-prefixed" is not
+// the same thing as "ours" — reclaiming a user's dot-named package would be a
+// far worse bug than the leak this sweep exists to fix. Only the exact shape the
+// constructors produce is matched: the prefix, then the lowercase hex of a
+// uint64, optionally followed by the retired suffix.
+func isTempEntryName(name string) (retired, ok bool) {
+	rest, retired := strings.CutSuffix(name, retiredSuffix)
+	rest, hasPrefix := strings.CutPrefix(rest, tempPrefix)
+	if !hasPrefix || !fsutil.IsLowerHex(rest) {
+		return false, false
+	}
+	return retired, true
+}

--- a/internal/link/reap_test.go
+++ b/internal/link/reap_test.go
@@ -1,0 +1,261 @@
+package link
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// seedDir creates dir with a single file in it, so a sweep that reclaims it has
+// a non-zero size to report.
+func seedDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("seed %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index.js"), []byte("payload"), 0644); err != nil {
+		t.Fatalf("seed %s: %v", dir, err)
+	}
+}
+
+func foundPaths(entries []TempEntry) []string {
+	paths := make([]string, 0, len(entries))
+	for _, e := range entries {
+		paths = append(paths, e.Path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// TestFindTempEntriesFindsAnInterruptedRelink covers the directory Link
+// populates and renames into place: a process killed during population leaves
+// it behind, and nothing has ever reclaimed it.
+func TestFindTempEntriesFindsAnInterruptedRelink(t *testing.T) {
+	project := t.TempDir()
+	orphan := filepath.Join(project, ".lnpm", ".tmp-deadbeef")
+	seedDir(t, orphan)
+
+	entries, unreadable := FindTempEntries(project)
+	if unreadable != 0 {
+		t.Fatalf("FindTempEntries() could not read %d director(ies)", unreadable)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("FindTempEntries() found %v, want just %s", foundPaths(entries), orphan)
+	}
+	if entries[0].Path != orphan {
+		t.Errorf("FindTempEntries() found %s, want %s", entries[0].Path, orphan)
+	}
+	if entries[0].Retired {
+		t.Errorf("an in-progress temp directory was reported as a retired package")
+	}
+	if entries[0].Size == 0 {
+		t.Errorf("FindTempEntries() reported size 0 for a directory holding a file")
+	}
+}
+
+// TestFindTempEntriesFindsARetiredPackage covers the worse shape: a process
+// killed between the two renames of the swap leaves the *previous* package
+// behind under the retired name, so the directory holds a complete copy of real
+// content rather than a half-written one.
+func TestFindTempEntriesFindsARetiredPackage(t *testing.T) {
+	project := t.TempDir()
+	orphan := filepath.Join(project, ".lnpm", ".tmp-1a2b3c.old")
+	seedDir(t, orphan)
+
+	entries, unreadable := FindTempEntries(project)
+	if unreadable != 0 {
+		t.Fatalf("FindTempEntries() could not read %d director(ies)", unreadable)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("FindTempEntries() found %v, want just %s", foundPaths(entries), orphan)
+	}
+	if !entries[0].Retired {
+		t.Errorf("a retired directory was not reported as holding a complete package")
+	}
+}
+
+// TestFindTempEntriesFindsScopedTempDirs pins that the sweep reads more than the
+// top level: a scoped package's temp directory is created inside the scope
+// directory, so a one-level sweep misses it entirely.
+func TestFindTempEntriesFindsScopedTempDirs(t *testing.T) {
+	project := t.TempDir()
+	inProgress := filepath.Join(project, ".lnpm", "@org", ".tmp-c0ffee")
+	retired := filepath.Join(project, ".lnpm", "@org", ".tmp-c0ffee.old")
+	seedDir(t, inProgress)
+	seedDir(t, retired)
+
+	entries, unreadable := FindTempEntries(project)
+	if unreadable != 0 {
+		t.Fatalf("FindTempEntries() could not read %d director(ies)", unreadable)
+	}
+	got := foundPaths(entries)
+	want := []string{inProgress, retired}
+	sort.Strings(want)
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("FindTempEntries() found %v, want %v", got, want)
+	}
+}
+
+// TestFindTempEntriesLeavesRealPackagesAlone is the test that matters most.
+// ListLinked hides every dot-prefixed entry, so it is tempting to treat any
+// dot-prefixed entry as reclaimable — but a package name may legitimately begin
+// with a dot, and a scope directory must survive a temp directory inside it
+// being reclaimed. A sweep that matches any dot-prefixed entry passes every
+// other test in this file and destroys a real package here.
+func TestFindTempEntriesLeavesRealPackagesAlone(t *testing.T) {
+	project := t.TempDir()
+	lnpm := filepath.Join(project, ".lnpm")
+
+	keep := []string{
+		filepath.Join(lnpm, "ordinary-pkg"),
+		// A package whose name legitimately begins with a dot.
+		filepath.Join(lnpm, ".hidden-pkg"),
+		// Close to the temp shape but not it: no hex tail, and a name that only
+		// looks like the retired form.
+		filepath.Join(lnpm, ".tmp-notahexname"),
+		filepath.Join(lnpm, ".tmpish"),
+		filepath.Join(lnpm, "tmp-deadbeef"),
+		filepath.Join(lnpm, "@org", "scoped-pkg"),
+		filepath.Join(lnpm, "@org", ".hidden-scoped-pkg"),
+	}
+	for _, dir := range keep {
+		seedDir(t, dir)
+	}
+	// One genuine orphan alongside them, so the sweep is doing work rather than
+	// passing by finding nothing at all.
+	orphan := filepath.Join(lnpm, "@org", ".tmp-99")
+	seedDir(t, orphan)
+
+	entries, unreadable := FindTempEntries(project)
+	if unreadable != 0 {
+		t.Fatalf("FindTempEntries() could not read %d director(ies)", unreadable)
+	}
+	if len(entries) != 1 || entries[0].Path != orphan {
+		t.Fatalf("FindTempEntries() found %v, want just %s", foundPaths(entries), orphan)
+	}
+
+	// The scope directory itself must survive, and so must everything in it.
+	for _, dir := range keep {
+		if _, err := os.Stat(dir); err != nil {
+			t.Errorf("%s no longer stats: %v", dir, err)
+		}
+	}
+}
+
+// TestFindTempEntriesWithoutLnpmDir pins that a project that has never linked
+// anything is not an error: gc sweeps every project it knows about.
+func TestFindTempEntriesWithoutLnpmDir(t *testing.T) {
+	entries, unreadable := FindTempEntries(t.TempDir())
+	if unreadable != 0 {
+		t.Fatalf("FindTempEntries() could not read %d director(ies)", unreadable)
+	}
+	if len(entries) != 0 {
+		t.Errorf("FindTempEntries() found %v in a project with no .lnpm directory", foundPaths(entries))
+	}
+}
+
+// TestFindTempEntriesMatchesWhatTheConstructorsProduce ties the matcher to the
+// names newTempDir actually creates, so a change to one without the other is
+// caught here rather than by a leak nobody sees.
+func TestFindTempEntriesMatchesWhatTheConstructorsProduce(t *testing.T) {
+	project := t.TempDir()
+	lnpm := filepath.Join(project, ".lnpm")
+	if err := os.MkdirAll(lnpm, 0755); err != nil {
+		t.Fatalf("create .lnpm: %v", err)
+	}
+
+	made, err := newTempDir(lnpm)
+	if err != nil {
+		t.Fatalf("newTempDir() error = %v", err)
+	}
+	// The retired name the swap in Link derives from it.
+	retired := made + retiredSuffix
+	if err := os.Mkdir(retired, 0755); err != nil {
+		t.Fatalf("create retired dir: %v", err)
+	}
+
+	entries, unreadable := FindTempEntries(project)
+	if unreadable != 0 {
+		t.Fatalf("FindTempEntries() could not read %d director(ies)", unreadable)
+	}
+	got := foundPaths(entries)
+	want := []string{made, retired}
+	sort.Strings(want)
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("FindTempEntries() found %v, want %v", got, want)
+	}
+}
+
+// TestFindTempEntriesFindsAnOrphanedTempLink covers LinkSource's leftover, which
+// is a link rather than a directory and so is missed by a sweep that only looks
+// at directories.
+func TestFindTempEntriesFindsAnOrphanedTempLink(t *testing.T) {
+	project := t.TempDir()
+	lnpm := filepath.Join(project, ".lnpm")
+	if err := os.MkdirAll(lnpm, 0755); err != nil {
+		t.Fatalf("create .lnpm: %v", err)
+	}
+	target := t.TempDir()
+	orphan, err := newTempLink(lnpm, target)
+	if err != nil {
+		t.Fatalf("newTempLink() error = %v", err)
+	}
+
+	entries, unreadable := FindTempEntries(project)
+	if unreadable != 0 {
+		t.Fatalf("FindTempEntries() could not read %d director(ies)", unreadable)
+	}
+	if len(entries) != 1 || entries[0].Path != orphan {
+		t.Fatalf("FindTempEntries() found %v, want just %s", foundPaths(entries), orphan)
+	}
+	// Sizing must not follow the link: the target is not what is being freed.
+	if entries[0].Size != 0 {
+		t.Errorf("FindTempEntries() sized a link at %d bytes, want 0", entries[0].Size)
+	}
+	if !entries[0].Link {
+		t.Errorf("a leftover from LinkSource was not reported as a link")
+	}
+}
+
+// TestFindTempEntriesDistinguishesADirectoryFromALink pins the difference gc
+// reports on. A retired directory holds a complete copy of the previous package;
+// a retired link holds a link and no copy of anything, so describing it the same
+// way would state something plainly untrue about the only place these entries
+// are ever mentioned.
+func TestFindTempEntriesDistinguishesADirectoryFromALink(t *testing.T) {
+	project := t.TempDir()
+	lnpm := filepath.Join(project, ".lnpm")
+	if err := os.MkdirAll(lnpm, 0755); err != nil {
+		t.Fatalf("create .lnpm: %v", err)
+	}
+	retiredDir := filepath.Join(lnpm, ".tmp-aa11.old")
+	seedDir(t, retiredDir)
+
+	retiredLink, err := newTempLink(lnpm, t.TempDir())
+	if err != nil {
+		t.Fatalf("newTempLink() error = %v", err)
+	}
+	if err := os.Rename(retiredLink, retiredLink+retiredSuffix); err != nil {
+		t.Fatalf("retire the link: %v", err)
+	}
+	retiredLink += retiredSuffix
+
+	entries, unreadable := FindTempEntries(project)
+	if unreadable != 0 {
+		t.Fatalf("FindTempEntries() could not read %d director(ies)", unreadable)
+	}
+	byPath := map[string]TempEntry{}
+	for _, e := range entries {
+		byPath[e.Path] = e
+	}
+	if len(byPath) != 2 {
+		t.Fatalf("FindTempEntries() found %v, want both retired entries", foundPaths(entries))
+	}
+	if got := byPath[retiredDir]; !got.Retired || got.Link {
+		t.Errorf("retired directory reported as retired=%v link=%v, want retired=true link=false", got.Retired, got.Link)
+	}
+	if got := byPath[retiredLink]; !got.Retired || !got.Link {
+		t.Errorf("retired link reported as retired=%v link=%v, want retired=true link=true", got.Retired, got.Link)
+	}
+}

--- a/internal/store/backfill.go
+++ b/internal/store/backfill.go
@@ -105,31 +105,9 @@ func BackfillDone() (bool, error) {
 // failure, so the caller can mark what it did find and leave the backfill
 // pending for the rest.
 func listEntries(storeRoot string) (entries []string, unreadable int) {
-	names, err := readDirs(storeRoot)
-	if err != nil {
-		debug.Logf("store: cannot scan %s for entries: %v", storeRoot, err)
-		return nil, 1
-	}
+	dirs, unreadable := packageDirs(storeRoot)
 
-	var packageDirs []string
-	for _, name := range names {
-		dir := filepath.Join(storeRoot, name)
-		if !strings.HasPrefix(name, "@") {
-			packageDirs = append(packageDirs, dir)
-			continue
-		}
-		scoped, err := readDirs(dir)
-		if err != nil {
-			debug.Logf("store: cannot scan scope %s: %v", dir, err)
-			unreadable++
-			continue
-		}
-		for _, s := range scoped {
-			packageDirs = append(packageDirs, filepath.Join(dir, s))
-		}
-	}
-
-	for _, dir := range packageDirs {
+	for _, dir := range dirs {
 		hashes, err := readDirs(dir)
 		if err != nil {
 			debug.Logf("store: cannot scan package %s: %v", dir, err)
@@ -141,6 +119,36 @@ func listEntries(storeRoot string) (entries []string, unreadable int) {
 		}
 	}
 	return entries, unreadable
+}
+
+// packageDirs returns the directory holding the entries of every package in the
+// store, and how many directories could not be read. A package's entries live
+// at <store>/<name>/<hash>, with one extra level for scoped names, so these are
+// the directories <hash> entries and the write path's temp directories sit in.
+func packageDirs(storeRoot string) (dirs []string, unreadable int) {
+	names, err := readDirs(storeRoot)
+	if err != nil {
+		debug.Logf("store: cannot scan %s for entries: %v", storeRoot, err)
+		return nil, 1
+	}
+
+	for _, name := range names {
+		dir := filepath.Join(storeRoot, name)
+		if !strings.HasPrefix(name, "@") {
+			dirs = append(dirs, dir)
+			continue
+		}
+		scoped, err := readDirs(dir)
+		if err != nil {
+			debug.Logf("store: cannot scan scope %s: %v", dir, err)
+			unreadable++
+			continue
+		}
+		for _, s := range scoped {
+			dirs = append(dirs, filepath.Join(dir, s))
+		}
+	}
+	return dirs, unreadable
 }
 
 // readDirs returns the names of dir's subdirectories, skipping dot-prefixed ones.

--- a/internal/store/reap.go
+++ b/internal/store/reap.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pedrosousa13/lnpm/internal/debug"
+	"github.com/pedrosousa13/lnpm/internal/fsutil"
+)
+
+// TempDir is one temp directory the store's write path left behind.
+type TempDir struct {
+	// Path is the absolute path of the directory.
+	Path string
+	// Size is how many bytes reclaiming it frees.
+	Size int64
+}
+
+// FindTempDirs returns the temp directories still sitting beside store entries,
+// and how many directories it could not read. Store writes a package into one of
+// these and renames it into place, and its deferred cleanup only runs on a
+// normal return — so a publish killed by a signal, an OOM or a power loss leaves
+// one behind holding a full package copy. It only reads; the caller decides
+// whether to remove them.
+//
+// Callers must hold the exclusive database lock. Publish opens the database
+// before it writes to the store, so while that lock is held nothing found here
+// can have a live writer. Without it this is a list of directories some other
+// lnpm process may be writing into right now.
+//
+// A directory that cannot be read is counted and skipped rather than returned as
+// a failure, matching link.FindTempEntries; the reasoning is given there.
+func (s *Store) FindTempDirs() (dirs []TempDir, unreadable int) {
+	parents, unreadable := packageDirs(s.basePath)
+
+	for _, parent := range parents {
+		items, err := os.ReadDir(parent)
+		if err != nil {
+			debug.Logf("store: cannot scan %s for temp directories: %v", parent, err)
+			unreadable++
+			continue
+		}
+		for _, item := range items {
+			if !item.IsDir() || !isTempDirName(item.Name()) {
+				continue
+			}
+			path := filepath.Join(parent, item.Name())
+			dirs = append(dirs, TempDir{Path: path, Size: fsutil.DirSize(path)})
+		}
+	}
+	return dirs, unreadable
+}
+
+// isTempDirName reports whether name is one newTempDir produced: a dot, the
+// entry's hash, the infix, and the decimal tail os.MkdirTemp appends.
+//
+// The match is deliberately narrow rather than "anything dot-prefixed". The
+// completeness marker, the backfill sentinel and a package whose name begins
+// with a dot are all dot-prefixed and none of them is ours to delete.
+func isTempDirName(name string) bool {
+	rest, ok := strings.CutPrefix(name, ".")
+	if !ok {
+		return false
+	}
+	i := strings.LastIndex(rest, tempInfix)
+	if i <= 0 {
+		return false
+	}
+	return fsutil.IsLowerHex(rest[:i]) && isDigits(rest[i+len(tempInfix):])
+}
+
+// isDigits reports whether s is a non-empty run of decimal digits, which is what
+// os.MkdirTemp appends to the pattern it is given.
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/store/reap_test.go
+++ b/internal/store/reap_test.go
@@ -1,0 +1,152 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// newReapStore points the store at a throwaway directory and returns it.
+func newReapStore(t *testing.T) *Store {
+	t.Helper()
+	t.Setenv("LNPM_STORE", t.TempDir())
+	s, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return s
+}
+
+// seedStoreDir creates dir with one file in it.
+func seedStoreDir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("seed %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index.js"), []byte("payload"), 0644); err != nil {
+		t.Fatalf("seed %s: %v", dir, err)
+	}
+}
+
+func tempDirPaths(dirs []TempDir) []string {
+	paths := make([]string, 0, len(dirs))
+	for _, d := range dirs {
+		paths = append(paths, d.Path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// TestFindTempDirsFindsAnInterruptedPublish covers the store's own leak: Store
+// writes into a temp directory beside the target entry and renames it into
+// place, and the deferred cleanup that removes it only runs on a normal return.
+func TestFindTempDirsFindsAnInterruptedPublish(t *testing.T) {
+	s := newReapStore(t)
+	orphan := filepath.Join(s.Root(), "my-pkg", ".0123456789abcdef.tmp-987654321")
+	seedStoreDir(t, orphan)
+
+	dirs, unreadable := s.FindTempDirs()
+	if unreadable != 0 {
+		t.Fatalf("FindTempDirs() could not read %d director(ies)", unreadable)
+	}
+	if len(dirs) != 1 || dirs[0].Path != orphan {
+		t.Fatalf("FindTempDirs() found %v, want just %s", tempDirPaths(dirs), orphan)
+	}
+	if dirs[0].Size == 0 {
+		t.Errorf("FindTempDirs() reported size 0 for a directory holding a file")
+	}
+}
+
+// TestFindTempDirsFindsScopedTempDirs pins that a scoped package's temp
+// directory, which sits one level deeper, is not missed.
+func TestFindTempDirsFindsScopedTempDirs(t *testing.T) {
+	s := newReapStore(t)
+	orphan := filepath.Join(s.Root(), "@org", "pkg", ".fedcba9876543210.tmp-42")
+	seedStoreDir(t, orphan)
+
+	dirs, unreadable := s.FindTempDirs()
+	if unreadable != 0 {
+		t.Fatalf("FindTempDirs() could not read %d director(ies)", unreadable)
+	}
+	if len(dirs) != 1 || dirs[0].Path != orphan {
+		t.Fatalf("FindTempDirs() found %v, want just %s", tempDirPaths(dirs), orphan)
+	}
+}
+
+// TestFindTempDirsLeavesStoreEntriesAlone is the negative case. Store entries,
+// the completeness marker and the backfill sentinel all live in the same tree,
+// and a sweep that matches any dot-prefixed entry would take the store's own
+// bookkeeping with it.
+func TestFindTempDirsLeavesStoreEntriesAlone(t *testing.T) {
+	s := newReapStore(t)
+
+	keep := []string{
+		filepath.Join(s.Root(), "my-pkg", "0123456789abcdef"),
+		filepath.Join(s.Root(), "@org", "pkg", "fedcba9876543210"),
+		// A package whose name legitimately begins with a dot.
+		filepath.Join(s.Root(), ".hidden-pkg", "0011223344556677"),
+		// Close to the temp shape but not it: a non-numeric random tail, and a
+		// hash portion that is not hex.
+		filepath.Join(s.Root(), "my-pkg", ".0123456789abcdef.tmp-notdigits"),
+		filepath.Join(s.Root(), "my-pkg", ".nothex.tmp-1234"),
+		filepath.Join(s.Root(), "my-pkg", ".tmp-1234"),
+	}
+	for _, dir := range keep {
+		seedStoreDir(t, dir)
+	}
+	orphan := filepath.Join(s.Root(), "my-pkg", ".aabbccddeeff0011.tmp-7")
+	seedStoreDir(t, orphan)
+
+	dirs, unreadable := s.FindTempDirs()
+	if unreadable != 0 {
+		t.Fatalf("FindTempDirs() could not read %d director(ies)", unreadable)
+	}
+	if len(dirs) != 1 || dirs[0].Path != orphan {
+		t.Fatalf("FindTempDirs() found %v, want just %s", tempDirPaths(dirs), orphan)
+	}
+	for _, dir := range keep {
+		if _, err := os.Stat(dir); err != nil {
+			t.Errorf("%s no longer stats: %v", dir, err)
+		}
+	}
+}
+
+// TestFindTempDirsMatchesWhatTheWritePathProduces ties the matcher to the name
+// the write path actually creates, by calling the very function Store calls
+// rather than re-deriving the name from the same constant the matcher reads.
+// Re-deriving it would let the write path change its literal and the sweep go
+// quietly blind with every test still green.
+func TestFindTempDirsMatchesWhatTheWritePathProduces(t *testing.T) {
+	s := newReapStore(t)
+	const hash = "0123456789abcdef"
+	parent := filepath.Join(s.Root(), "my-pkg")
+	if err := os.MkdirAll(parent, 0755); err != nil {
+		t.Fatalf("create package dir: %v", err)
+	}
+	made, err := newTempDir(parent, hash)
+	if err != nil {
+		t.Fatalf("newTempDir() error = %v", err)
+	}
+
+	dirs, unreadable := s.FindTempDirs()
+	if unreadable != 0 {
+		t.Fatalf("FindTempDirs() could not read %d director(ies)", unreadable)
+	}
+	if len(dirs) != 1 || dirs[0].Path != made {
+		t.Fatalf("FindTempDirs() found %v, want just %s", tempDirPaths(dirs), made)
+	}
+}
+
+// TestFindTempDirsOnAnEmptyStore pins that a store with nothing in it is not an
+// error: gc runs against fresh stores too.
+func TestFindTempDirsOnAnEmptyStore(t *testing.T) {
+	s := newReapStore(t)
+	dirs, unreadable := s.FindTempDirs()
+	if unreadable != 0 {
+		t.Fatalf("FindTempDirs() could not read %d director(ies)", unreadable)
+	}
+	if len(dirs) != 0 {
+		t.Errorf("FindTempDirs() found %v in an empty store", tempDirPaths(dirs))
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -16,6 +16,19 @@ import (
 	"github.com/pedrosousa13/lnpm/internal/pack"
 )
 
+// tempInfix separates a temp directory's hash from the random tail os.MkdirTemp
+// appends, and newTempDir below is the only place a temp directory name is
+// built. The sweep in reap.go matches against the same constant and recognises
+// what this function creates by calling it, so the write path and the sweep
+// cannot drift into disagreeing about the name.
+const tempInfix = ".tmp-"
+
+// newTempDir creates the directory the write path populates for hash, as a
+// sibling of the entry it will be renamed to.
+func newTempDir(parent, hash string) (string, error) {
+	return os.MkdirTemp(parent, "."+hash+tempInfix)
+}
+
 // shortHash returns the first 8 characters of a hash for display
 func shortHash(hash string) string {
 	if len(hash) > 8 {
@@ -99,7 +112,7 @@ func (s *Store) Store(name, hash string, files []*pack.FileInfo, sourceDir strin
 	if err := os.MkdirAll(parent, 0755); err != nil {
 		return "", fmt.Errorf("failed to create store directory: %w", err)
 	}
-	destPath, err := os.MkdirTemp(parent, "."+hash+".tmp-")
+	destPath, err := newTempDir(parent, hash)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp store directory: %w", err)
 	}


### PR DESCRIPTION
Two write paths build into a temporary directory and rename it into place — the store's package write, and the linker's relink. Both register a deferred cleanup, and a deferred cleanup only runs on a normal return. A process killed by a signal, an OOM, or a power loss leaves the directory behind, and nothing ever reclaimed it.

Three shapes leak, and all three are **invisible**: `ListLinked` skips dot-prefixed entries precisely so an in-progress relink is not reported as a linked package — correct for the live case, but it means orphans are hidden as well as unreclaimed. Nothing in the tool would ever mention them.

The retired shape is the worst: it holds a complete copy of the previous package, so it is real content the user has no way to discover.

## The safety argument

The sweep runs inside `gc` **while the exclusive database lock is held**. Every path that creates one of these directories opens the database first, and it takes an exclusive OS file lock, so a temp directory observed during the sweep has no live writer by construction.

Deliberately not an age heuristic, a pid file, or a lock file — it reuses an invariant the codebase already has and the OS already enforces.

**Verified rather than assumed:** `bolt.Open` is called without `ReadOnly`, so `flock(db, exclusive=true, …)` takes `LOCK_EX` (`LOCKFILE_EXCLUSIVE_LOCK` on Windows), released only in `close()`.

The ordering is load-bearing: if `gc` closed the database and then swept, the guarantee would evaporate and the sweep could race a publish that started in the meantime — reintroducing exactly the corruption #137 removed. So `reapTempDirs` refuses to run unless `LockHeld()` is true, and a test closes the handle and asserts the sweep errors and deletes nothing. `LockHeld` is genuine rather than an assertion that cannot fail: bbolt clears `db.path` in `close()`, so it really does flip.

## Not eating user data

The matchers key on the **actual prefixes**, never on "any dot-prefixed entry" — a package name may legitimately begin with a dot. The linker uses `.tmp-<hex>` with an optional `.old`; the store uses `.<hash>.tmp-<decimal>`, a different pattern.

Review attacked the matchers on paper with names a user could plausibly have — `.tmp-foo`, `.tmp-` alone, uppercase hex, `.tmp-abc.old.old`, `.tmpish`, `tmp-deadbeef`, `.hidden-pkg`, `.hidden-scoped-pkg`, `.abc.tmp-1.tmp-2` — and every one is correctly rejected.

Mutating each matcher to `strings.HasPrefix(name, ".")` fails exactly one test apiece, and those tests would otherwise be the only thing standing between the sweep and a user's dot-named package.

## Constants own their write paths

Review caught the first cut declaring a `tempInfix` constant whose comment said it existed "rather than a hand-copied guess" — while `store.go` still wrote the literal. Change the literal and the sweep would silently stop reaping, with no test failing, because the test re-derived the name from the constant.

Both packages now build their temp names through the constant the matcher uses, and `TestFindTempDirsMatchesWhatTheWritePathProduces` calls the real write path. A new drift mutation confirms it: changing the infix to `".temporary-"` now fails that test, where before it would have passed green.

## Reporting

`gc` names what it reclaimed rather than freeing bytes silently, and distinguishes all four cases — an in-progress directory, a retired directory holding a complete package, an in-progress link, and a retired link. The link cases matter: a retired `LinkSource` entry is a symlink of size 0, and the first cut told the user it was a "complete copy of the previous package", which was simply false.

The two confirmations are now independent decisions. Declining package deletion previously returned before the sweep ran, so a user who said no to packages would never learn temp directories existed.

## One rule for unreadable directories

Both finders now count and skip rather than abort, and surface the count through `iconWarn()`. Per ADR-0001 the question is direction, not severity: skipping *narrows* what a reaper destroys and leaves the bytes for the next run, while aborting would abandon every other project plus the store sweep that already succeeded — and `gc` is exactly the command a user reaches for when something is already wrong. Not silent, because invisibility is half the bug being fixed.

`DirSize` and `IsLowerHex` moved to `internal/fsutil`, the established shared home, rather than living duplicated in both packages.

## Verified

Every fix pinned by mutation, not just by a passing test: the greedy matcher on both sides, the write-path drift, the retired-link label, and the decoupled prompts.

An end-to-end run against a real `publish` + `add` in a throwaway store reclaimed all four shapes while `.hidden-pkg`, `demo-pkg`, the `@org` scope directory **and the symlink's target source tree** all survived.

Gates: `go test ./...` under `umask 022`, `go vet`, `golangci-lint`, `gofmt`, plus `windows/amd64` build and `windows/amd64`, `darwin/arm64`, `linux/arm64` vet.

**Windows was not executed.** The sweep matches anything that is not a regular file rather than testing for `ModeSymlink`, so it does not depend on which mode bits Go reports for a junction, and `os.RemoveAll` removes a reparse point without following it. Sharing violations make removal fail more often there; each failure warns and the sweep continues, and nothing is claimed as freed that was not.

## Noticed, not fixed

- **`gc --fix-links` deletes orphaned link records with no confirmation**, sitting before the `confirm` guard — the pre-existing finding the issue flags. Not repeated here; the new sweep is dry-run and confirmation aware. Still unfixed.
- `RunGC` never closes the database. Harmless today, and it happens to make the ordering constraint trivially satisfied — which is why the explicit `LockHeld` assertion exists rather than relying on it.
- `gc`'s scan loop discards errors from `GetLinksForPackage` and `GetProjectByID`, so a transient read failure could silently make a package look orphaned and therefore deletable.
- `backfillMarkers` runs on every `store.New()`, including inside `gc`, and can re-mark an entry a concurrent deletion just unmarked. Documented in its own comment as a known bounded window.

Closes #233