### PR TITLE
fix(workspace): abort ListPackages on a member that will not read or parse

### DIFF
--- a/docs/adr/0001-swallowed-errors-that-widen-a-publish-are-bugs.md
+++ b/docs/adr/0001-swallowed-errors-that-widen-a-publish-are-bugs.md
@@ -1,11 +1,11 @@
 # Swallowed errors that widen a publish are bugs; ones that narrow it are not
 
-lnpm's publish paths repeatedly discard an error and continue, and the same
+lnpm's publish paths repeatedly discarded an error and continued, and the same
 `if err != nil { continue }` means opposite things depending on which way it
-fails. When workspace pattern expansion discards a failure on a `!`-prefixed
-negation, the package the maintainer excluded is published into the shared
-store; when it discards one on an include pattern, or when package listing
-skips a member whose `package.json` will not parse, the result is publishing
+fails. When workspace pattern expansion discarded a failure on a `!`-prefixed
+negation, the package the maintainer excluded was published into the shared
+store; when it discarded one on an include pattern, or when package listing
+skipped a member whose `package.json` would not parse, the result was publishing
 less than asked. We treat the first as a bug to fix loudly and the second as a
 judgement call to make case by case, because publishing a package the
 maintainer deliberately excluded is not recoverable by the person it surprises,
@@ -16,8 +16,21 @@ while publishing too few is visible to the one running the command.
 A reader will find the two directions handled differently in the same file, and
 that asymmetry is deliberate rather than an oversight — the resolution is not
 "make them consistent". Concretely, a malformed workspace glob pattern aborts
-the operation and names the pattern, while an unreadable workspace member is
-still an open question tracked separately.
+the operation and names the pattern, and so does a workspace member that will
+not read, will not parse, or names no package.
+
+That last group is the judgement call above, called in #246. Pattern expansion
+already filters on `package.json` presence, so every member it hands to package
+listing had one moments earlier: a failure there is a broken member of a
+workspace the caller asked for, not the non-package directory weighed below.
+The nameless member — no `name` key, an empty one, or a `null` document — was
+included on the maintainer's explicit confirmation, knowing pattern expansion
+does not filter on `name` and that a marker manifest such as `{"private": true}`
+therefore fails the whole listing; publishing under an empty name, or resolving
+a `workspace:` specifier against one, is the worse outcome. The abort is not
+confined to `publish --all` — `pack.indexWorkspace` lists the same packages
+whenever a single package carries `workspace:` dependencies, so one broken
+sibling stops that publish too.
 
 The rule is about direction, not about severity: a fail-open path is worth
 fixing even when it needs a config typo to trigger, and a fail-closed path can

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -271,9 +271,12 @@ func (w *Workspace) ListPackages() ([]Package, error) {
 		}
 
 		// A nameless package cannot be published or resolved against, and
-		// returning it with an empty name carries the breakage downstream.
+		// returning it with an empty name carries the breakage downstream. The
+		// name is absent, explicitly "", or the whole document is a JSON null,
+		// which encoding/json unmarshals as a no-op; the message covers all
+		// three rather than claiming the key is missing.
 		if pkg.Name == "" {
-			return nil, fmt.Errorf("workspace package %s has no name field", pkgJSON)
+			return nil, fmt.Errorf("workspace package %s has an empty or missing name", pkgJSON)
 		}
 
 		packages = append(packages, Package{

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -241,14 +241,18 @@ func expandGlobs(root string, patterns []string) ([]string, error) {
 // ListPackages returns all packages in the workspace with their metadata.
 //
 // A member that will not read, will not parse, or names no package fails the
-// whole listing. This is the "glob legitimately matches a non-package
-// directory" case that docs/adr/0001 leaves open, except that it is not that
-// case: expandGlobs already dropped every directory without a package.json
-// before it reached w.Packages, so a failure here is a broken member of a
-// workspace the caller asked for - a permission problem, a config typo, or a
-// file deleted underneath us - and not a directory that merely is not a
-// package. Skipping it publishes less than `--all` asked for and still reports
-// success.
+// whole listing - the decision docs/adr/0001 records. expandGlobs already
+// dropped every directory without a package.json before it reached w.Packages,
+// so a failure here is a broken member of a workspace the caller asked for - a
+// permission problem, a config typo, or a file deleted underneath us - and not
+// the non-package directory the ADR weighed under Considered options when it
+// declined to hard-fail by default. Skipping it publishes less than the caller
+// asked for and still reports success.
+//
+// Both production callers inherit that. publishAll fails the whole `--all` run,
+// and pack.indexWorkspace fails a single-package publish whose manifest carries
+// workspace: dependencies, so one broken sibling stops `lnpm publish` on an
+// otherwise healthy package.
 //
 // An unreadable member and an unparseable one are deliberately not
 // distinguished; both name the offending file and wrap the underlying error.

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -238,7 +238,20 @@ func expandGlobs(root string, patterns []string) ([]string, error) {
 	return filtered, nil
 }
 
-// ListPackages returns all packages in the workspace with their metadata
+// ListPackages returns all packages in the workspace with their metadata.
+//
+// A member that will not read, will not parse, or names no package fails the
+// whole listing. This is the "glob legitimately matches a non-package
+// directory" case that docs/adr/0001 leaves open, except that it is not that
+// case: expandGlobs already dropped every directory without a package.json
+// before it reached w.Packages, so a failure here is a broken member of a
+// workspace the caller asked for - a permission problem, a config typo, or a
+// file deleted underneath us - and not a directory that merely is not a
+// package. Skipping it publishes less than `--all` asked for and still reports
+// success.
+//
+// An unreadable member and an unparseable one are deliberately not
+// distinguished; both name the offending file and wrap the underlying error.
 func (w *Workspace) ListPackages() ([]Package, error) {
 	var packages []Package
 
@@ -246,7 +259,7 @@ func (w *Workspace) ListPackages() ([]Package, error) {
 		pkgJSON := filepath.Join(pkgPath, "package.json")
 		data, err := os.ReadFile(pkgJSON)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("failed to read workspace package %s: %w", pkgJSON, err)
 		}
 
 		var pkg struct {
@@ -254,7 +267,13 @@ func (w *Workspace) ListPackages() ([]Package, error) {
 			Version string `json:"version"`
 		}
 		if err := json.Unmarshal(data, &pkg); err != nil {
-			continue
+			return nil, fmt.Errorf("failed to parse workspace package %s: %w", pkgJSON, err)
+		}
+
+		// A nameless package cannot be published or resolved against, and
+		// returning it with an empty name carries the breakage downstream.
+		if pkg.Name == "" {
+			return nil, fmt.Errorf("workspace package %s has no name field", pkgJSON)
 		}
 
 		packages = append(packages, Package{

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -179,6 +180,127 @@ func TestDetectPNPMWorkspaceMalformedPatternReturnsError(t *testing.T) {
 	}
 	if ws != nil {
 		t.Errorf("Expected no workspace alongside the error, got %+v", ws)
+	}
+}
+
+// --- ListPackages -----------------------------------------------------------
+//
+// Every path in w.Packages had a package.json when expandGlobs filtered on it,
+// so a member that will not read, will not parse, or names no package is a
+// broken member of a workspace the caller asked for, not a directory that
+// happens not to be a package. docs/adr/0001 makes that an abort.
+
+// requirePermissionEnforcement skips tests that make a file unreadable with
+// chmod. Windows models only a read-only bit and root ignores permission bits
+// entirely, so neither can produce the failure these tests depend on.
+func requirePermissionEnforcement(t *testing.T) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows reports only a read-only bit, not Unix permission bits")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses the permission checks this test relies on")
+	}
+}
+
+func TestListPackagesReturnsEveryWellFormedMember(t *testing.T) {
+	root := t.TempDir()
+	pkgA := writePackage(t, root, "packages/package-a")
+	pkgB := writePackage(t, root, "packages/package-b")
+
+	ws := &Workspace{Root: root, Type: "npm", Packages: []string{pkgA, pkgB}}
+	packages, err := ws.ListPackages()
+	if err != nil {
+		t.Fatalf("Failed to list packages: %v", err)
+	}
+
+	if len(packages) != 2 {
+		t.Fatalf("Expected 2 packages, got %d: %v", len(packages), packages)
+	}
+	for i, want := range []struct{ name, path string }{
+		{"package-a", pkgA},
+		{"package-b", pkgB},
+	} {
+		if packages[i].Name != want.name || packages[i].Path != want.path {
+			t.Errorf("Expected package %d to be %s at %s, got %s at %s",
+				i, want.name, want.path, packages[i].Name, packages[i].Path)
+		}
+		if packages[i].Version != "1.0.0" {
+			t.Errorf("Expected package %d version 1.0.0, got %s", i, packages[i].Version)
+		}
+	}
+}
+
+func TestListPackagesUnparseableMemberFails(t *testing.T) {
+	root := t.TempDir()
+	pkgA := writePackage(t, root, "packages/package-a")
+	pkgB := writePackage(t, root, "packages/package-b")
+
+	broken := filepath.Join(pkgB, "package.json")
+	if err := os.WriteFile(broken, []byte(`{"name":"package-b",}`), 0644); err != nil {
+		t.Fatalf("Failed to write malformed package.json: %v", err)
+	}
+
+	ws := &Workspace{Root: root, Type: "npm", Packages: []string{pkgA, pkgB}}
+	packages, err := ws.ListPackages()
+	if err == nil {
+		t.Fatalf("Expected an error for the unparseable member, got nil and packages %v", packages)
+	}
+	if !strings.Contains(err.Error(), broken) {
+		t.Errorf("Expected the error to name %s, got: %v", broken, err)
+	}
+	if len(packages) != 0 {
+		t.Errorf("Expected no packages alongside the error, got %v", packages)
+	}
+}
+
+func TestListPackagesUnreadableMemberFails(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	root := t.TempDir()
+	pkgA := writePackage(t, root, "packages/package-a")
+	pkgB := writePackage(t, root, "packages/package-b")
+
+	unreadable := filepath.Join(pkgB, "package.json")
+	if err := os.Chmod(unreadable, 0000); err != nil {
+		t.Fatalf("Failed to chmod package.json: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0644) })
+
+	ws := &Workspace{Root: root, Type: "npm", Packages: []string{pkgA, pkgB}}
+	packages, err := ws.ListPackages()
+	if err == nil {
+		t.Fatalf("Expected an error for the unreadable member, got nil and packages %v", packages)
+	}
+	if !strings.Contains(err.Error(), unreadable) {
+		t.Errorf("Expected the error to name %s, got: %v", unreadable, err)
+	}
+	if len(packages) != 0 {
+		t.Errorf("Expected no packages alongside the error, got %v", packages)
+	}
+}
+
+func TestListPackagesNamelessMemberFails(t *testing.T) {
+	root := t.TempDir()
+	pkgA := writePackage(t, root, "packages/package-a")
+	pkgB := writePackage(t, root, "packages/package-b")
+
+	nameless := filepath.Join(pkgB, "package.json")
+	if err := os.WriteFile(nameless, []byte(`{"version":"1.0.0"}`), 0644); err != nil {
+		t.Fatalf("Failed to write nameless package.json: %v", err)
+	}
+
+	ws := &Workspace{Root: root, Type: "npm", Packages: []string{pkgA, pkgB}}
+	packages, err := ws.ListPackages()
+	if err == nil {
+		t.Fatalf("Expected an error for the nameless member, got nil and packages %v", packages)
+	}
+	if !strings.Contains(err.Error(), nameless) {
+		t.Errorf("Expected the error to name %s, got: %v", nameless, err)
+	}
+	if len(packages) != 0 {
+		t.Errorf("Expected no packages alongside the error, got %v", packages)
 	}
 }
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -305,25 +305,42 @@ func TestListPackagesUnreadableMemberFails(t *testing.T) {
 	}
 }
 
+// Three different manifests reach the nameless branch, and the message has to
+// be true of all of them. A JSON null is the surprising one: encoding/json
+// treats unmarshalling it as a no-op rather than an error, so the document
+// parses and leaves the zero value behind.
 func TestListPackagesNamelessMemberFails(t *testing.T) {
-	root := t.TempDir()
-	pkgA := writePackage(t, root, "packages/package-a")
-	pkgB := writePackage(t, root, "packages/package-b")
+	for _, tc := range []struct{ name, manifest string }{
+		{"missing name key", `{"version":"1.0.0"}`},
+		{"empty name", `{"name":"","version":"1.0.0"}`},
+		{"null document", `null`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			pkgA := writePackage(t, root, "packages/package-a")
+			pkgB := writePackage(t, root, "packages/package-b")
 
-	nameless := filepath.Join(pkgB, "package.json")
-	if err := os.WriteFile(nameless, []byte(`{"version":"1.0.0"}`), 0644); err != nil {
-		t.Fatalf("Failed to write nameless package.json: %v", err)
-	}
+			nameless := filepath.Join(pkgB, "package.json")
+			if err := os.WriteFile(nameless, []byte(tc.manifest), 0644); err != nil {
+				t.Fatalf("Failed to write nameless package.json: %v", err)
+			}
 
-	ws := &Workspace{Root: root, Type: "npm", Packages: []string{pkgA, pkgB}}
-	packages, err := ws.ListPackages()
-	if err == nil {
-		t.Fatalf("Expected an error for the nameless member, got nil and packages %v", packages)
-	}
-	if !strings.Contains(err.Error(), nameless) {
-		t.Errorf("Expected the error to name %s, got: %v", nameless, err)
-	}
-	if len(packages) != 0 {
-		t.Errorf("Expected no packages alongside the error, got %v", packages)
+			ws := &Workspace{Root: root, Type: "npm", Packages: []string{pkgA, pkgB}}
+			packages, err := ws.ListPackages()
+			if err == nil {
+				t.Fatalf("Expected an error for the nameless member, got nil and packages %v", packages)
+			}
+			if !strings.Contains(err.Error(), nameless) {
+				t.Errorf("Expected the error to name %s, got: %v", nameless, err)
+			}
+			// The message must describe every one of these manifests, so it
+			// cannot claim the name field is simply absent.
+			if !strings.Contains(err.Error(), "empty or missing name") {
+				t.Errorf("Expected the error to call the name empty or missing, got: %v", err)
+			}
+			if len(packages) != 0 {
+				t.Errorf("Expected no packages alongside the error, got %v", packages)
+			}
+		})
 	}
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -183,6 +183,30 @@ func TestDetectPNPMWorkspaceMalformedPatternReturnsError(t *testing.T) {
 	}
 }
 
+func TestDetectPNPMWorkspaceExcludesNegatedPackage(t *testing.T) {
+	root := t.TempDir()
+	pkgA := writePackage(t, root, "packages/package-a")
+	writePackage(t, root, "packages/package-b")
+
+	yaml := "packages:\n  - 'packages/*'\n  - '!packages/package-b'\n"
+	if err := os.WriteFile(filepath.Join(root, "pnpm-workspace.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatalf("Failed to write pnpm-workspace.yaml: %v", err)
+	}
+
+	ws, err := Detect(root)
+	if err != nil {
+		t.Fatalf("Failed to detect workspace: %v", err)
+	}
+	if ws == nil {
+		t.Fatal("Expected workspace, got nil")
+	}
+	if ws.Type != "pnpm" {
+		t.Errorf("Expected pnpm, got %s", ws.Type)
+	}
+
+	assertPackages(t, ws.Packages, []string{pkgA})
+}
+
 // --- ListPackages -----------------------------------------------------------
 //
 // Every path in w.Packages had a package.json when expandGlobs filtered on it,
@@ -302,28 +326,4 @@ func TestListPackagesNamelessMemberFails(t *testing.T) {
 	if len(packages) != 0 {
 		t.Errorf("Expected no packages alongside the error, got %v", packages)
 	}
-}
-
-func TestDetectPNPMWorkspaceExcludesNegatedPackage(t *testing.T) {
-	root := t.TempDir()
-	pkgA := writePackage(t, root, "packages/package-a")
-	writePackage(t, root, "packages/package-b")
-
-	yaml := "packages:\n  - 'packages/*'\n  - '!packages/package-b'\n"
-	if err := os.WriteFile(filepath.Join(root, "pnpm-workspace.yaml"), []byte(yaml), 0644); err != nil {
-		t.Fatalf("Failed to write pnpm-workspace.yaml: %v", err)
-	}
-
-	ws, err := Detect(root)
-	if err != nil {
-		t.Fatalf("Failed to detect workspace: %v", err)
-	}
-	if ws == nil {
-		t.Fatal("Expected workspace, got nil")
-	}
-	if ws.Type != "pnpm" {
-		t.Errorf("Expected pnpm, got %s", ws.Type)
-	}
-
-	assertPackages(t, ws.Packages, []string{pkgA})
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,6 +1,9 @@
 package workspace
 
 import (
+	"encoding/json"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -274,6 +277,12 @@ func TestListPackagesUnparseableMemberFails(t *testing.T) {
 	if !strings.Contains(err.Error(), broken) {
 		t.Errorf("Expected the error to name %s, got: %v", broken, err)
 	}
+	// The doc comment promises the underlying error is wrapped, not just
+	// described, so a caller can still reach the syntax error underneath.
+	var syntax *json.SyntaxError
+	if !errors.As(err, &syntax) {
+		t.Errorf("Expected the error to wrap a *json.SyntaxError, got: %v", err)
+	}
 	if len(packages) != 0 {
 		t.Errorf("Expected no packages alongside the error, got %v", packages)
 	}
@@ -299,6 +308,9 @@ func TestListPackagesUnreadableMemberFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), unreadable) {
 		t.Errorf("Expected the error to name %s, got: %v", unreadable, err)
+	}
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Errorf("Expected the error to wrap a permission error, got: %v", err)
 	}
 	if len(packages) != 0 {
 		t.Errorf("Expected no packages alongside the error, got %v", packages)

--- a/tests/e2e/monorepo_test.go
+++ b/tests/e2e/monorepo_test.go
@@ -211,3 +211,48 @@ func TestPublishAllRejectsMalformedWorkspacePattern(t *testing.T) {
 		}
 	}
 }
+
+// TestPublishAllRejectsUnparseableWorkspaceMember is the same proof one level
+// down: a workspace member whose package.json will not parse stops
+// `publish --all` outright instead of quietly publishing the healthy sibling
+// and reporting success. Running the compiled binary is what pins the parts the
+// in-process test cannot see — a non-zero exit, and the offending file reaching
+// the user's terminal.
+func TestPublishAllRejectsUnparseableWorkspaceMember(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	store := newStore(t)
+
+	writeFile(t, filepath.Join(root, "package.json"),
+		`{"name":"root","private":true,"workspaces":["packages/*"]}`)
+	writeFile(t, filepath.Join(root, "packages", "healthy", "package.json"),
+		`{"name":"e2e-healthy-member","version":"1.0.0"}`)
+	writeFile(t, filepath.Join(root, "packages", "broken", "package.json"),
+		`{"name":"e2e-broken-member","version":"1.0.0",}`)
+
+	out, err := runLNPMErr(t, store, root, "publish", "--all")
+	if err == nil {
+		t.Fatalf("expected publish --all to exit non-zero for an unparseable member, output:\n%s", out)
+	}
+
+	// The binary builds its paths from its own resolved working directory,
+	// which does not always spell the temp root the way t.TempDir did — macOS
+	// resolves /var to /private/var, Windows expands 8.3 short names — so match
+	// the workspace-relative tail. It still tells the two members apart.
+	brokenRel := filepath.Join("packages", "broken", "package.json")
+	if !strings.Contains(out, brokenRel) {
+		t.Errorf("expected the failure to name %s, output:\n%s", brokenRel, out)
+	}
+	healthyRel := filepath.Join("packages", "healthy", "package.json")
+	if strings.Contains(out, healthyRel) {
+		t.Errorf("expected the failure to name only the broken member, but it names %s:\n%s", healthyRel, out)
+	}
+
+	status := runLNPM(t, store, root, "status")
+	for _, name := range []string{"e2e-healthy-member", "e2e-broken-member"} {
+		if strings.Contains(status, name) {
+			t.Errorf("expected nothing published, but %s is in the store:\n%s", name, status)
+		}
+	}
+}

--- a/tests/workspace_test.go
+++ b/tests/workspace_test.go
@@ -130,16 +130,24 @@ func TestPublishAllUnparseableMemberFailsAndPublishesNothing(t *testing.T) {
 	env := setupTest(t)
 
 	wsDir := env.CopyFixture("npm-workspace")
-	broken := filepath.Join(wsDir, "packages", "package-b", "package.json")
-	env.writeFile(broken, `{"name":"@npm-test/package-b",}`)
+	brokenRel := filepath.Join("packages", "package-b", "package.json")
+	env.writeFile(filepath.Join(wsDir, brokenRel), `{"name":"@npm-test/package-b",}`)
 
 	env.chdir(wsDir)
 	err := cli.RunPublish(false, true, false, true)
 	if err == nil {
 		t.Fatal("Expected publish --all to fail for the unparseable member, got nil")
 	}
-	if !strings.Contains(err.Error(), broken) {
-		t.Errorf("Expected the error to name %s, got: %v", broken, err)
+	// Assert on the workspace-relative tail, not the absolute path: RunPublish
+	// builds its paths from os.Getwd, which resolves symlinks and 8.3 short
+	// names, so it does not always spell the temp root the way t.TempDir did.
+	// The tail still tells the two members apart, which is the point.
+	if !strings.Contains(err.Error(), brokenRel) {
+		t.Errorf("Expected the error to name %s, got: %v", brokenRel, err)
+	}
+	intactRel := filepath.Join("packages", "package-a", "package.json")
+	if strings.Contains(err.Error(), intactRel) {
+		t.Errorf("Expected the error to name only the broken member, but it names %s: %v", intactRel, err)
 	}
 
 	env.AssertPackageInDatabase("@npm-test/package-a", false)

--- a/tests/workspace_test.go
+++ b/tests/workspace_test.go
@@ -123,6 +123,29 @@ func TestDetectYarnWorkspace(t *testing.T) {
 	}
 }
 
+// A member the user asked to publish that will not parse must stop the whole
+// run: publishing the rest would report success having published less than
+// `--all` asked for.
+func TestPublishAllUnparseableMemberFailsAndPublishesNothing(t *testing.T) {
+	env := setupTest(t)
+
+	wsDir := env.CopyFixture("npm-workspace")
+	broken := filepath.Join(wsDir, "packages", "package-b", "package.json")
+	env.writeFile(broken, `{"name":"@npm-test/package-b",}`)
+
+	env.chdir(wsDir)
+	err := cli.RunPublish(false, true, false, true)
+	if err == nil {
+		t.Fatal("Expected publish --all to fail for the unparseable member, got nil")
+	}
+	if !strings.Contains(err.Error(), broken) {
+		t.Errorf("Expected the error to name %s, got: %v", broken, err)
+	}
+
+	env.AssertPackageInDatabase("@npm-test/package-a", false)
+	env.AssertPackageInDatabase("@npm-test/package-b", false)
+}
+
 func TestNoWorkspace(t *testing.T) {
 	ws, err := workspace.Detect("/tmp")
 	if err != nil {


### PR DESCRIPTION
Closes #246.

`Workspace.ListPackages` walked the workspace members, and `continue`d past any
whose `package.json` would not read or would not parse — then returned
`packages, nil` regardless. Its `error` return was dead code, so a single typo in
one member's manifest silently removed that package from the publish set and
`publish --all` reported success having published less than asked.

Demonstrated verbatim by reverting the fix under the new e2e test: a two-package
workspace with one malformed member prints `Published 1/1 packages` and exits
zero.

## What changed

`ListPackages` now aborts, naming the offending file and wrapping the underlying
error, on three cases:

- the member's `package.json` cannot be read,
- it will not parse,
- it parses but carries an empty or missing `name`.

Well-formed workspaces are unaffected. Unreadable and unparseable are
deliberately not distinguished — the accepted cost of the rule settled on the
issue: *fail on a config you are actually using; skip past one you are merely
walking through.*

Aborting is safe here because `expandGlobs` already filters on `package.json`
presence, so every path reaching `ListPackages` had a manifest moments earlier. A
failure is a broken member of a workspace the caller asked for, not a directory
that merely is not a package.

## Two consequences worth flagging

**The blast radius is wider than `--all`.** `pack.indexWorkspace` calls the same
method to resolve `workspace:` protocol dependencies, so `lnpm publish` on a
single package now fails if an unrelated sibling is broken. This replaces a
misleading `no such package in the workspace` with the real reason, but it is a
behaviour change on a path the issue did not name.

**A marker manifest now fails the listing.** `expandGlobs` filters on
`package.json` presence, not on `name`, so a glob-matched directory holding
something like `{"private": true}` aborts the whole run. This was raised in
review against `docs/adr/0001`, put to the maintainer with that evidence, and
confirmed: publishing under an empty name, or resolving a `workspace:` specifier
against one, is the worse outcome. The escape hatch is a `!` negation in the
workspace config. `docs/adr/0001` is updated to record the decision it had left
open.

## Tests

Four unit tests (well-formed, unreadable, unparseable, nameless — the last a
three-case table covering a missing key, an explicit `""`, and a `null`
document), one in-process integration test, and one e2e test that runs the
compiled binary, asserts a non-zero exit, and re-checks the store. Every new test
was revert-checked and fails without the fix, except the well-formed one, which
is a happy-path regression guard and is labelled as such. The wrapping contract
is pinned with `errors.Is`/`errors.As`. No pre-existing test was modified —
both test files are additions only.

Test assertions match the failing member by its workspace-relative path. An
absolute-path assertion cannot work here: `RunPublish` calls `os.Getwd()` after
`chdir`, which returns the resolved path, so `t.TempDir()`'s spelling and the
error's spelling differ on macOS (`/var` vs `/private/var`) and Windows (8.3 vs
long form). Verified on Linux by pointing `TMPDIR` at a symlink, which reproduces
the macOS divergence exactly.

## Verification

`go test ./... -count=1`, `go vet`, `golangci-lint`, `gofmt -l`, plus builds and
vets for windows/amd64, darwin/arm64 and linux/arm64 — all clean. Local gates
cross-compile for Windows but never execute there, so Windows behaviour rests on
CI rather than on anything proven locally.
