### PR TITLE
Keep GetDB's init error so every caller sees it

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -19,6 +19,7 @@ import (
 
 var (
 	instance *DB
+	initErr  error
 	once     sync.Once
 )
 
@@ -97,16 +98,16 @@ type FileEntry struct {
 	ModTime      int64       `json:"mod_time"` // Unix nano timestamp for quick change detection
 }
 
-// GetDB returns the singleton database instance
+// GetDB returns the singleton database instance.
+//
+// initDB runs once, so its error is kept in package state and handed to every
+// later caller too. A caller that got nil back with no error would panic on
+// first use instead of reporting why the database could not be opened.
 func GetDB() (*DB, error) {
-	var initErr error
 	once.Do(func() {
 		instance, initErr = initDB()
 	})
-	if initErr != nil {
-		return nil, initErr
-	}
-	return instance, nil
+	return instance, initErr
 }
 
 // initDB initializes the database
@@ -200,6 +201,7 @@ func ResetForTesting() {
 		_ = instance.Close()
 	}
 	instance = nil
+	initErr = nil
 	once = sync.Once{}
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -80,6 +80,71 @@ func TestGetDB_WaitsOutALockHeldLongerThanASecond(t *testing.T) {
 	}
 }
 
+// TestGetDB_AfterAFailedInit_KeepsReportingTheError checks that a failed
+// initialisation stays reported. sync.Once runs initDB exactly once, so every
+// later caller has to be handed the error the first one saw — otherwise they
+// get a nil handle with no error and panic on first use, losing the diagnostic.
+//
+// The singleton is package-global, so this test must not call t.Parallel() and
+// must not run alongside one that does.
+func TestGetDB_AfterAFailedInit_KeepsReportingTheError(t *testing.T) {
+	ResetForTesting()
+	storeDir := t.TempDir()
+	t.Setenv("LNPM_STORE", storeDir)
+	t.Cleanup(ResetForTesting)
+
+	holdDatabaseLock(t, storeDir)
+	shortenOpenTimeout(t, 200*time.Millisecond)
+
+	if _, err := GetDB(); err == nil {
+		t.Fatal("Expected the first call to fail against a locked database")
+	}
+
+	database, err := GetDB()
+	if err == nil {
+		t.Fatal("Expected the second call to report the failed initialisation too")
+	}
+	if !strings.Contains(err.Error(), lockMessage) {
+		t.Errorf("Expected the second call's error to mention %q, got: %v", lockMessage, err)
+	}
+	if database != nil {
+		t.Error("Expected no database instance from a failed initialisation")
+	}
+}
+
+// TestGetDB_AfterResetFollowingAFailedInit_Succeeds is the flip side: the
+// remembered error must be cleared by ResetForTesting, or a process that failed
+// once could never open the database again.
+//
+// The singleton is package-global, so this test must not call t.Parallel() and
+// must not run alongside one that does.
+func TestGetDB_AfterResetFollowingAFailedInit_Succeeds(t *testing.T) {
+	ResetForTesting()
+	storeDir := t.TempDir()
+	t.Setenv("LNPM_STORE", storeDir)
+	t.Cleanup(ResetForTesting)
+
+	holder := holdDatabaseLock(t, storeDir)
+	shortenOpenTimeout(t, 200*time.Millisecond)
+
+	if _, err := GetDB(); err == nil {
+		t.Fatal("Expected the first call to fail against a locked database")
+	}
+
+	if err := holder.Close(); err != nil {
+		t.Fatalf("Failed to release the database lock: %v", err)
+	}
+	ResetForTesting()
+
+	database, err := GetDB()
+	if err != nil {
+		t.Fatalf("Expected the open to succeed once the lock was released, got: %v", err)
+	}
+	if database == nil {
+		t.Fatal("Expected a database instance")
+	}
+}
+
 // TestGetDB_NonTimeoutFailure_DoesNotBlameAnotherProcess pins the error
 // classification: an open that fails for a reason other than the lock must not
 // be reported as a concurrent lnpm invocation.


### PR DESCRIPTION
`initErr` was declared **local** to `GetDB` and only assigned inside `once.Do`, which runs exactly once. So when `initDB()` failed, the first call returned the error correctly and every subsequent call re-declared `initErr` as nil, skipped the `once.Do` body, and fell through to `return instance, nil` — with `instance` nil.

Callers got `(nil, nil)`: a nil handle with no error, panicking on first use instead of reporting why the database could not be opened.

## Why it matters

#165 added a clear message for the case where another lnpm process holds the database lock. That message comes from `initDB`, so **only the first caller ever saw it**. Any later `GetDB()` in the same process got a nil dereference instead — turning a good diagnostic into a crash. Several commands call `GetDB()` from more than one place, so this is reachable in practice rather than theoretical.

## The fix

Exactly the issue's sketch: `initErr` moves into the package-level `var` block so it survives past the `once.Do`, `GetDB` returns it directly, and `ResetForTesting` clears it. No signature changes, no restructuring of the singleton, no retry-on-error.

## Concurrency

`GetDB` is reachable from multiple goroutines, and the fix moves a read outside the `once.Do` closure — so this deserved checking rather than assuming.

Go's memory model states that the completion of `f` in `once.Do(f)` is synchronized before the return of **every** `once.Do` call, and `Do` does not return until `f` has. A goroutine arriving mid-`f` blocks on `Once`'s mutex, so the write happens-before every read. This is also not a new pattern: the pre-change code already read package-level `instance` outside the closure under that identical guarantee.

Reviewed at high confidence. **`-race` cannot be run on the development machine (no gcc)**, so this rests on reasoning plus CI's race detector, not on a local run.

## Tests

`TestGetDB_AfterAFailedInit_KeepsReportingTheError` asserts on the **second** call specifically — a test checking only the first would pass today and prove nothing. Verified red-first, and review re-verified it independently by reverting `db.go` in a scratch copy:

```
--- FAIL: TestGetDB_AfterAFailedInit_KeepsReportingTheError
    db_test.go:105: Expected the second call to report the failed initialisation too
```

`TestGetDB_AfterResetFollowingAFailedInit_Succeeds` passes against the unfixed code and is honestly labelled as what it is: not a regression guard for this bug, but a characterisation test protecting against a plausible *alternative* implementation — one that short-circuits on a sticky `initErr` with no clearing path. Verified by mutation: implementing the fix that way, without clearing, fails it.

Both reuse the existing `holdDatabaseLock` and `shortenOpenTimeout` levers rather than hand-rolling, and both carry the non-parallel note for touching package-level state.

## A note on `initErr = nil` in `ResetForTesting`

Mutation-tested twice, and worth recording because it is deliberately kept despite being unreachable today: removing it leaves the suite green, because `ResetForTesting` also resets `once`, so the next `once.Do` unconditionally overwrites `initErr`.

Kept anyway. The issue specifies it; `ResetForTesting` resets a three-field state group and clearing two of three is a trap for whoever next touches `GetDB`; and review identified a genuinely reachable case — if `initDB` ever panicked, `Once` still marks itself done and `initErr` would retain a stale value.

Gates: `go test ./...` under `umask 022`, `go vet`, `golangci-lint`, `gofmt`, plus `windows/amd64` build and `windows/amd64`, `darwin/arm64`, `linux/arm64` vet.

## Windows

The failing init is produced by the file lock, so these tests do depend on lock semantics — but they add **no new** Windows exposure: `holdDatabaseLock` is already relied on by the merged `TestGetDB_LockHeldElsewhere_NamesTheOtherProcess` and `TestGetDB_WaitsOutALockHeldLongerThanASecond`.

One step is new: the reset test closes the holder and reopens within the same process, relying on the lock releasing synchronously on `Close` — synchronous under both `flock` and `CloseHandle`. `t.Cleanup` ordering was checked deliberately: `TempDir`'s removal is registered first and so runs last, after both the holder close and `ResetForTesting`'s `instance.Close()`, so no open handle blocks the temp-dir delete. That is the usual Windows-only way a test like this dies.

## Noticed, not fixed

- `ResetForTesting` discards `instance.Close()`'s error, so a store that failed to close would silently leak a lock into the next test. Pre-existing.
- `DeleteLink` duplicates `removeIDFromIndex` inline, twice, having had that helper extracted immediately above it. Dead duplication, unrelated to this fix.

Closes #253