### PR TITLE
feat(restore): add `lnpm restore` to re-link packages after `retreat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ lnpm push
 | `lnpm doctor` | Diagnose issues |
 | `lnpm gc` | Garbage collect unused packages (`--dry-run`, `--older-than 30d`, `--fix-links`, `--yes`) |
 | `lnpm retreat` | Remove all lnpm changes |
+| `lnpm restore` | Re-link the packages `lnpm retreat` removed |
 | `lnpm config` | View/edit configuration |
 | `lnpm update` | Update lnpm to the latest version |
 | `lnpm completion` | Generate shell completions |
@@ -183,6 +184,19 @@ npm publish
 `lnpm check` scans `package.json` for leftover `file:.lnpm/` or `link:.lnpm/`
 references and exits non-zero if any remain — drop it in a `prepublishOnly`
 script or CI step to avoid accidentally publishing local links to npm.
+
+### After Publishing to npm
+
+```bash
+# Re-link everything the retreat removed
+lnpm restore
+```
+
+`lnpm retreat --force` saves what it unlinked to `lnpm.lock.retreat`, and
+`lnpm restore` links it all back. Packages added again in the meantime are kept
+as they are; nothing is unlinked. Packages restored this way are store copies
+(`file:.lnpm/<pkg>`) — re-run `lnpm add --link <pkg>` for the ones you want
+pointed back at their live source.
 
 ### Shell Completions
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,15 @@ lnpm restore
 `lnpm restore` links it all back. Packages added again in the meantime are kept
 as they are; nothing is unlinked. Packages restored this way are store copies
 (`file:.lnpm/<pkg>`) — re-run `lnpm add --link <pkg>` for the ones you want
-pointed back at their live source.
+pointed back at their live source. `lnpm.lock.retreat` is lnpm's own state: it
+is never published, and a second `lnpm retreat --force` merges into it rather
+than replacing it, so an unfinished restore is not lost.
+
+The snapshot records no `--dev` or `--pure` flag, so a package that had no
+`package.json` entry before the retreat cannot get the same treatment back.
+Restore writes it into `dependencies` and says so. For a `--pure` package that
+entry is spurious — `--pure` exists to keep a package out of `package.json` —
+so delete it after the restore.
 
 ### Shell Completions
 
@@ -401,7 +409,7 @@ lnpm decides which files to publish in Go — it does not shell out to the `npm`
 - Respects `package.json` `files` field
 - Honors a root `.npmignore`, falling back to a root `.gitignore` (ignore files in subdirectories are not read)
 - Supports gitignore pattern syntax — root anchoring (`/dist`), directory patterns (`dist/`) and negation (`*.txt` followed by `!keep.txt`), with the last matching pattern deciding
-- Applies a built-in exclusion list — VCS metadata and ignore files (`.git`, `.hg`, `.svn`, `CVS`, `.gitignore`, `.gitattributes`, `.npmignore`, `.npmrc`), `node_modules`, OS cruft (`.DS_Store`, `Thumbs.db`), editor and merge backups (`*.swp`, `*.swo`, `*~`, `*.orig`), lnpm and yalc state (`.lnpm/`, `.yalc/`, `lnpm.lock`, `yalc.lock`), `*.log`, `*.tgz`, and exactly `.env` and `.env.*` — that a `!` pattern cannot re-include. The patterns are literal, not prefixes: `.envrc` matches neither `.env` nor `.env.*`, so it is published
+- Applies a built-in exclusion list — VCS metadata and ignore files (`.git`, `.hg`, `.svn`, `CVS`, `.gitignore`, `.gitattributes`, `.npmignore`, `.npmrc`), `node_modules`, OS cruft (`.DS_Store`, `Thumbs.db`), editor and merge backups (`*.swp`, `*.swo`, `*~`, `*.orig`), lnpm and yalc state (`.lnpm/`, `.yalc/`, `lnpm.lock`, `lnpm.lock.retreat`, `yalc.lock`), `*.log`, `*.tgz`, and exactly `.env` and `.env.*` — that a `!` pattern cannot re-include. The patterns are literal, not prefixes: `.envrc` matches neither `.env` nor `.env.*`, so it is published
 - **Additional safety**: Explicit `.git` filtering prevents any VCS files from being linked
 - **Symlinks are skipped, never followed** — a symlink inside a package can't pull files from outside it (e.g. `~/.ssh`) into the store
 - Package names are restricted to a plain name (`my-pkg`) or a single scope (`@org/my-pkg`), because the name is joined into the store path. Everything else is rejected: a second `/`, a single `/` whose first segment is not a scope, `.` or `..` segments, absolute paths, backslashes and NUL bytes

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ lnpm push
 | `lnpm push` | Push changes to all linked projects |
 | `lnpm status` | Show all published packages and active links across every project |
 | `lnpm list` | List this project's linked packages (`--store` lists the store, `--projects` lists consumers) |
-| `lnpm check` | Fail if package.json still has lnpm references (pre-publish guard) |
+| `lnpm check` | Fail if lnpm has left anything an `npm publish` would ship (pre-publish guard) |
 | `lnpm doctor` | Diagnose issues |
 | `lnpm gc` | Garbage collect unused packages (`--dry-run`, `--older-than 30d`, `--fix-links`, `--yes`) |
 | `lnpm retreat` | Remove all lnpm changes |
@@ -181,9 +181,12 @@ lnpm check
 npm publish
 ```
 
-`lnpm check` scans `package.json` for leftover `file:.lnpm/` or `link:.lnpm/`
-references and exits non-zero if any remain — drop it in a `prepublishOnly`
-script or CI step to avoid accidentally publishing local links to npm.
+`lnpm check` reports what lnpm has left in the project that an `npm publish`
+would carry into the tarball, and exits non-zero if there is any — drop it in a
+`prepublishOnly` script or CI step. It looks for two things: leftover
+`file:.lnpm/` or `link:.lnpm/` references in `package.json`, and the
+`lnpm.lock.retreat` snapshot described below, when nothing in the project would
+keep that snapshot out of the tarball.
 
 ### After Publishing to npm
 
@@ -196,9 +199,16 @@ lnpm restore
 `lnpm restore` links it all back. Packages added again in the meantime are kept
 as they are; nothing is unlinked. Packages restored this way are store copies
 (`file:.lnpm/<pkg>`) — re-run `lnpm add --link <pkg>` for the ones you want
-pointed back at their live source. `lnpm.lock.retreat` is lnpm's own state: it
-is never published, and a second `lnpm retreat --force` merges into it rather
-than replacing it, so an unfinished restore is not lost.
+pointed back at their live source. A second `lnpm retreat --force` merges into
+`lnpm.lock.retreat` rather than replacing it, so an unfinished restore is not
+lost.
+
+`lnpm.lock.retreat` is lnpm's own state, and it records an absolute source path
+for every package it lists. `lnpm publish` never packs it. `npm publish` knows
+nothing about it, so keep it out of your tarball the way you keep any other file
+out — a `files` field in `package.json`, or a line in `.npmignore` or
+`.gitignore`. `lnpm check` fails if the snapshot is there and none of those
+would stop it.
 
 The snapshot records no `--dev` or `--pure` flag, so a package that had no
 `package.json` entry before the retreat cannot get the same treatment back.

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -2,16 +2,27 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
+
+	"github.com/pedrosousa13/lnpm/internal/pack"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
 
-// RunCheck scans the current project's package.json for leftover lnpm
-// references (file:.lnpm/ or link:.lnpm/) and returns a non-nil error if any
-// are found. It is meant as a pre-publish guard: run `lnpm retreat` to clear
-// the references before publishing to npm.
+// RunCheck reports whatever lnpm has left in the current project that an
+// `npm publish` from here would carry into the tarball, and returns a non-nil
+// error if there is any. It is the guard the README puts between
+// `lnpm retreat --force` and `npm publish`.
+//
+// Two things qualify. The first is a leftover lnpm reference (file:.lnpm/ or
+// link:.lnpm/) in package.json, which would ship a dependency specifier that
+// resolves to nothing on the consumer's machine. The second is the snapshot
+// `lnpm retreat` leaves behind, which records an absolute source path per
+// linked package.
 func RunCheck() error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -45,16 +56,66 @@ func RunCheck() error {
 		}
 	}
 
-	if len(found) == 0 {
-		fmt.Printf("%s No lnpm references in package.json\n", iconOK())
-		return nil
+	var problems []string
+
+	if len(found) > 0 {
+		sort.Strings(found)
+		fmt.Printf("%s Found %d lnpm reference(s) in package.json:\n", iconFail(), len(found))
+		for _, line := range found {
+			fmt.Println(line)
+		}
+		fmt.Printf("\n  %s Run 'lnpm retreat --force' to restore original dependencies before publishing\n", iconTip())
+		problems = append(problems, fmt.Sprintf("%d lnpm reference(s) found in package.json", len(found)))
 	}
 
-	sort.Strings(found)
-	fmt.Printf("%s Found %d lnpm reference(s) in package.json:\n", iconFail(), len(found))
-	for _, line := range found {
-		fmt.Println(line)
+	if publishableSnapshot(cwd, filesField(pkgJSON)) {
+		fmt.Printf("%s %s is in the project root and nothing here keeps it out of a tarball\n", iconFail(), lockfile.RetreatFileName)
+		fmt.Printf("  It is lnpm's record of what 'lnpm retreat' unlinked, and it holds an absolute path per package\n")
+		fmt.Printf("\n  %s Add %s to .npmignore or .gitignore, or list only what you ship in package.json \"files\"\n", iconTip(), lockfile.RetreatFileName)
+		fmt.Printf("      'lnpm restore' consumes the snapshot, but only after you have published\n")
+		problems = append(problems, lockfile.RetreatFileName+" would be published")
 	}
-	fmt.Printf("\n  %s Run 'lnpm retreat --force' to restore original dependencies before publishing\n", iconTip())
-	return fmt.Errorf("%d lnpm reference(s) found in package.json", len(found))
+
+	if len(problems) == 0 {
+		fmt.Printf("%s Nothing lnpm left behind would be published\n", iconOK())
+		return nil
+	}
+	return errors.New(strings.Join(problems, "; "))
+}
+
+// publishableSnapshot reports whether the retreat snapshot is sitting in the
+// project root with nothing to keep it out of a published tarball.
+//
+// Its presence is not itself a problem: the documented flow is retreat, check,
+// `npm publish`, restore, so the snapshot is on disk at check time by design,
+// and failing on that alone would fail every publish of every project that uses
+// restore at all. It is a problem only when it would actually be packed, because
+// it records an absolute source path for every package that was linked.
+//
+// `lnpm publish` never packs it - internal/pack excludes it outright - so the
+// case this covers is the npm CLI, which reads none of lnpm's rules. What it
+// does read is the "files" field and a root .npmignore, falling back to a root
+// .gitignore, which is why one line in an ignore file settles this for good.
+func publishableSnapshot(dir string, files []string) bool {
+	if _, err := os.Stat(lockfile.RetreatPath(dir)); err != nil {
+		return false
+	}
+	return !pack.ExcludedByProjectRules(dir, files, lockfile.RetreatFileName)
+}
+
+// filesField returns the package.json "files" entries, dropping anything that is
+// not a string, the way pack's own reader does. A "files" field of some other
+// shape entirely is no whitelist and reads as nil.
+func filesField(pkgJSON map[string]interface{}) []string {
+	raw, ok := pkgJSON["files"].([]interface{})
+	if !ok {
+		return nil
+	}
+	files := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		if s, ok := entry.(string); ok {
+			files = append(files, s)
+		}
+	}
+	return files
 }

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -270,15 +270,20 @@ Examples:
 // checkCmd scans package.json for leftover lnpm references
 var checkCmd = &cobra.Command{
 	Use:   "check",
-	Short: "Check package.json for leftover lnpm references",
-	Long: `Scan the current project's package.json for lnpm references
-(file:.lnpm/ or link:.lnpm/) left behind by 'lnpm add'.
+	Short: "Check the project for lnpm leftovers an npm publish would ship",
+	Long: `Report what lnpm has left in the current project that an 'npm publish'
+from here would carry into the tarball.
 
-Exits non-zero if any are found, so it can be used as a pre-publish guard
+Two things qualify: lnpm references (file:.lnpm/ or link:.lnpm/) in
+package.json, left behind by 'lnpm add'; and lnpm.lock.retreat, the snapshot
+'lnpm retreat' leaves for 'lnpm restore', when neither the package.json "files"
+field nor .npmignore nor .gitignore would keep it out.
+
+Exits non-zero if anything is found, so it can be used as a pre-publish guard
 in scripts or CI before running 'npm publish'.
 
 Examples:
-  lnpm check   # Fails if any lnpm reference remains in package.json`,
+  lnpm check   # Fails if lnpm has left anything publishable behind`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return RunCheck()
 	},

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -229,7 +229,7 @@ This command:
   1. Restores original package.json dependencies
   2. Removes node_modules symlinks
   3. Deletes .lnpm/ directory
-  4. Deletes lnpm.lock file
+  4. Saves lnpm.lock as lnpm.lock.retreat, for 'lnpm restore'
 
 Use this before publishing to npm or when done with local development.
 
@@ -252,6 +252,10 @@ behind, so local development can carry on after publishing to npm.
 
 Packages added again since the retreat are kept as they are, and packages the
 snapshot never saw are left alone. Nothing is unlinked.
+
+Everything comes back as a store copy (file:.lnpm/<pkg>), because the snapshot
+does not record which packages were added with --link. Run 'lnpm add --link
+<pkg>' again for the ones that should point back at their live source.
 
 A package whose recorded version is no longer the one in the store is reported
 and skipped; the snapshot is kept so restore can be re-run after publishing it.

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -243,6 +243,26 @@ Examples:
 	},
 }
 
+// restoreCmd re-links the packages a previous retreat unlinked
+var restoreCmd = &cobra.Command{
+	Use:   "restore",
+	Short: "Re-link the packages removed by 'lnpm retreat'",
+	Long: `Re-link every package recorded in the snapshot 'lnpm retreat --force' left
+behind, so local development can carry on after publishing to npm.
+
+Packages added again since the retreat are kept as they are, and packages the
+snapshot never saw are left alone. Nothing is unlinked.
+
+A package whose recorded version is no longer the one in the store is reported
+and skipped; the snapshot is kept so restore can be re-run after publishing it.
+
+Examples:
+  lnpm restore   # Undo the last 'lnpm retreat --force'`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return RunRestore()
+	},
+}
+
 // checkCmd scans package.json for leftover lnpm references
 var checkCmd = &cobra.Command{
 	Use:   "check",
@@ -263,6 +283,9 @@ Examples:
 func init() {
 	// Register retreat command
 	rootCmd.AddCommand(retreatCmd)
+
+	// Register restore command
+	rootCmd.AddCommand(restoreCmd)
 
 	// Register check command
 	rootCmd.AddCommand(checkCmd)

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -1,0 +1,241 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/pedrosousa13/lnpm/internal/config"
+	"github.com/pedrosousa13/lnpm/internal/db"
+	"github.com/pedrosousa13/lnpm/internal/gitignore"
+	"github.com/pedrosousa13/lnpm/internal/link"
+	"github.com/pedrosousa13/lnpm/internal/pkgjson"
+	"github.com/pedrosousa13/lnpm/internal/store"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
+)
+
+// RunRestore re-links every package recorded in the snapshot `lnpm retreat`
+// left behind, undoing the retreat.
+//
+// It merges rather than replaces: a package the user added again between the
+// retreat and the restore wins over the snapshot's entry for the same name, and
+// packages the snapshot never saw are left alone. Nothing is unlinked.
+//
+// Two parts of the pre-retreat state cannot be rebuilt from the snapshot,
+// because the lock file records neither. The first is whether a package was
+// added with --link: everything is restored as a store copy, which is what the
+// file:.lnpm/<pkg> specifier the command writes describes. The second is which
+// dependency field a package belonged in; that is recovered from package.json,
+// where retreat has just put the original specifier back, and reported when the
+// package has no entry there to recover it from.
+func RunRestore() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	pkgJSONPath := filepath.Join(cwd, "package.json")
+	if _, err := os.Stat(pkgJSONPath); err != nil {
+		return fmt.Errorf("no package.json found in current directory")
+	}
+
+	snapshotName := filepath.Base(lockfile.RetreatPath(cwd))
+
+	snapshot, err := lockfile.LoadRetreat(cwd)
+	if err != nil {
+		return fmt.Errorf("could not read %s: %w", snapshotName, err)
+	}
+	if snapshot == nil || len(snapshot.List()) == 0 {
+		fmt.Printf("Nothing to restore: no packages recorded by a previous 'lnpm retreat'\n")
+		return nil
+	}
+
+	database, err := db.GetDB()
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+
+	s, err := store.New()
+	if err != nil {
+		return fmt.Errorf("failed to access store: %w", err)
+	}
+
+	lock, err := lockfile.Load(cwd)
+	if err != nil {
+		return fmt.Errorf("failed to load lock file: %w", err)
+	}
+
+	fmt.Printf("Restoring from %s...\n", snapshotName)
+
+	cfg := config.Get()
+	if cfg.ShouldManageGitignore() {
+		if added, err := gitignore.EnsureInGitignore(cwd, ".lnpm/"); err != nil {
+			fmt.Printf("  %s Could not update .gitignore: %v\n", iconWarn(), err)
+		} else if added {
+			fmt.Printf("  %s Added .lnpm/ to .gitignore\n", iconOK())
+		}
+	}
+
+	linker := link.New(cwd)
+
+	// Sorted so the report reads the same way on every run; lock.List() walks a
+	// map.
+	names := snapshot.List()
+	sort.Strings(names)
+
+	failed := 0
+	restored := 0
+	for _, name := range names {
+		entry, _ := snapshot.Get(name)
+
+		// A package added again since the retreat is already linked, and the
+		// user's newer add is the one to keep.
+		if lock.Has(name) {
+			fmt.Printf("  %s %s was added again since the retreat; keeping that link\n", iconOK(), name)
+			continue
+		}
+
+		// The store keeps the latest published version per package, so the
+		// version the snapshot recorded may since have been superseded. Report
+		// it the way add does and carry on with the rest.
+		pkg, err := database.GetPackageByName(name)
+		if err != nil {
+			fmt.Printf("  %s %s: failed to look up package: %v\n", iconFail(), name, err)
+			failed++
+			continue
+		}
+		if pkg == nil {
+			fmt.Printf("  %s %s: not found in store. Did you run 'lnpm publish' in the package directory?\n", iconFail(), name)
+			failed++
+			continue
+		}
+		if entry.Version != "" && pkg.Version != entry.Version {
+			fmt.Printf("  %s %s: %v\n", iconFail(), name, versionNotInStoreError(entry.Version, name, pkg.Version))
+			failed++
+			continue
+		}
+
+		// Read package.json before anything is written to it, so the specifier
+		// retreat restored becomes this link's original version.
+		deps, err := readPackageJSONDeps(pkgJSONPath, name, false)
+		if err != nil {
+			fmt.Printf("  %s %s: failed to read package.json: %v\n", iconFail(), name, err)
+			failed++
+			continue
+		}
+		originalVersion := deps.originalVersion
+		if originalVersion == "" {
+			originalVersion = entry.OriginalVersion
+		}
+
+		linkType, err := linkPackage(linker, s, pkg, false)
+		if err != nil {
+			fmt.Printf("  %s %s: %v\n", iconFail(), name, err)
+			failed++
+			continue
+		}
+
+		// ORDERING CONSTRAINT: the same one add documents. The specifier lives
+		// only in package.json and the write below overwrites it, so the lock
+		// entry that carries it has to be on disk first.
+		lock.Add(name, lockfile.Package{
+			Version:         pkg.Version,
+			Hash:            pkg.ContentHash,
+			Source:          pkg.SourcePath,
+			Linked:          time.Now(),
+			OriginalVersion: originalVersion,
+		})
+		if err := lock.Save(cwd); err != nil {
+			return fmt.Errorf("failed to save lock file: %w", err)
+		}
+
+		if !dependencyFieldKnown(deps.src, name) {
+			fmt.Printf("  %s %s was not in package.json before the retreat, so its field is unknown; restoring it into %s\n",
+				iconWarn(), name, deps.field)
+		}
+
+		// The lock entry stays on a failure here: package.json is untouched, so
+		// it still holds whatever retreat left, and the entry records that as the
+		// original version - which is what a later remove or retreat needs.
+		if err := writeLnpmReference(pkgJSONPath, name, false, false); err != nil {
+			fmt.Printf("  %s %s: failed to update package.json: %v\n", iconFail(), name, err)
+			failed++
+			continue
+		}
+
+		recordRestoredLink(database, cwd, pkg, linkType)
+
+		fmt.Printf("%s Restored %s@%s\n", iconOK(), name, pkg.Version)
+		restored++
+	}
+
+	if failed == 0 {
+		if err := os.Remove(lockfile.RetreatPath(cwd)); err != nil && !os.IsNotExist(err) {
+			fmt.Printf("  %s Failed to remove %s: %v\n", iconWarn(), snapshotName, err)
+		}
+	}
+
+	fmt.Println()
+	if failed > 0 {
+		fmt.Printf("  %s %s kept; re-run 'lnpm restore' once the packages above are available\n", iconTip(), snapshotName)
+		return fmt.Errorf("%d of %d package(s) failed to restore", failed, len(names))
+	}
+
+	fmt.Printf("%s Restore complete!\n", iconOK())
+	if restored > 0 {
+		fmt.Printf("\n  %s Run 'npm install' if you need to resolve peer dependencies\n", iconTip())
+	}
+	return nil
+}
+
+// recordRestoredLink registers the project and its link to pkg, so `lnpm list`
+// and `lnpm push` see the restored package the way they see an added one. A
+// failure here costs only bookkeeping - the link on disk is already in place -
+// so it is reported and not treated as a failed restore.
+func recordRestoredLink(database *db.DB, cwd string, pkg *db.Package, linkType link.LinkType) {
+	proj := &db.Project{
+		Path:           cwd,
+		Name:           getProjectName(cwd),
+		PackageManager: string(config.DetectPackageManager(cwd)),
+	}
+	if err := database.InsertProject(proj); err != nil {
+		fmt.Printf("  %s Failed to register project: %v\n", iconWarn(), err)
+		return
+	}
+
+	existingProj, err := database.GetProjectByPath(cwd)
+	if err != nil {
+		fmt.Printf("  %s Failed to get project: %v\n", iconWarn(), err)
+		return
+	}
+
+	dbLink := &db.Link{
+		PackageID: pkg.ID,
+		ProjectID: existingProj.ID,
+		LinkType:  string(linkType),
+	}
+	if err := database.InsertLink(dbLink); err != nil {
+		fmt.Printf("  %s Failed to record link for %s: %v\n", iconWarn(), pkg.Name, err)
+	}
+}
+
+// dependencyFieldKnown reports whether package.json still says which dependency
+// field a package belongs in. When it does not - the package was added with
+// --dev or --pure without ever having an entry, and retreat dropped what add had
+// written - restore has to guess, and says so.
+func dependencyFieldKnown(pkgJSON []byte, name string) bool {
+	for _, field := range []string{"dependencies", "devDependencies"} {
+		has, err := pkgjson.HasDep(pkgJSON, field, name)
+		if err != nil {
+			// Unparseable package.json is reported by the read that follows;
+			// claiming the field is known keeps this from adding noise to it.
+			return true
+		}
+		if has {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -23,6 +23,11 @@ import (
 // retreat and the restore wins over the snapshot's entry for the same name, and
 // packages the snapshot never saw are left alone. Nothing is unlinked.
 //
+// Each name leaves the snapshot as it is dealt with, so what is on disk at any
+// point is the work still outstanding. A run that fails on some package keeps
+// the snapshot for the re-run it advises, and the re-run then sees only what is
+// genuinely left.
+//
 // Two parts of the pre-retreat state cannot be rebuilt from the snapshot,
 // because the lock file records neither. The first is whether a package was
 // added with --link: everything is restored as a store copy, which is what the
@@ -106,11 +111,14 @@ func RunRestore() error {
 
 		// A package already in the lock file was added again by the user since
 		// the retreat, and their newer add is the one to keep. Restore's own
-		// half-finished work cannot be mistaken for it: a lock entry is written
-		// only once the package.json write it describes has landed, so a package
-		// a previous restore could not finish leaves nothing here.
+		// work cannot be mistaken for it. A package a previous run finished is
+		// no longer in the snapshot, so it never reaches this loop; a package a
+		// previous run could not finish left no lock entry, because an entry is
+		// written only once the package.json write it describes has landed. So a
+		// name that is in the snapshot and in the lock file is the user's doing.
 		if lock.Has(name) {
 			fmt.Printf("  %s %s was added again since the retreat; keeping that link\n", iconOK(), name)
+			consumeSnapshotEntry(snapshot, cwd, name)
 			continue
 		}
 		attempted++
@@ -174,12 +182,13 @@ func RunRestore() error {
 		// ORDERING CONSTRAINT, and it is the reverse of the one add documents.
 		// add saves the lock entry before rewriting package.json because the
 		// specifier the entry carries lives nowhere else, so a failed rewrite
-		// would strand it. Restore holds a second copy of it: the snapshot,
-		// which it keeps whenever anything fails, records the same original
-		// version. So the entry can wait for the write - and it must, because an
-		// entry written ahead of the write is indistinguishable, on the re-run
-		// restore itself advises, from a package the user re-added, and would
-		// have that re-run skip the very package it was run to finish.
+		// would strand it. Restore holds a second copy of it: the snapshot's
+		// entry, which records the same original version and is not dropped
+		// until the write has landed. So the entry can wait for the write - and
+		// it must, because an entry written ahead of the write is
+		// indistinguishable, on the re-run restore itself advises, from a
+		// package the user re-added, and would have that re-run skip the very
+		// package it was run to finish.
 		//
 		// Saved per package rather than once at the end for the same reason: an
 		// entry batched to the end would be missing for every package whose
@@ -194,6 +203,7 @@ func RunRestore() error {
 		if err := lock.Save(cwd); err != nil {
 			return fmt.Errorf("failed to save lock file: %w", err)
 		}
+		consumeSnapshotEntry(snapshot, cwd, name)
 
 		recordRestoredLink(database, cwd, pkg, linkType)
 
@@ -201,6 +211,10 @@ func RunRestore() error {
 		restored++
 	}
 
+	// Nothing failed means every name was consumed above, so the file on disk is
+	// an empty snapshot. Removing it says the same thing and says it to every
+	// later retreat too, which reads a snapshot that is merely empty as an
+	// earlier retreat to merge into.
 	if failed == 0 {
 		if err := os.Remove(lockfile.RetreatPath(cwd)); err != nil && !os.IsNotExist(err) {
 			fmt.Printf("  %s Failed to remove %s: %v\n", iconWarn(), snapshotName, err)
@@ -209,7 +223,7 @@ func RunRestore() error {
 
 	fmt.Println()
 	if failed > 0 {
-		fmt.Printf("  %s %s kept; re-run 'lnpm restore' once the packages above are available\n", iconTip(), snapshotName)
+		fmt.Printf("  %s %s kept, holding only what is left; re-run 'lnpm restore' once the packages above are available\n", iconTip(), snapshotName)
 		// Counted against what was attempted, not against the snapshot: a
 		// package skipped because the user re-added it was never restore's to
 		// fail at, and counting it understates the share of the run that did.
@@ -221,6 +235,27 @@ func RunRestore() error {
 		fmt.Printf("\n  %s Run 'npm install' if you need to resolve peer dependencies\n", iconTip())
 	}
 	return nil
+}
+
+// consumeSnapshotEntry drops name from the snapshot and writes what is left back
+// to disk, so the snapshot always describes the work still outstanding rather
+// than the work the retreat once handed over.
+//
+// It is what makes a re-run after a partial failure honest. The snapshot has to
+// survive a run that failed on any package, because the packages that failed
+// still need it; kept whole, it would also still name every package this run did
+// restore, and the re-run would find them in the lock file and report restore's
+// own work back to the user as packages they re-added. It would also let a
+// package the user has since removed be re-linked by the next restore.
+//
+// A failure to write is reported and not treated as a failed restore: the link
+// is on disk and the lock file records it, so the run's work stands, and the
+// cost is a stale line in a report the user may never see.
+func consumeSnapshotEntry(snapshot *lockfile.LockFile, cwd, name string) {
+	snapshot.Remove(name)
+	if err := snapshot.SaveRetreat(cwd); err != nil {
+		fmt.Printf("  %s Failed to update %s: %v\n", iconWarn(), lockfile.RetreatFileName, err)
+	}
 }
 
 // recordRestoredLink registers the project and its link to pkg, so `lnpm list`

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -41,14 +41,32 @@ func RunRestore() error {
 		return fmt.Errorf("no package.json found in current directory")
 	}
 
-	snapshotName := filepath.Base(lockfile.RetreatPath(cwd))
+	snapshotName := lockfile.RetreatFileName
 
+	// The error already names the file it failed on, so it is returned as it
+	// came: wrapping it here would give the snapshot two names in one message.
 	snapshot, err := lockfile.LoadRetreat(cwd)
 	if err != nil {
-		return fmt.Errorf("could not read %s: %w", snapshotName, err)
+		return err
 	}
-	if snapshot == nil || len(snapshot.List()) == 0 {
-		fmt.Printf("Nothing to restore: no packages recorded by a previous 'lnpm retreat'\n")
+	if snapshot == nil {
+		fmt.Printf("Nothing to restore: no snapshot from a previous 'lnpm retreat'\n")
+		return nil
+	}
+
+	// Sorted so the report reads the same way on every run; List() walks a map.
+	names := snapshot.List()
+	sort.Strings(names)
+
+	if len(names) == 0 {
+		// A snapshot is not the same thing as no snapshot: this one is a retreat
+		// that found a lock file with nothing in it. There is nothing to put
+		// back, but the file is spent, and leaving it would stop every later
+		// restore on it and make every later retreat look like a second one.
+		if err := os.Remove(lockfile.RetreatPath(cwd)); err != nil && !os.IsNotExist(err) {
+			fmt.Printf("  %s Failed to remove %s: %v\n", iconWarn(), snapshotName, err)
+		}
+		fmt.Printf("Nothing to restore: the last 'lnpm retreat' recorded no packages\n")
 		return nil
 	}
 
@@ -80,22 +98,22 @@ func RunRestore() error {
 
 	linker := link.New(cwd)
 
-	// Sorted so the report reads the same way on every run; lock.List() walks a
-	// map.
-	names := snapshot.List()
-	sort.Strings(names)
-
 	failed := 0
 	restored := 0
+	attempted := 0
 	for _, name := range names {
 		entry, _ := snapshot.Get(name)
 
-		// A package added again since the retreat is already linked, and the
-		// user's newer add is the one to keep.
+		// A package already in the lock file was added again by the user since
+		// the retreat, and their newer add is the one to keep. Restore's own
+		// half-finished work cannot be mistaken for it: a lock entry is written
+		// only once the package.json write it describes has landed, so a package
+		// a previous restore could not finish leaves nothing here.
 		if lock.Has(name) {
 			fmt.Printf("  %s %s was added again since the retreat; keeping that link\n", iconOK(), name)
 			continue
 		}
+		attempted++
 
 		// The store keeps the latest published version per package, so the
 		// version the snapshot recorded may since have been superseded. Report
@@ -137,9 +155,35 @@ func RunRestore() error {
 			continue
 		}
 
-		// ORDERING CONSTRAINT: the same one add documents. The specifier lives
-		// only in package.json and the write below overwrites it, so the lock
-		// entry that carries it has to be on disk first.
+		// Nothing is recorded for this package until package.json holds the
+		// reference: on a failure here it still holds whatever retreat left, and
+		// the snapshot - kept, because this counts as a failure - still records
+		// the original version, so the re-run has everything it needs.
+		if err := writeLnpmReference(pkgJSONPath, name, false, false); err != nil {
+			fmt.Printf("  %s %s: failed to update package.json: %v\n", iconFail(), name, err)
+			failed++
+			continue
+		}
+
+		if !dependencyFieldKnown(deps.src, name) {
+			fmt.Printf("  %s %s was not in package.json before the retreat, so its field is unknown; restoring it into %s\n",
+				iconWarn(), name, deps.field)
+			fmt.Printf("      If it was added with --pure, delete that entry: --pure keeps a package out of package.json\n")
+		}
+
+		// ORDERING CONSTRAINT, and it is the reverse of the one add documents.
+		// add saves the lock entry before rewriting package.json because the
+		// specifier the entry carries lives nowhere else, so a failed rewrite
+		// would strand it. Restore holds a second copy of it: the snapshot,
+		// which it keeps whenever anything fails, records the same original
+		// version. So the entry can wait for the write - and it must, because an
+		// entry written ahead of the write is indistinguishable, on the re-run
+		// restore itself advises, from a package the user re-added, and would
+		// have that re-run skip the very package it was run to finish.
+		//
+		// Saved per package rather than once at the end for the same reason: an
+		// entry batched to the end would be missing for every package whose
+		// reference is already in package.json when a later one fails hard.
 		lock.Add(name, lockfile.Package{
 			Version:         pkg.Version,
 			Hash:            pkg.ContentHash,
@@ -149,20 +193,6 @@ func RunRestore() error {
 		})
 		if err := lock.Save(cwd); err != nil {
 			return fmt.Errorf("failed to save lock file: %w", err)
-		}
-
-		if !dependencyFieldKnown(deps.src, name) {
-			fmt.Printf("  %s %s was not in package.json before the retreat, so its field is unknown; restoring it into %s\n",
-				iconWarn(), name, deps.field)
-		}
-
-		// The lock entry stays on a failure here: package.json is untouched, so
-		// it still holds whatever retreat left, and the entry records that as the
-		// original version - which is what a later remove or retreat needs.
-		if err := writeLnpmReference(pkgJSONPath, name, false, false); err != nil {
-			fmt.Printf("  %s %s: failed to update package.json: %v\n", iconFail(), name, err)
-			failed++
-			continue
 		}
 
 		recordRestoredLink(database, cwd, pkg, linkType)
@@ -180,7 +210,10 @@ func RunRestore() error {
 	fmt.Println()
 	if failed > 0 {
 		fmt.Printf("  %s %s kept; re-run 'lnpm restore' once the packages above are available\n", iconTip(), snapshotName)
-		return fmt.Errorf("%d of %d package(s) failed to restore", failed, len(names))
+		// Counted against what was attempted, not against the snapshot: a
+		// package skipped because the user re-added it was never restore's to
+		// fail at, and counting it understates the share of the run that did.
+		return fmt.Errorf("%d of %d package(s) failed to restore", failed, attempted)
 	}
 
 	fmt.Printf("%s Restore complete!\n", iconOK())
@@ -225,15 +258,14 @@ func recordRestoredLink(database *db.DB, cwd string, pkg *db.Package, linkType l
 // field a package belongs in. When it does not - the package was added with
 // --dev or --pure without ever having an entry, and retreat dropped what add had
 // written - restore has to guess, and says so.
+//
+// HasDep only fails on a package.json that is not a JSON object, which the read
+// this call follows has already parsed as one, so the error cannot arrive here.
+// It is folded into "the field is not known" rather than given a branch of its
+// own: the answer would be a guess either way, and the caller says so.
 func dependencyFieldKnown(pkgJSON []byte, name string) bool {
 	for _, field := range []string{"dependencies", "devDependencies"} {
-		has, err := pkgjson.HasDep(pkgJSON, field, name)
-		if err != nil {
-			// Unparseable package.json is reported by the read that follows;
-			// claiming the field is known keeps this from adding noise to it.
-			return true
-		}
-		if has {
+		if has, err := pkgjson.HasDep(pkgJSON, field, name); err == nil && has {
 			return true
 		}
 	}

--- a/internal/cli/retreat.go
+++ b/internal/cli/retreat.go
@@ -66,7 +66,12 @@ func RunRetreat(force bool, runInstall bool) error {
 		}
 
 		fmt.Println("  - Delete .lnpm/ directory")
-		fmt.Printf("  - Save lnpm.lock as %s, for 'lnpm restore'\n", lockfile.RetreatFileName)
+		// Only when there is a lock file to save. A project with a stray .lnpm/
+		// and no lock file reaches here, and --force would print nothing about
+		// the lock file, because there is nothing to move aside.
+		if _, err := os.Stat(lockfile.Path(cwd)); err == nil {
+			fmt.Printf("  - Save lnpm.lock as %s, for 'lnpm restore'\n", lockfile.RetreatFileName)
+		}
 		return nil
 	}
 
@@ -178,14 +183,17 @@ func RunRetreat(force bool, runInstall bool) error {
 // The lock file being stashed then describes only what has been linked since,
 // and moving it over the snapshot would drop every package the earlier retreat
 // unlinked and the restore never got to. So the two are merged instead, this
-// retreat's entries winning any name they share: they are the newer record, and
-// the specifiers they carry are the ones just written back into package.json.
+// retreat's entries winning any name they share: they are the newer record of
+// the link. The exception is the original version, which is not a fact about the
+// link at all and is kept from the snapshot when the newer entry has none - see
+// the merge loop.
 func stashLockForRestore(cwd string, lock *lockfile.LockFile) {
 	if _, err := os.Stat(lockfile.Path(cwd)); err != nil {
 		// No lock file means there is nothing to save and nothing to say. Any
 		// other stat failure is worth a word, since the file may still be there.
 		if !os.IsNotExist(err) {
 			fmt.Printf("  %s Could not check lnpm.lock: %v\n", iconWarn(), err)
+			fmt.Printf("  %s The links are already gone; if lnpm.lock is still there, re-run 'lnpm retreat' to save it for 'lnpm restore'\n", iconWarn())
 		}
 		return
 	}
@@ -212,11 +220,31 @@ func stashLockForRestore(cwd string, lock *lockfile.LockFile) {
 
 	for _, name := range lock.List() {
 		entry, _ := lock.Get(name)
+		// The one field the newer entry must not win on when it is empty. Every
+		// other field describes the link, which the newer entry describes
+		// better; the original version describes what package.json held before
+		// lnpm ever touched it, and once lost it cannot be worked out again -
+		// later retreats would drop the package from package.json instead of
+		// putting the user's range back.
+		//
+		// It goes missing when the earlier retreat could not write package.json,
+		// which it only warns about: package.json then still holds the lnpm
+		// reference, so the `lnpm add` that produced this entry read that as the
+		// original version and recorded nothing.
+		if entry.OriginalVersion == "" {
+			if priorEntry, ok := prior.Get(name); ok {
+				entry.OriginalVersion = priorEntry.OriginalVersion
+			}
+		}
 		prior.Add(name, entry)
 	}
 	if err := prior.SaveRetreat(cwd); err != nil {
 		fmt.Printf("  %s Failed to save lnpm.lock into %s: %v\n", iconWarn(), lockfile.RetreatFileName, err)
-		fmt.Printf("  %s lnpm.lock is still in place; 'lnpm restore' has nothing to work from\n", iconWarn())
+		// The snapshot is written through a temp file and a rename, so the
+		// earlier retreat's record is intact and restore can still put those
+		// packages back. Only this retreat's own entries are missing from it,
+		// and they are still in lnpm.lock, which is still in place.
+		fmt.Printf("  %s lnpm.lock is still in place and %s still holds the earlier retreat; re-run 'lnpm retreat' to merge them\n", iconWarn(), lockfile.RetreatFileName)
 		return
 	}
 	if err := os.Remove(lockfile.Path(cwd)); err != nil {

--- a/internal/cli/retreat.go
+++ b/internal/cli/retreat.go
@@ -138,12 +138,14 @@ func RunRetreat(force bool, runInstall bool) error {
 		}
 	}
 
-	// Remove lnpm.lock
-	lockPath := filepath.Join(cwd, "lnpm.lock")
-	if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
+	// Move lnpm.lock aside rather than deleting it. The rename takes it out of
+	// the project the same way a delete would - nothing resolves lnpm.lock any
+	// more - while keeping the record of what was linked, which is the only
+	// thing 'lnpm restore' can rebuild the links from.
+	if err := os.Rename(lockfile.Path(cwd), lockfile.RetreatPath(cwd)); err != nil && !os.IsNotExist(err) {
 		fmt.Printf("  %s Failed to remove lnpm.lock: %v\n", iconWarn(), err)
 	} else {
-		fmt.Printf("  %s Removed lnpm.lock\n", iconOK())
+		fmt.Printf("  %s Removed lnpm.lock (saved for 'lnpm restore')\n", iconOK())
 	}
 
 	// Run package manager install if requested

--- a/internal/cli/retreat.go
+++ b/internal/cli/retreat.go
@@ -27,7 +27,9 @@ func RunRetreat(force bool, runInstall bool) error {
 	// dependencies, so removing .lnpm/ and lnpm.lock would leave the project
 	// half-retreated.
 	if err != nil {
-		return fmt.Errorf("could not read lnpm.lock: %w\n\nHint: Fix or remove lnpm.lock, then re-run 'lnpm retreat' to clean up the rest", err)
+		// The wrapped error names the file it failed on, so repeating the name
+		// here would give one artifact two spellings in one message.
+		return fmt.Errorf("%w\n\nHint: Fix or remove lnpm.lock, then re-run 'lnpm retreat' to clean up the rest", err)
 	}
 	if len(lock.List()) == 0 {
 		// Check for .lnpm directory
@@ -64,7 +66,7 @@ func RunRetreat(force bool, runInstall bool) error {
 		}
 
 		fmt.Println("  - Delete .lnpm/ directory")
-		fmt.Println("  - Delete lnpm.lock")
+		fmt.Printf("  - Save lnpm.lock as %s, for 'lnpm restore'\n", lockfile.RetreatFileName)
 		return nil
 	}
 
@@ -138,15 +140,7 @@ func RunRetreat(force bool, runInstall bool) error {
 		}
 	}
 
-	// Move lnpm.lock aside rather than deleting it. The rename takes it out of
-	// the project the same way a delete would - nothing resolves lnpm.lock any
-	// more - while keeping the record of what was linked, which is the only
-	// thing 'lnpm restore' can rebuild the links from.
-	if err := os.Rename(lockfile.Path(cwd), lockfile.RetreatPath(cwd)); err != nil && !os.IsNotExist(err) {
-		fmt.Printf("  %s Failed to remove lnpm.lock: %v\n", iconWarn(), err)
-	} else {
-		fmt.Printf("  %s Removed lnpm.lock (saved for 'lnpm restore')\n", iconOK())
-	}
+	stashLockForRestore(cwd, lock)
 
 	// Run package manager install if requested
 	if runInstall {
@@ -171,4 +165,63 @@ func RunRetreat(force bool, runInstall bool) error {
 	}
 
 	return nil
+}
+
+// stashLockForRestore moves lnpm.lock aside rather than deleting it. The move
+// takes it out of the project the same way a delete would - nothing resolves
+// lnpm.lock any more - while keeping the record of what was linked, which is the
+// only thing 'lnpm restore' can rebuild the links from. lock is that record, as
+// this retreat found it.
+//
+// A snapshot from an earlier retreat may still be sitting there unconsumed,
+// because a restore reported failures and kept it, or because none was ever run.
+// The lock file being stashed then describes only what has been linked since,
+// and moving it over the snapshot would drop every package the earlier retreat
+// unlinked and the restore never got to. So the two are merged instead, this
+// retreat's entries winning any name they share: they are the newer record, and
+// the specifiers they carry are the ones just written back into package.json.
+func stashLockForRestore(cwd string, lock *lockfile.LockFile) {
+	if _, err := os.Stat(lockfile.Path(cwd)); err != nil {
+		// No lock file means there is nothing to save and nothing to say. Any
+		// other stat failure is worth a word, since the file may still be there.
+		if !os.IsNotExist(err) {
+			fmt.Printf("  %s Could not check lnpm.lock: %v\n", iconWarn(), err)
+		}
+		return
+	}
+
+	prior, err := lockfile.LoadRetreat(cwd)
+	if err != nil {
+		// Merging into a snapshot that cannot be read is not possible, and
+		// overwriting it would destroy a record only the user can now recover.
+		// Leave both files alone and say what to do about it.
+		fmt.Printf("  %s Could not read %s: %v\n", iconWarn(), lockfile.RetreatFileName, err)
+		fmt.Printf("  %s Kept lnpm.lock: fix or remove %s, then re-run 'lnpm retreat'\n", iconWarn(), lockfile.RetreatFileName)
+		return
+	}
+
+	if prior == nil {
+		if err := os.Rename(lockfile.Path(cwd), lockfile.RetreatPath(cwd)); err != nil {
+			fmt.Printf("  %s Failed to save lnpm.lock as %s: %v\n", iconWarn(), lockfile.RetreatFileName, err)
+			fmt.Printf("  %s lnpm.lock is still in place; 'lnpm restore' has nothing to work from\n", iconWarn())
+			return
+		}
+		fmt.Printf("  %s Removed lnpm.lock (saved as %s for 'lnpm restore')\n", iconOK(), lockfile.RetreatFileName)
+		return
+	}
+
+	for _, name := range lock.List() {
+		entry, _ := lock.Get(name)
+		prior.Add(name, entry)
+	}
+	if err := prior.SaveRetreat(cwd); err != nil {
+		fmt.Printf("  %s Failed to save lnpm.lock into %s: %v\n", iconWarn(), lockfile.RetreatFileName, err)
+		fmt.Printf("  %s lnpm.lock is still in place; 'lnpm restore' has nothing to work from\n", iconWarn())
+		return
+	}
+	if err := os.Remove(lockfile.Path(cwd)); err != nil {
+		fmt.Printf("  %s Failed to remove lnpm.lock: %v\n", iconWarn(), err)
+		return
+	}
+	fmt.Printf("  %s Removed lnpm.lock (merged into %s for 'lnpm restore')\n", iconOK(), lockfile.RetreatFileName)
 }

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -553,6 +553,23 @@ func ReadPackageJSON(dir string) (*PackageJSON, error) {
 	return readPackageJSON(dir)
 }
 
+// ExcludedByProjectRules reports whether the package at dir keeps relPath out of
+// a published tarball through rules of its own: the package.json "files" field
+// passed as filesField, and the root .npmignore - falling back to a root
+// .gitignore when there is none, as npm does.
+//
+// It deliberately does not consult defaultExcludes. Those are lnpm's additions
+// to npm's rules, and this answers what a tool that reads only the project's own
+// rules would ship - which is what `npm publish` is. `lnpm check` uses it to ask
+// whether a file lnpm left in the project root is about to be published by
+// something other than lnpm.
+func ExcludedByProjectRules(dir string, filesField []string, relPath string) bool {
+	if len(filesField) > 0 && !isIncluded(relPath, filesField) && !isDefaultInclude(relPath) {
+		return true
+	}
+	return isExcluded(relPath, loadIgnorePatterns(dir))
+}
+
 // filterGitFiles removes any files related to .git directories
 // This is a defense-in-depth safety filter applied after all other filtering
 func filterGitFiles(files []*FileInfo) []*FileInfo {

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 	"github.com/panjf2000/ants/v2"
 	"github.com/pedrosousa13/lnpm/internal/debug"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
 
 // PackageJSON represents the relevant fields from package.json
@@ -74,6 +75,12 @@ var defaultExcludes = []string{
 	".lnpm",
 	".lnpm/**",
 	"lnpm.lock",
+	// The snapshot `lnpm retreat` leaves in place of the lock file. The
+	// documented publish flow is retreat, then publish, so it is sitting in the
+	// package root at exactly this moment, and it records an absolute source
+	// path per linked package. The patterns here are literal, not prefixes, so
+	// "lnpm.lock" above does not cover it.
+	lockfile.RetreatFileName,
 	"yalc.lock",
 	"*.log",
 	"*.orig",

--- a/pkg/lockfile/lockfile.go
+++ b/pkg/lockfile/lockfile.go
@@ -25,22 +25,53 @@ type Package struct {
 }
 
 const (
-	lockFileName   = "lnpm.lock"
-	currentVersion = 1
+	lockFileName = "lnpm.lock"
+	// retreatFileName is the snapshot `lnpm retreat` leaves behind in place of
+	// the lock file it removes, so `lnpm restore` can put the links back.
+	retreatFileName = lockFileName + ".retreat"
+	currentVersion  = 1
 )
+
+// Path returns the lock file path for a project directory.
+func Path(projectPath string) string {
+	return filepath.Join(projectPath, lockFileName)
+}
+
+// RetreatPath returns the path of the retreat snapshot for a project directory.
+func RetreatPath(projectPath string) string {
+	return filepath.Join(projectPath, retreatFileName)
+}
 
 // Load reads a lock file from a project directory
 func Load(projectPath string) (*LockFile, error) {
-	path := filepath.Join(projectPath, lockFileName)
+	lock, err := read(Path(projectPath))
+	if err != nil {
+		return nil, err
+	}
+	if lock == nil {
+		// A missing lock file reads as an empty one.
+		return &LockFile{
+			Version:  currentVersion,
+			Packages: make(map[string]Package),
+		}, nil
+	}
+	return lock, nil
+}
 
+// LoadRetreat reads the retreat snapshot from a project directory. It returns
+// nil when there is no snapshot, which callers must tell apart from a snapshot
+// holding no packages: the first means no retreat has run, the second a retreat
+// that had nothing to record.
+func LoadRetreat(projectPath string) (*LockFile, error) {
+	return read(RetreatPath(projectPath))
+}
+
+// read parses the lock file at path, returning nil when the file does not exist.
+func read(path string) (*LockFile, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// Return empty lock file
-			return &LockFile{
-				Version:  currentVersion,
-				Packages: make(map[string]Package),
-			}, nil
+			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to read lock file: %w", err)
 	}
@@ -60,7 +91,7 @@ func Load(projectPath string) (*LockFile, error) {
 
 // Save writes the lock file to a project directory
 func (l *LockFile) Save(projectPath string) error {
-	path := filepath.Join(projectPath, lockFileName)
+	path := Path(projectPath)
 
 	data, err := yaml.Marshal(l)
 	if err != nil {

--- a/pkg/lockfile/lockfile.go
+++ b/pkg/lockfile/lockfile.go
@@ -94,6 +94,14 @@ func read(path string) (*LockFile, error) {
 		lock.Packages = make(map[string]Package)
 	}
 
+	// A file with no "version:" key unmarshals as version 0, which is not a
+	// format anything ever wrote. Normalising here rather than at the call sites
+	// keeps a file that is read and written back - a merging retreat writes the
+	// snapshot it just read - from persisting that 0 as if it meant something.
+	if lock.Version == 0 {
+		lock.Version = currentVersion
+	}
+
 	return &lock, nil
 }
 
@@ -110,16 +118,69 @@ func (l *LockFile) SaveRetreat(projectPath string) error {
 	return l.write(RetreatPath(projectPath))
 }
 
-// write marshals the lock file to path.
+// write marshals the lock file to path, through a temp file in the same
+// directory and a rename onto path.
+//
+// The indirection is what makes a failed write harmless. A truncating write in
+// place is fine for lnpm.lock, whose contents can be rebuilt, but the retreat
+// snapshot shares this writer and cannot: a merging retreat writes the snapshot
+// it just read straight back over itself, so a write that failed after the open
+// had truncated would destroy the only record of what an earlier retreat
+// unlinked - the very file the merge exists to protect.
 func (l *LockFile) write(path string) error {
 	data, err := yaml.Marshal(l)
 	if err != nil {
 		return fmt.Errorf("failed to marshal lock file: %w", err)
 	}
 
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	// A rename hands the destination the temp file's own mode, so the mode of
+	// the file being replaced has to be carried over deliberately. 0644 is the
+	// mode a first write creates.
+	//
+	// A rename also replaces the destination whatever its mode, so a read-only
+	// file - which the open of a direct write would have refused - has to be
+	// refused here instead. .gitignore's writer turned atomic the same way and
+	// carries the same guard.
+	mode := os.FileMode(0644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+		if mode&0200 == 0 {
+			return fmt.Errorf("failed to write %s: it is read-only (mode %o)", path, mode)
+		}
+	}
+
+	staged, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
 		return fmt.Errorf("failed to write %s: %w", path, err)
 	}
+
+	// Cleared once the rename has consumed the staging file, so this cleanup can
+	// never delete the file it just wrote into place.
+	stagedPath := staged.Name()
+	defer func() {
+		if stagedPath != "" {
+			_ = os.Remove(stagedPath)
+		}
+	}()
+
+	if _, err := staged.Write(data); err != nil {
+		_ = staged.Close()
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	// chmod explicitly rather than relying on the process umask: os.CreateTemp
+	// makes the file 0600, which is not what a lock file has ever been.
+	if err := staged.Chmod(mode); err != nil {
+		_ = staged.Close()
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	if err := staged.Close(); err != nil {
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+
+	if err := os.Rename(stagedPath, path); err != nil {
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	stagedPath = ""
 
 	return nil
 }

--- a/pkg/lockfile/lockfile.go
+++ b/pkg/lockfile/lockfile.go
@@ -26,9 +26,12 @@ type Package struct {
 
 const (
 	lockFileName = "lnpm.lock"
-	// retreatFileName is the snapshot `lnpm retreat` leaves behind in place of
-	// the lock file it removes, so `lnpm restore` can put the links back.
-	retreatFileName = lockFileName + ".retreat"
+	// RetreatFileName is the snapshot `lnpm retreat` leaves behind in place of
+	// the lock file it removes, so `lnpm restore` can put the links back. It is
+	// exported because it is lnpm's own state sitting in a project root, which
+	// anything that decides what belongs to a project - packing a publish, above
+	// all - has to be able to recognise without spelling the name again.
+	RetreatFileName = lockFileName + ".retreat"
 	currentVersion  = 1
 )
 
@@ -39,7 +42,7 @@ func Path(projectPath string) string {
 
 // RetreatPath returns the path of the retreat snapshot for a project directory.
 func RetreatPath(projectPath string) string {
-	return filepath.Join(projectPath, retreatFileName)
+	return filepath.Join(projectPath, RetreatFileName)
 }
 
 // Load reads a lock file from a project directory
@@ -67,18 +70,23 @@ func LoadRetreat(projectPath string) (*LockFile, error) {
 }
 
 // read parses the lock file at path, returning nil when the file does not exist.
+//
+// The errors name the file they came from rather than calling it "the lock
+// file": the snapshot shares this reader, and a message that named the format
+// instead of the file would send a user whose snapshot is corrupt to inspect a
+// lock file that is perfectly fine.
 func read(path string) (*LockFile, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to read lock file: %w", err)
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
 	}
 
 	var lock LockFile
 	if err := yaml.Unmarshal(data, &lock); err != nil {
-		return nil, fmt.Errorf("failed to parse lock file: %w", err)
+		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
 	}
 
 	// Ensure packages map exists
@@ -91,15 +99,26 @@ func read(path string) (*LockFile, error) {
 
 // Save writes the lock file to a project directory
 func (l *LockFile) Save(projectPath string) error {
-	path := Path(projectPath)
+	return l.write(Path(projectPath))
+}
 
+// SaveRetreat writes the lock file as the retreat snapshot of a project
+// directory. `lnpm retreat` needs it when a snapshot from an earlier retreat is
+// still unconsumed: the two have to be merged and written out, which a rename of
+// the lock file cannot do.
+func (l *LockFile) SaveRetreat(projectPath string) error {
+	return l.write(RetreatPath(projectPath))
+}
+
+// write marshals the lock file to path.
+func (l *LockFile) write(path string) error {
 	data, err := yaml.Marshal(l)
 	if err != nil {
 		return fmt.Errorf("failed to marshal lock file: %w", err)
 	}
 
 	if err := os.WriteFile(path, data, 0644); err != nil {
-		return fmt.Errorf("failed to write lock file: %w", err)
+		return fmt.Errorf("failed to write %s: %w", path, err)
 	}
 
 	return nil

--- a/pkg/lockfile/lockfile_test.go
+++ b/pkg/lockfile/lockfile_test.go
@@ -268,3 +268,142 @@ func TestLoadRetreatCorrupt(t *testing.T) {
 		t.Error("LoadRetreat() error = nil, want an error for a corrupt snapshot")
 	}
 }
+
+// TestSaveRetreatWritesTheSnapshotBesideTheLockFile covers the write half of the
+// snapshot pair. A merging retreat cannot rename the lock file over an existing
+// snapshot, so it reads the snapshot, adds the lock file's entries and saves it
+// back through here; that has to land on the snapshot path and leave the lock
+// file alone.
+func TestSaveRetreatWritesTheSnapshotBesideTheLockFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	lock := &LockFile{Version: currentVersion, Packages: make(map[string]Package)}
+	lock.Add("saved-package", Package{Version: "2.0.0", Hash: "abc", OriginalVersion: "^2.0.0"})
+	if err := lock.SaveRetreat(tmpDir); err != nil {
+		t.Fatalf("SaveRetreat() error: %v", err)
+	}
+
+	if _, err := os.Stat(Path(tmpDir)); !os.IsNotExist(err) {
+		t.Errorf("SaveRetreat() wrote a lock file too; os.Stat(%s) error = %v, want IsNotExist", Path(tmpDir), err)
+	}
+
+	got, err := LoadRetreat(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadRetreat() error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("LoadRetreat() = nil, want the snapshot SaveRetreat just wrote")
+	}
+	pkg, ok := got.Get("saved-package")
+	if !ok {
+		t.Fatalf("snapshot missing saved-package, holds %v", got.List())
+	}
+	if pkg.Version != "2.0.0" || pkg.OriginalVersion != "^2.0.0" {
+		t.Errorf("saved-package = %+v, want Version 2.0.0 and OriginalVersion ^2.0.0", pkg)
+	}
+}
+
+// TestSaveRetreatReplacesTheSnapshotRatherThanTruncatingIt pins the one property
+// that keeps a failed write from destroying an unconsumed snapshot: the file is
+// replaced, not opened and truncated.
+//
+// A retreat that finds a snapshot already on disk merges into it and writes the
+// result back over the same path. Written in place, the open truncates first, so
+// a write that then failed would leave the record of what the earlier retreat
+// unlinked empty, and it exists nowhere else. Written through a temp file and a
+// rename, a failure cannot get that far.
+//
+// The truncating write is invisible once it succeeds, so what is asserted is the
+// replacement itself: os.SameFile is false only because the snapshot on disk is
+// a different file from the one that was there before.
+func TestSaveRetreatReplacesTheSnapshotRatherThanTruncatingIt(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	lock := &LockFile{Version: currentVersion, Packages: make(map[string]Package)}
+	lock.Add("first-package", Package{Version: "1.0.0"})
+	if err := lock.SaveRetreat(tmpDir); err != nil {
+		t.Fatalf("SaveRetreat() error: %v", err)
+	}
+	before, err := os.Stat(RetreatPath(tmpDir))
+	if err != nil {
+		t.Fatalf("Stat() error: %v", err)
+	}
+
+	lock.Add("second-package", Package{Version: "1.0.0"})
+	if err := lock.SaveRetreat(tmpDir); err != nil {
+		t.Fatalf("SaveRetreat() error: %v", err)
+	}
+	after, err := os.Stat(RetreatPath(tmpDir))
+	if err != nil {
+		t.Fatalf("Stat() error: %v", err)
+	}
+
+	if os.SameFile(before, after) {
+		t.Error("SaveRetreat() rewrote the snapshot in place; want a temp file renamed onto it, so a failed write cannot truncate the snapshot it is merging into")
+	}
+	if before.Mode().Perm() != after.Mode().Perm() {
+		t.Errorf("snapshot mode = %v after the rewrite, want the %v it had before", after.Mode().Perm(), before.Mode().Perm())
+	}
+
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("ReadDir() error: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != RetreatFileName {
+			t.Errorf("SaveRetreat() left %s behind, want only %s", entry.Name(), RetreatFileName)
+		}
+	}
+}
+
+// TestReadNormalisesAMissingVersion covers a snapshot or lock file with no
+// "version:" key. It unmarshals as version 0, which is not a format anything
+// ever wrote, and a merging retreat writes what it read straight back - so
+// without normalising, the 0 would be persisted as if it meant something.
+func TestReadNormalisesAMissingVersion(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(Path(tmpDir), []byte("packages:\n  my-package:\n    version: 1.0.0\n"), 0644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	lock, err := Load(tmpDir)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if lock.Version != currentVersion {
+		t.Errorf("Version = %d, want %d", lock.Version, currentVersion)
+	}
+}
+
+// TestSaveRefusesAReadOnlyLockFile pins the one thing the rename gave away. A
+// direct write opens the destination and so is refused by the file's own mode; a
+// rename replaces the destination whatever its mode, and would quietly overwrite
+// a lock file the user or a tool had marked read-only. The refusal is made
+// explicitly instead, from the mode itself, so it holds wherever Chmod does.
+func TestSaveRefusesAReadOnlyLockFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	lock := &LockFile{Version: currentVersion, Packages: make(map[string]Package)}
+	lock.Add("first-package", Package{Version: "1.0.0"})
+	if err := lock.Save(tmpDir); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+	if err := os.Chmod(Path(tmpDir), 0444); err != nil {
+		t.Fatalf("Chmod() error: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(Path(tmpDir), 0644) })
+
+	lock.Add("second-package", Package{Version: "1.0.0"})
+	if err := lock.Save(tmpDir); err == nil {
+		t.Fatal("Save() error = nil, want a refusal to replace a read-only lock file")
+	}
+
+	got, err := Load(tmpDir)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if got.Has("second-package") {
+		t.Errorf("the refused Save() landed anyway; lock file holds %v", got.List())
+	}
+}

--- a/pkg/lockfile/lockfile_test.go
+++ b/pkg/lockfile/lockfile_test.go
@@ -195,3 +195,76 @@ func TestScopedPackages(t *testing.T) {
 		t.Error("Loaded lock file missing @another-org/utils")
 	}
 }
+
+// TestPathAndRetreatPath pins the two file names the CLI has to agree on: the
+// live lock file, and the snapshot `lnpm retreat` leaves for `lnpm restore`.
+func TestPathAndRetreatPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if got, want := Path(tmpDir), filepath.Join(tmpDir, "lnpm.lock"); got != want {
+		t.Errorf("Path() = %q, want %q", got, want)
+	}
+	if got, want := RetreatPath(tmpDir), filepath.Join(tmpDir, "lnpm.lock.retreat"); got != want {
+		t.Errorf("RetreatPath() = %q, want %q", got, want)
+	}
+}
+
+// TestLoadRetreatMissing checks that an absent snapshot is reported as "there is
+// nothing here" rather than as an empty lock file, because the two mean
+// different things to restore: no snapshot at all is a no-op, an empty one is a
+// retreat that had nothing to record.
+func TestLoadRetreatMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	lock, err := LoadRetreat(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadRetreat() error: %v", err)
+	}
+	if lock != nil {
+		t.Errorf("LoadRetreat() = %+v, want nil for a missing snapshot", lock)
+	}
+}
+
+// TestLoadRetreatReadsSnapshot checks that a snapshot written next to the lock
+// file parses with the same format as the lock file itself.
+func TestLoadRetreatReadsSnapshot(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	lock := &LockFile{Version: currentVersion, Packages: make(map[string]Package)}
+	lock.Add("my-package", Package{Version: "1.2.3", Hash: "abc", OriginalVersion: "^1.0.0"})
+	if err := lock.Save(tmpDir); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+	if err := os.Rename(Path(tmpDir), RetreatPath(tmpDir)); err != nil {
+		t.Fatalf("Rename() error: %v", err)
+	}
+
+	got, err := LoadRetreat(tmpDir)
+	if err != nil {
+		t.Fatalf("LoadRetreat() error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("LoadRetreat() = nil, want the saved snapshot")
+	}
+	pkg, ok := got.Get("my-package")
+	if !ok {
+		t.Fatal("snapshot missing my-package")
+	}
+	if pkg.Version != "1.2.3" || pkg.OriginalVersion != "^1.0.0" {
+		t.Errorf("my-package = %+v, want Version 1.2.3 and OriginalVersion ^1.0.0", pkg)
+	}
+}
+
+// TestLoadRetreatCorrupt checks that an unreadable snapshot is an error, not a
+// silent "nothing to restore".
+func TestLoadRetreatCorrupt(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(RetreatPath(tmpDir), []byte("packages: {not valid yaml"), 0644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	if _, err := LoadRetreat(tmpDir); err == nil {
+		t.Error("LoadRetreat() error = nil, want an error for a corrupt snapshot")
+	}
+}

--- a/tests/check_test.go
+++ b/tests/check_test.go
@@ -3,9 +3,11 @@ package tests
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
 
 // TestCheckCleanProject verifies check passes (nil error) when no lnpm
@@ -102,5 +104,97 @@ func TestCheckCatchesRealAddLink(t *testing.T) {
 	env.chdir(projectDir)
 	if err := cli.RunCheck(); err == nil {
 		t.Fatal("expected check to fail after add --link, got nil")
+	}
+}
+
+// TestCheckDetectsAPublishableRetreatSnapshot covers the hazard this branch
+// creates. `lnpm retreat --force` leaves lnpm.lock.retreat in the project root,
+// and the README's own sequence runs `npm publish` next. The npm CLI reads none
+// of lnpm's packing rules, so in a project with no "files" field and no ignore
+// file the snapshot - an absolute source path per linked package - goes into the
+// tarball.
+func TestCheckDetectsAPublishableRetreatSnapshot(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("snapshot-check-pkg")
+	projectDir := env.newProject("snapshot-check-project")
+	env.addPkg(projectDir, "snapshot-check-pkg", false, false)
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+	// retreat un-ignores .lnpm/, and this project has nothing else in
+	// .gitignore, so nothing stands between the snapshot and the tarball.
+	env.writeFile(filepath.Join(projectDir, ".gitignore"), "")
+	env.AssertFileExists(lockfile.RetreatPath(projectDir), true)
+	env.chdir(projectDir)
+
+	var err error
+	out := captureStdout(t, func() { err = cli.RunCheck() })
+	if err == nil {
+		t.Fatal("Expected check to fail with a publishable retreat snapshot, got nil")
+	}
+	if !strings.Contains(out, lockfile.RetreatFileName) {
+		t.Errorf("Expected the report to name the snapshot, got:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), lockfile.RetreatFileName) {
+		t.Errorf("Expected the error to name the snapshot, got: %v", err)
+	}
+}
+
+// TestCheckPassesWhenTheSnapshotCannotBePublished is the other half, and the one
+// that keeps the guard from being a permanent false alarm. The documented flow
+// retreats, checks, publishes and then restores, so the snapshot is on disk at
+// check time by design. What check asks is whether it would actually be packed,
+// and each of these three project setups answers no - by the same rules npm
+// itself reads.
+func TestCheckPassesWhenTheSnapshotCannotBePublished(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(env *TestEnvironment, projectDir string)
+	}{
+		{
+			name: "listed in .gitignore, which npm falls back to",
+			setup: func(env *TestEnvironment, projectDir string) {
+				env.writeFile(filepath.Join(projectDir, ".gitignore"), lockfile.RetreatFileName+"\n")
+			},
+		},
+		{
+			name: "listed in .npmignore",
+			setup: func(env *TestEnvironment, projectDir string) {
+				env.writeFile(filepath.Join(projectDir, ".npmignore"), lockfile.RetreatFileName+"\n")
+			},
+		},
+		{
+			name: "not in the package.json files whitelist",
+			setup: func(env *TestEnvironment, projectDir string) {
+				env.writePackageJSON(projectDir, map[string]interface{}{
+					"name":    "snapshot-safe-project",
+					"version": "1.0.0",
+					"files":   []interface{}{"index.js"},
+				})
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupTest(t)
+
+			env.simplePkg("snapshot-safe-pkg")
+			projectDir := env.newProject("snapshot-safe-project")
+			env.addPkg(projectDir, "snapshot-safe-pkg", false, false)
+
+			if err := cli.RunRetreat(true, false); err != nil {
+				t.Fatalf("Failed to retreat: %v", err)
+			}
+			env.AssertFileExists(lockfile.RetreatPath(projectDir), true)
+			tc.setup(env, projectDir)
+			env.chdir(projectDir)
+
+			if err := cli.RunCheck(); err != nil {
+				t.Errorf("Expected check to pass when the snapshot cannot be published, got: %v", err)
+			}
+		})
 	}
 }

--- a/tests/publish_test.go
+++ b/tests/publish_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
 
 // TestPublishVariants table-drives the publishes whose only meaningful assertion
@@ -337,4 +338,49 @@ func TestPublishPreservesFileMetadata(t *testing.T) {
 	if !foundExec {
 		t.Error("Executable permission not preserved in database")
 	}
+}
+
+// TestPublishExcludesTheRetreatSnapshot walks the exact sequence the README
+// documents - retreat --force, then publish - and pins that the snapshot retreat
+// leaves behind is treated as lnpm's own state, the way lnpm.lock always was.
+//
+// The snapshot records every linked package's absolute source path on the
+// developer's machine, so shipping it would widen what a publish discloses. It
+// sits in the package root at precisely the moment publish runs, which is what
+// makes the default exclusion the only thing standing between it and the
+// registry.
+func TestPublishExcludesTheRetreatSnapshot(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("snapshot-leak-dep")
+
+	pkgDir := env.CreateTestPackage("snapshot-leak-pkg", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'snapshot-leak-pkg';",
+	})
+	env.addPkg(pkgDir, "snapshot-leak-dep", false, false)
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+	env.AssertFileExists(lockfile.RetreatPath(pkgDir), true)
+
+	env.chdir(pkgDir)
+	if err := cli.RunPublish(false, false, false, false); err != nil {
+		t.Fatalf("Failed to publish: %v", err)
+	}
+
+	pkg, err := env.Database.GetPackageByName("snapshot-leak-pkg")
+	if err != nil || pkg == nil {
+		t.Fatalf("Failed to get package: %v", err)
+	}
+	files, err := env.Database.GetFilesForPackage(pkg.ID)
+	if err != nil {
+		t.Fatalf("Failed to get files: %v", err)
+	}
+	snapshotName := filepath.Base(lockfile.RetreatPath(pkgDir))
+	for _, f := range files {
+		if f.RelativePath == snapshotName {
+			t.Errorf("Expected %s to be excluded from the published files, but it was packed", snapshotName)
+		}
+	}
+	env.AssertFileExists(filepath.Join(pkg.StorePath, snapshotName), false)
 }

--- a/tests/restore_permissions_test.go
+++ b/tests/restore_permissions_test.go
@@ -1,0 +1,91 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
+)
+
+// A restore that could not finish a package tells the user to re-run it once the
+// obstacle is gone, so the re-run has to finish what the first attempt started.
+//
+// It can only do that if a half-restored package is distinguishable from one the
+// user re-added between the retreat and the restore, which is the other reason a
+// name can already be in the lock file - and the reason restore skips it. The
+// two are told apart by never writing the lock entry until the package.json
+// write it describes has landed: a name in the lock is then always the user's
+// own doing.
+//
+// Without that, the re-run reports the package as re-added, deletes the snapshot
+// because nothing failed, and exits zero on a project whose package.json never
+// got its lnpm reference.
+func TestRestoreRerunFinishesAPartiallyRestoredPackage(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	env := setupTest(t)
+	env.simplePkg("partial-restore-pkg")
+
+	projectDir := env.CreateTestPackage("partial-restore-project", "1.0.0", nil)
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":         "partial-restore-project",
+		"version":      "1.0.0",
+		"dependencies": map[string]interface{}{"partial-restore-pkg": "^1.0.0"},
+	})
+	env.addPkg(projectDir, "partial-restore-pkg", false, false)
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+	env.AssertPackageJSON(projectDir, "partial-restore-pkg", "^1.0.0")
+
+	pkgJSONPath := filepath.Join(projectDir, "package.json")
+	makePackageJSONReadOnly(t, projectDir)
+
+	env.chdir(projectDir)
+	captureStdout(t, func() {
+		if err := cli.RunRestore(); err == nil {
+			t.Error("Expected restore to fail when package.json cannot be written, got nil")
+		}
+	})
+
+	// Nothing may claim the package is restored: package.json still holds the
+	// user's specifier, so a lock entry would describe a link package.json does
+	// not have, and would be read on the re-run as a package the user re-added.
+	env.AssertPackageJSON(projectDir, "partial-restore-pkg", "^1.0.0")
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		if entry, ok := lock.Get("partial-restore-pkg"); ok {
+			t.Errorf("Expected no lock entry for a package whose package.json write failed, got %+v", entry)
+		}
+	})
+	env.AssertFileExists(lockfile.RetreatPath(projectDir), true)
+
+	if err := os.Chmod(pkgJSONPath, 0644); err != nil {
+		t.Fatalf("Failed to restore package.json mode: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := cli.RunRestore(); err != nil {
+			t.Errorf("Expected the re-run to succeed, got: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "was added again since the retreat") {
+		t.Errorf("Expected the re-run to finish the package rather than report it as re-added, got:\n%s", out)
+	}
+	env.AssertPackageJSON(projectDir, "partial-restore-pkg", "file:.lnpm/partial-restore-pkg")
+	env.AssertSymlinkExists(projectDir, "partial-restore-pkg")
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		entry, ok := lock.Get("partial-restore-pkg")
+		if !ok {
+			t.Fatal("Expected partial-restore-pkg in lnpm.lock after the re-run")
+		}
+		if entry.OriginalVersion != "^1.0.0" {
+			t.Errorf("OriginalVersion = %q, want ^1.0.0", entry.OriginalVersion)
+		}
+	})
+	env.AssertFileExists(lockfile.RetreatPath(projectDir), false)
+}

--- a/tests/restore_test.go
+++ b/tests/restore_test.go
@@ -1,0 +1,278 @@
+package tests
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
+)
+
+// TestRestoreRelinksPackagesFromSnapshot is the round trip the feature exists
+// for: add, retreat, restore, and the project is back where it started. It
+// covers the acceptance criteria that restore recreates .lnpm/<pkg>, the
+// node_modules symlink and the file:.lnpm/<pkg> specifier for every package in
+// the snapshot, and that a clean restore consumes the snapshot and leaves
+// lnpm.lock holding the pre-retreat entries.
+func TestRestoreRelinksPackagesFromSnapshot(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("restore-pkg-a")
+	env.simplePkg("restore-pkg-b")
+	projectDir := env.newProject("restore-project")
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":         "restore-project",
+		"version":      "1.0.0",
+		"dependencies": map[string]interface{}{"restore-pkg-a": "^1.0.0"},
+	})
+	env.addPkg(projectDir, "restore-pkg-a", false, false)
+	env.addPkg(projectDir, "restore-pkg-b", false, false)
+
+	before := map[string]lockfile.Package{}
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		for _, name := range lock.List() {
+			before[name], _ = lock.Get(name)
+		}
+	})
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := cli.RunRestore(); err != nil {
+			t.Errorf("Failed to restore: %v", err)
+		}
+	})
+
+	for _, name := range []string{"restore-pkg-a", "restore-pkg-b"} {
+		env.AssertSymlinkExists(projectDir, name)
+		env.AssertStoreCopy(projectDir, name)
+		env.AssertPackageJSON(projectDir, name, "file:.lnpm/"+name)
+		env.AssertDatabaseLink(name, projectDir)
+		if want := "Restored " + name + "@1.0.0"; !strings.Contains(out, want) {
+			t.Errorf("Expected the report to contain %q, got:\n%s", want, out)
+		}
+	}
+
+	// .lnpm/ is lnpm's own working directory; retreat un-ignores it, so a
+	// restore that did not put the entry back would leave the linked copies
+	// staged for commit.
+	env.AssertGitignore(projectDir, ".lnpm/", true)
+
+	// The snapshot is spent once every package in it is linked again.
+	env.AssertFileExists(lockfile.RetreatPath(projectDir), false)
+
+	env.AssertLockfileExists(projectDir, true)
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		for name, want := range before {
+			got, ok := lock.Get(name)
+			if !ok {
+				t.Fatalf("Expected %s back in lnpm.lock", name)
+			}
+			// Linked is a timestamp of this restore, so it is deliberately not
+			// compared; everything that describes the link itself must match.
+			if got.Version != want.Version || got.Hash != want.Hash ||
+				got.Source != want.Source || got.OriginalVersion != want.OriginalVersion {
+				t.Errorf("lnpm.lock entry for %s = %+v, want the pre-retreat %+v", name, got, want)
+			}
+		}
+		if len(lock.List()) != len(before) {
+			t.Errorf("Expected lnpm.lock to hold %d packages, got %v", len(before), lock.List())
+		}
+	})
+}
+
+// TestRestoreWithoutSnapshotReportsNothingToRestore covers the criterion that a
+// restore with no prior retreat says so plainly instead of failing.
+func TestRestoreWithoutSnapshotReportsNothingToRestore(t *testing.T) {
+	env := setupTest(t)
+
+	projectDir := env.newProject("no-snapshot-project")
+
+	out := captureStdout(t, func() {
+		if err := cli.RunRestore(); err != nil {
+			t.Errorf("Expected restore with no snapshot to succeed, got: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "othing to restore") {
+		t.Errorf("Expected a 'nothing to restore' message, got:\n%s", out)
+	}
+	env.AssertLockfileExists(projectDir, false)
+	env.AssertDirectoryExists(filepath.Join(projectDir, ".lnpm"), false)
+}
+
+// TestRestoreReportsStaleVersionAndContinues covers the criterion that a package
+// whose recorded version is no longer the one in the store is reported per
+// package and does not abort the rest of the restore. The store is latest-wins,
+// so republishing at a new version is what strands the snapshot's entry.
+func TestRestoreReportsStaleVersionAndContinues(t *testing.T) {
+	env := setupTest(t)
+
+	stalePkgDir := env.simplePkg("stale-restore-pkg")
+	env.simplePkg("fresh-restore-pkg")
+	projectDir := env.newProject("stale-restore-project")
+	env.addPkg(projectDir, "stale-restore-pkg", false, false)
+	env.addPkg(projectDir, "fresh-restore-pkg", false, false)
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+
+	env.republish(stalePkgDir, "stale-restore-pkg", "2.0.0", "module.exports = 'v2';")
+	env.chdir(projectDir)
+
+	var err error
+	out := captureStdout(t, func() { err = cli.RunRestore() })
+	if err == nil {
+		t.Error("Expected restore to exit non-zero when a package could not be restored")
+	}
+
+	if !strings.Contains(out, "stale-restore-pkg") || !strings.Contains(out, "2.0.0") {
+		t.Errorf("Expected the report to name stale-restore-pkg and the stored 2.0.0, got:\n%s", out)
+	}
+
+	// The healthy package is restored regardless.
+	env.AssertSymlinkExists(projectDir, "fresh-restore-pkg")
+	env.AssertPackageJSON(projectDir, "fresh-restore-pkg", "file:.lnpm/fresh-restore-pkg")
+	env.AssertSymlinkMissing(projectDir, "stale-restore-pkg")
+	env.AssertPackageJSONMissing(projectDir, "stale-restore-pkg")
+
+	// The snapshot survives an incomplete restore, so the user can republish the
+	// stale package and run restore again.
+	env.AssertFileExists(lockfile.RetreatPath(projectDir), true)
+}
+
+// TestRestoreMergesWithPackagesAddedSinceRetreat pins the chosen answer to the
+// issue's open question: restore merges, and a package added since the retreat
+// wins over the snapshot's entry for the same name. Nothing is removed and no
+// newer add is reported as a stale version.
+func TestRestoreMergesWithPackagesAddedSinceRetreat(t *testing.T) {
+	env := setupTest(t)
+
+	readdedDir := env.simplePkg("readded-pkg")
+	env.simplePkg("snapshot-only-pkg")
+	env.simplePkg("added-later-pkg")
+	projectDir := env.newProject("merge-restore-project")
+	env.addPkg(projectDir, "readded-pkg", false, false)
+	env.addPkg(projectDir, "snapshot-only-pkg", false, false)
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+
+	// Between retreat and restore the user republishes and re-adds one of the
+	// snapshot's packages, and adds a package the snapshot never saw.
+	env.republish(readdedDir, "readded-pkg", "2.0.0", "module.exports = 'v2';")
+	env.addPkg(projectDir, "readded-pkg", false, false)
+	env.addPkg(projectDir, "added-later-pkg", false, false)
+
+	if err := cli.RunRestore(); err != nil {
+		t.Fatalf("Failed to restore: %v", err)
+	}
+
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		readded, ok := lock.Get("readded-pkg")
+		if !ok {
+			t.Fatal("Expected readded-pkg to survive the restore")
+		}
+		if readded.Version != "2.0.0" {
+			t.Errorf("Expected the newer add of readded-pkg to win at 2.0.0, got %q", readded.Version)
+		}
+		if !lock.Has("snapshot-only-pkg") {
+			t.Error("Expected snapshot-only-pkg to be restored from the snapshot")
+		}
+		if !lock.Has("added-later-pkg") {
+			t.Error("Expected added-later-pkg, added after the retreat, to be left alone")
+		}
+	})
+	env.AssertSymlinkExists(projectDir, "snapshot-only-pkg")
+	env.AssertSymlinkExists(projectDir, "added-later-pkg")
+	env.AssertFileExists(lockfile.RetreatPath(projectDir), false)
+}
+
+// TestRestoreKeepsADevDependencyInDevDependencies is the dev-ness half of a
+// faithful restore. The lock file records no dev flag, so restore recovers the
+// field from package.json, which retreat has just put the original specifier
+// back into. AssertPackageJSON accepts either field, so this reads the file
+// directly.
+func TestRestoreKeepsADevDependencyInDevDependencies(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("dev-restore-pkg")
+	projectDir := env.newProject("dev-restore-project")
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":            "dev-restore-project",
+		"version":         "1.0.0",
+		"devDependencies": map[string]interface{}{"dev-restore-pkg": "^1.0.0"},
+	})
+	env.addPkg(projectDir, "dev-restore-pkg", true, false)
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+	if err := cli.RunRestore(); err != nil {
+		t.Fatalf("Failed to restore: %v", err)
+	}
+
+	deps, devDeps := dependencyFields(t, projectDir)
+	if got := devDeps["dev-restore-pkg"]; got != "file:.lnpm/dev-restore-pkg" {
+		t.Errorf("devDependencies[dev-restore-pkg] = %v, want file:.lnpm/dev-restore-pkg", got)
+	}
+	if _, ok := deps["dev-restore-pkg"]; ok {
+		t.Error("Expected dev-restore-pkg to stay out of dependencies")
+	}
+}
+
+// TestRestoreReportsAnUnknownDependencyField covers the one part of the
+// pre-retreat state that is genuinely unrecoverable. A package added with --dev
+// (or --pure) that package.json never held before has no original specifier in
+// the lock file, and retreat drops it from package.json entirely, so by the time
+// restore runs nothing on disk says which field it belonged in. Restore puts it
+// in dependencies, matching plain `lnpm add`, and says so rather than moving a
+// dev dependency into production dependencies without a word.
+func TestRestoreReportsAnUnknownDependencyField(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("orphan-dev-pkg")
+	projectDir := env.newProject("orphan-dev-project")
+	env.addPkg(projectDir, "orphan-dev-pkg", true, false)
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := cli.RunRestore(); err != nil {
+			t.Errorf("Failed to restore: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "orphan-dev-pkg") || !strings.Contains(out, "dependencies") {
+		t.Errorf("Expected restore to report the guess it made for orphan-dev-pkg, got:\n%s", out)
+	}
+	deps, _ := dependencyFields(t, projectDir)
+	if got := deps["orphan-dev-pkg"]; got != "file:.lnpm/orphan-dev-pkg" {
+		t.Errorf("dependencies[orphan-dev-pkg] = %v, want file:.lnpm/orphan-dev-pkg", got)
+	}
+}
+
+// dependencyFields returns the project's dependencies and devDependencies maps,
+// for the assertions that care which of the two an entry landed in.
+func dependencyFields(t *testing.T, projectDir string) (deps, devDeps map[string]interface{}) {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(projectDir, "package.json"))
+	if err != nil {
+		t.Fatalf("Failed to read package.json: %v", err)
+	}
+	var pkgJSON map[string]interface{}
+	if err := json.Unmarshal(data, &pkgJSON); err != nil {
+		t.Fatalf("Failed to parse package.json: %v", err)
+	}
+	return getMapValue(pkgJSON, "dependencies"), getMapValue(pkgJSON, "devDependencies")
+}

--- a/tests/restore_test.go
+++ b/tests/restore_test.go
@@ -231,38 +231,192 @@ func TestRestoreKeepsADevDependencyInDevDependencies(t *testing.T) {
 
 // TestRestoreReportsAnUnknownDependencyField covers the one part of the
 // pre-retreat state that is genuinely unrecoverable. A package added with --dev
-// (or --pure) that package.json never held before has no original specifier in
-// the lock file, and retreat drops it from package.json entirely, so by the time
-// restore runs nothing on disk says which field it belonged in. Restore puts it
-// in dependencies, matching plain `lnpm add`, and says so rather than moving a
-// dev dependency into production dependencies without a word.
+// or --pure that package.json never held before has no original specifier in the
+// lock file, and retreat leaves nothing in package.json, so by the time restore
+// runs nothing on disk says which field it belonged in - or whether it belonged
+// in one at all. Restore puts it in dependencies, matching plain `lnpm add`, and
+// says so rather than moving a dev dependency into production dependencies, or
+// giving a --pure package the package.json entry it was added to avoid, without
+// a word.
 func TestRestoreReportsAnUnknownDependencyField(t *testing.T) {
+	cases := []struct {
+		name string
+		pkg  string
+		dev  bool
+		pure bool
+	}{
+		{"added with --dev", "orphan-dev-pkg", true, false},
+		{"added with --pure", "orphan-pure-pkg", false, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupTest(t)
+
+			env.simplePkg(tc.pkg)
+			projectDir := env.newProject("orphan-field-project")
+			env.addPkg(projectDir, tc.pkg, tc.dev, tc.pure)
+
+			if err := cli.RunRetreat(true, false); err != nil {
+				t.Fatalf("Failed to retreat: %v", err)
+			}
+
+			out := captureStdout(t, func() {
+				if err := cli.RunRestore(); err != nil {
+					t.Errorf("Failed to restore: %v", err)
+				}
+			})
+
+			// Matched against the note itself, not just the package name and the
+			// word "dependencies": both of those also appear in the success line
+			// and in the npm install tip, so a looser check passes with the note
+			// removed.
+			want := tc.pkg + " was not in package.json before the retreat, so its field is unknown; restoring it into dependencies"
+			if !strings.Contains(out, want) {
+				t.Errorf("Expected the report to contain %q, got:\n%s", want, out)
+			}
+			// A --pure package is the case the note has to be explicit about:
+			// restore writes an entry --pure exists to avoid, and only the user
+			// knows that, so the note has to say what to do about it.
+			if !strings.Contains(out, "--pure") {
+				t.Errorf("Expected the note to tell a --pure user the entry is spurious, got:\n%s", out)
+			}
+
+			deps, _ := dependencyFields(t, projectDir)
+			if got := deps[tc.pkg]; got != "file:.lnpm/"+tc.pkg {
+				t.Errorf("dependencies[%s] = %v, want file:.lnpm/%s", tc.pkg, got, tc.pkg)
+			}
+		})
+	}
+}
+
+// TestRestoreCountsOnlyThePackagesItAttempted pins the denominator of the
+// failure summary. Packages restore skipped because the user re-added them were
+// never attempted, so counting them makes the failure look like a smaller
+// fraction of the work than it was.
+func TestRestoreCountsOnlyThePackagesItAttempted(t *testing.T) {
 	env := setupTest(t)
 
-	env.simplePkg("orphan-dev-pkg")
-	projectDir := env.newProject("orphan-dev-project")
-	env.addPkg(projectDir, "orphan-dev-pkg", true, false)
+	readdedDir := env.simplePkg("count-readded-pkg")
+	staleDir := env.simplePkg("count-stale-pkg")
+	env.simplePkg("count-ok-pkg")
+	projectDir := env.newProject("count-restore-project")
+	env.addPkg(projectDir, "count-readded-pkg", false, false)
+	env.addPkg(projectDir, "count-stale-pkg", false, false)
+	env.addPkg(projectDir, "count-ok-pkg", false, false)
 
 	if err := cli.RunRetreat(true, false); err != nil {
 		t.Fatalf("Failed to retreat: %v", err)
 	}
 
+	// One package is re-added since the retreat, so restore skips it untouched;
+	// another is republished, so the version the snapshot recorded is gone and
+	// restore cannot put it back. Only two of the three are ever attempted.
+	env.republish(readdedDir, "count-readded-pkg", "2.0.0", "module.exports = 'v2';")
+	env.addPkg(projectDir, "count-readded-pkg", false, false)
+	env.republish(staleDir, "count-stale-pkg", "2.0.0", "module.exports = 'v2';")
+	env.chdir(projectDir)
+
+	var err error
+	captureStdout(t, func() { err = cli.RunRestore() })
+	if err == nil {
+		t.Fatal("Expected restore to exit non-zero when a package could not be restored")
+	}
+	if want := "1 of 2 package(s) failed to restore"; err.Error() != want {
+		t.Errorf("restore error = %q, want %q", err.Error(), want)
+	}
+}
+
+// TestRestoreRemovesAnEmptySnapshot covers the snapshot a retreat with a lock
+// file holding no packages leaves behind. There is nothing in it to restore, but
+// it is still a snapshot, and leaving it on disk means every later restore stops
+// on it and no later retreat can be told apart from a first one.
+func TestRestoreRemovesAnEmptySnapshot(t *testing.T) {
+	env := setupTest(t)
+
+	projectDir := env.newProject("empty-snapshot-project")
+	env.writeFile(lockfile.RetreatPath(projectDir), "version: 1\npackages: {}\n")
+
 	out := captureStdout(t, func() {
 		if err := cli.RunRestore(); err != nil {
-			t.Errorf("Failed to restore: %v", err)
+			t.Errorf("Expected restore of an empty snapshot to succeed, got: %v", err)
 		}
 	})
 
-	// Matched against the note itself, not just the package name and the word
-	// "dependencies": both of those also appear in the success line and in the
-	// npm install tip, so a looser check passes with the note removed.
-	want := "orphan-dev-pkg was not in package.json before the retreat, so its field is unknown; restoring it into dependencies"
-	if !strings.Contains(out, want) {
-		t.Errorf("Expected the report to contain %q, got:\n%s", want, out)
+	if !strings.Contains(out, "othing to restore") {
+		t.Errorf("Expected a 'nothing to restore' message, got:\n%s", out)
 	}
-	deps, _ := dependencyFields(t, projectDir)
-	if got := deps["orphan-dev-pkg"]; got != "file:.lnpm/orphan-dev-pkg" {
-		t.Errorf("dependencies[orphan-dev-pkg] = %v, want file:.lnpm/orphan-dev-pkg", got)
+	env.AssertFileExists(lockfile.RetreatPath(projectDir), false)
+}
+
+// TestRestoreNamesTheSnapshotInAReadError covers the wording of a corrupt
+// snapshot's error. The snapshot and the lock file share a format and a reader,
+// so a message that says "lock file" gives one artifact two names and sends the
+// user to look at a file that is fine.
+func TestRestoreNamesTheSnapshotInAReadError(t *testing.T) {
+	env := setupTest(t)
+
+	projectDir := env.newProject("corrupt-snapshot-project")
+	env.writeFile(lockfile.RetreatPath(projectDir), "packages: {not valid yaml")
+
+	err := cli.RunRestore()
+	if err == nil {
+		t.Fatal("Expected an error for a corrupt snapshot, got nil")
+	}
+	if !strings.Contains(err.Error(), "lnpm.lock.retreat") {
+		t.Errorf("Expected the error to name the snapshot, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "lock file") {
+		t.Errorf("Expected the error not to also call the snapshot a lock file, got: %v", err)
+	}
+}
+
+// TestRestoreMarkersComeFromTheIconHelpers sweeps restore's report for the
+// decorative markers, so a line printing "✓"/"⚠"/"💡" as a string literal instead
+// of calling the helpers is caught. It is the same guard retreat and doctor
+// carry, for the same reason and with the same limits: see
+// TestRetreatMarkersComeFromTheIconHelpers on what capturing stdout does and
+// does not prove.
+func TestRestoreMarkersComeFromTheIconHelpers(t *testing.T) {
+	cases := []struct {
+		name string
+		// stale republishes the package after the retreat, so its recorded
+		// version is gone from the store and restore reports a failure.
+		stale bool
+		// dev adds the package with --dev and no package.json entry, so restore
+		// cannot tell which field it belonged in and reports a warning.
+		dev  bool
+		want string
+	}{
+		{name: "package restored", want: "Restored glyph-restore-pkg@1.0.0"},
+		{name: "version no longer in the store", stale: true, want: "not found in store"},
+		{name: "dependency field unknown", dev: true, want: "so its field is unknown"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("NO_COLOR", "1")
+			env := setupTest(t)
+
+			pkgDir := env.simplePkg("glyph-restore-pkg")
+			projectDir := env.newProject("glyph-restore-project")
+			env.addPkg(projectDir, "glyph-restore-pkg", tc.dev, false)
+
+			if err := cli.RunRetreat(true, false); err != nil {
+				t.Fatalf("Failed to retreat: %v", err)
+			}
+			if tc.stale {
+				env.republish(pkgDir, "glyph-restore-pkg", "2.0.0", "module.exports = 'v2';")
+			}
+			env.chdir(projectDir)
+
+			out := captureStdout(t, func() { _ = cli.RunRestore() })
+
+			if !strings.Contains(out, tc.want) {
+				t.Fatalf("Expected the report to contain %q, got:\n%s", tc.want, out)
+			}
+			assertNoRawGlyphs(t, out)
+		})
 	}
 }
 

--- a/tests/restore_test.go
+++ b/tests/restore_test.go
@@ -435,3 +435,103 @@ func dependencyFields(t *testing.T, projectDir string) (deps, devDeps map[string
 	}
 	return getMapValue(pkgJSON, "dependencies"), getMapValue(pkgJSON, "devDependencies")
 }
+
+// TestRestoreRerunDoesNotReportItsOwnWorkAsAReAdd covers the re-run restore
+// itself advises after a partial failure, in the multi-package project where the
+// first run got some of the way.
+//
+// The snapshot has to survive that run, because the package that failed still
+// needs it. Kept whole it would also still name the package the run restored,
+// and the re-run would find that name in the lock file - which is otherwise only
+// true of a package the user added again - and report restore's own work back to
+// them as theirs. The same stale entry would let a later restore re-link a
+// package the user has since removed on purpose.
+//
+// So each name leaves the snapshot as it is dealt with, and what is on disk is
+// the work still outstanding.
+func TestRestoreRerunDoesNotReportItsOwnWorkAsAReAdd(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("prune-ok-pkg")
+	staleDir := env.simplePkg("prune-stale-pkg")
+	projectDir := env.newProject("prune-restore-project")
+	env.addPkg(projectDir, "prune-ok-pkg", false, false)
+	env.addPkg(projectDir, "prune-stale-pkg", false, false)
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+
+	// Republishing strands the version the snapshot recorded, so the first run
+	// restores one package and fails on the other.
+	env.republish(staleDir, "prune-stale-pkg", "2.0.0", "module.exports = 'v2';")
+	env.chdir(projectDir)
+
+	var err error
+	captureStdout(t, func() { err = cli.RunRestore() })
+	if err == nil {
+		t.Fatal("Expected the first run to exit non-zero, got nil")
+	}
+	env.AssertSymlinkExists(projectDir, "prune-ok-pkg")
+
+	snapshot, err := lockfile.LoadRetreat(projectDir)
+	if err != nil {
+		t.Fatalf("Failed to load the retreat snapshot: %v", err)
+	}
+	if snapshot == nil {
+		t.Fatal("Expected the snapshot to survive a run that failed, got none")
+	}
+	if snapshot.Has("prune-ok-pkg") {
+		t.Errorf("Expected the restored package to be gone from the snapshot, it holds %v", snapshot.List())
+	}
+	if !snapshot.Has("prune-stale-pkg") {
+		t.Errorf("Expected the package that failed to stay in the snapshot, it holds %v", snapshot.List())
+	}
+
+	out := captureStdout(t, func() { _ = cli.RunRestore() })
+
+	if strings.Contains(out, "prune-ok-pkg was added again since the retreat") {
+		t.Errorf("Expected the re-run not to report the first run's own work as a re-add, got:\n%s", out)
+	}
+	env.AssertSymlinkExists(projectDir, "prune-ok-pkg")
+	env.AssertPackageJSON(projectDir, "prune-ok-pkg", "file:.lnpm/prune-ok-pkg")
+}
+
+// TestRestoreDropsAReAddedPackageFromTheSnapshot is the other name restore is
+// finished with the moment it has read it. A package the user added again is
+// left alone, and there is nothing further the snapshot's entry for it can ever
+// do - except be restored over a later 'lnpm remove' of that same package, or
+// have the skip reported again on every re-run.
+func TestRestoreDropsAReAddedPackageFromTheSnapshot(t *testing.T) {
+	env := setupTest(t)
+
+	readdedDir := env.simplePkg("skip-readded-pkg")
+	staleDir := env.simplePkg("skip-stale-pkg")
+	projectDir := env.newProject("skip-restore-project")
+	env.addPkg(projectDir, "skip-readded-pkg", false, false)
+	env.addPkg(projectDir, "skip-stale-pkg", false, false)
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+
+	// One package is added again by the user, so restore skips it; another is
+	// stranded, so the run fails and the snapshot is kept.
+	env.republish(readdedDir, "skip-readded-pkg", "2.0.0", "module.exports = 'v2';")
+	env.addPkg(projectDir, "skip-readded-pkg", false, false)
+	env.republish(staleDir, "skip-stale-pkg", "2.0.0", "module.exports = 'v2';")
+	env.chdir(projectDir)
+
+	captureStdout(t, func() { _ = cli.RunRestore() })
+
+	snapshot, err := lockfile.LoadRetreat(projectDir)
+	if err != nil {
+		t.Fatalf("Failed to load the retreat snapshot: %v", err)
+	}
+	if snapshot == nil {
+		t.Fatal("Expected the snapshot to survive a run that failed, got none")
+	}
+	if snapshot.Has("skip-readded-pkg") {
+		t.Errorf("Expected the re-added package to be gone from the snapshot, it holds %v", snapshot.List())
+	}
+}

--- a/tests/restore_test.go
+++ b/tests/restore_test.go
@@ -132,8 +132,9 @@ func TestRestoreReportsStaleVersionAndContinues(t *testing.T) {
 		t.Error("Expected restore to exit non-zero when a package could not be restored")
 	}
 
-	if !strings.Contains(out, "stale-restore-pkg") || !strings.Contains(out, "2.0.0") {
-		t.Errorf("Expected the report to name stale-restore-pkg and the stored 2.0.0, got:\n%s", out)
+	want := "version 1.0.0 of stale-restore-pkg not found in store (latest published is 2.0.0"
+	if !strings.Contains(out, want) {
+		t.Errorf("Expected the report to contain %q, got:\n%s", want, out)
 	}
 
 	// The healthy package is restored regardless.
@@ -252,8 +253,12 @@ func TestRestoreReportsAnUnknownDependencyField(t *testing.T) {
 		}
 	})
 
-	if !strings.Contains(out, "orphan-dev-pkg") || !strings.Contains(out, "dependencies") {
-		t.Errorf("Expected restore to report the guess it made for orphan-dev-pkg, got:\n%s", out)
+	// Matched against the note itself, not just the package name and the word
+	// "dependencies": both of those also appear in the success line and in the
+	// npm install tip, so a looser check passes with the note removed.
+	want := "orphan-dev-pkg was not in package.json before the retreat, so its field is unknown; restoring it into dependencies"
+	if !strings.Contains(out, want) {
+		t.Errorf("Expected the report to contain %q, got:\n%s", want, out)
 	}
 	deps, _ := dependencyFields(t, projectDir)
 	if got := deps["orphan-dev-pkg"]; got != "file:.lnpm/orphan-dev-pkg" {

--- a/tests/retreat_test.go
+++ b/tests/retreat_test.go
@@ -410,3 +410,49 @@ func assertNoRawGlyphs(t *testing.T, out string) {
 		}
 	}
 }
+
+// TestRetreatWritesRestoreSnapshot covers the first acceptance criterion of
+// `lnpm restore`: `retreat --force` must preserve a record of what it unlinked
+// instead of discarding it, so restore has something to work from. The snapshot
+// stands in for the lock file retreat removes, and carries the same entries.
+func TestRetreatWritesRestoreSnapshot(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("snapshot-pkg-a")
+	env.simplePkg("snapshot-pkg-b")
+	projectDir := env.newProject("snapshot-project")
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":         "snapshot-project",
+		"version":      "1.0.0",
+		"dependencies": map[string]interface{}{"snapshot-pkg-a": "^1.0.0"},
+	})
+	env.addPkg(projectDir, "snapshot-pkg-a", false, false)
+	env.addPkg(projectDir, "snapshot-pkg-b", false, false)
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+
+	env.AssertLockfileExists(projectDir, false)
+	env.AssertFileExists(lockfile.RetreatPath(projectDir), true)
+
+	snapshot, err := lockfile.LoadRetreat(projectDir)
+	if err != nil {
+		t.Fatalf("Failed to load the retreat snapshot: %v", err)
+	}
+	if snapshot == nil {
+		t.Fatal("Expected a retreat snapshot, got none")
+	}
+	for _, name := range []string{"snapshot-pkg-a", "snapshot-pkg-b"} {
+		entry, ok := snapshot.Get(name)
+		if !ok {
+			t.Fatalf("Expected %s in the retreat snapshot", name)
+		}
+		if entry.Version != "1.0.0" {
+			t.Errorf("Expected %s at 1.0.0 in the snapshot, got %q", name, entry.Version)
+		}
+	}
+	if entry, _ := snapshot.Get("snapshot-pkg-a"); entry.OriginalVersion != "^1.0.0" {
+		t.Errorf("Expected snapshot-pkg-a to record the original specifier ^1.0.0, got %q", entry.OriginalVersion)
+	}
+}

--- a/tests/retreat_test.go
+++ b/tests/retreat_test.go
@@ -60,19 +60,96 @@ func TestRetreatVariants(t *testing.T) {
 	}
 }
 
-// TestRetreatNoForceFlag tests that retreat without --force changes nothing.
+// TestRetreatNoForceFlag tests that retreat without --force changes nothing, and
+// that the preview describes what --force would actually do. Retreat no longer
+// deletes the lock file, it saves it for 'lnpm restore', so a preview still
+// promising a delete would be talking the user out of the one artifact restore
+// needs.
 func TestRetreatNoForceFlag(t *testing.T) {
 	env := setupTest(t)
 
 	_, projectDir := env.publishAndAdd("force-pkg")
 
-	if err := cli.RunRetreat(false, false); err != nil {
-		t.Fatalf("Retreat without force failed: %v", err)
+	out := captureStdout(t, func() {
+		if err := cli.RunRetreat(false, false); err != nil {
+			t.Fatalf("Retreat without force failed: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "Delete lnpm.lock") {
+		t.Errorf("Expected the preview not to promise a deleted lock file, got:\n%s", out)
+	}
+	if !strings.Contains(out, "lnpm.lock.retreat") {
+		t.Errorf("Expected the preview to name the snapshot it saves, got:\n%s", out)
 	}
 
 	env.AssertSymlinkExists(projectDir, "force-pkg")
 	env.AssertLockfileExists(projectDir, true)
 	env.AssertDirectoryExists(filepath.Join(projectDir, ".lnpm"), true)
+}
+
+// TestRetreatMergesIntoAnUnconsumedSnapshot covers the second retreat that
+// follows a restore which could not finish, or an add made after a retreat: the
+// lock file being saved holds only part of what the outstanding snapshot does,
+// and renaming it over the snapshot would drop the rest for good.
+//
+// Restore itself tells the user to expect this sequence, so the packages the
+// first retreat unlinked have to survive the second one.
+func TestRetreatMergesIntoAnUnconsumedSnapshot(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("merge-snapshot-old")
+	env.simplePkg("merge-snapshot-new")
+	projectDir := env.newProject("merge-snapshot-project")
+	env.addPkg(projectDir, "merge-snapshot-old", false, false)
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+
+	// The snapshot is still on disk - nothing has restored it - when a new
+	// package is added and the project is retreated a second time.
+	env.AssertFileExists(lockfile.RetreatPath(projectDir), true)
+	env.addPkg(projectDir, "merge-snapshot-new", false, false)
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat a second time: %v", err)
+	}
+
+	snapshot, err := lockfile.LoadRetreat(projectDir)
+	if err != nil {
+		t.Fatalf("Failed to load the retreat snapshot: %v", err)
+	}
+	if snapshot == nil {
+		t.Fatal("Expected a retreat snapshot after the second retreat, got none")
+	}
+	for _, name := range []string{"merge-snapshot-old", "merge-snapshot-new"} {
+		if !snapshot.Has(name) {
+			t.Errorf("Expected %s to survive the second retreat, snapshot holds %v", name, snapshot.List())
+		}
+	}
+}
+
+// TestRetreatWithoutALockFileSavesNothing covers the report for a project that
+// has a stray .lnpm/ but no lock file: retreat has nothing to save, so it must
+// not claim it saved anything for restore.
+func TestRetreatWithoutALockFileSavesNothing(t *testing.T) {
+	env := setupTest(t)
+
+	projectDir := env.newProject("no-lock-retreat-project")
+	if err := os.MkdirAll(filepath.Join(projectDir, ".lnpm"), 0755); err != nil {
+		t.Fatalf("Failed to create .lnpm/: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := cli.RunRetreat(true, false); err != nil {
+			t.Fatalf("Failed to retreat: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "lnpm.lock") {
+		t.Errorf("Expected no claim about the lock file when there was none, got:\n%s", out)
+	}
+	env.AssertFileExists(lockfile.RetreatPath(projectDir), false)
 }
 
 // TestRetreatNoLinks tests retreating a project with no links is a safe no-op.

--- a/tests/retreat_test.go
+++ b/tests/retreat_test.go
@@ -533,3 +533,155 @@ func TestRetreatWritesRestoreSnapshot(t *testing.T) {
 		t.Errorf("Expected snapshot-pkg-a to record the original specifier ^1.0.0, got %q", entry.OriginalVersion)
 	}
 }
+
+// TestRetreatPreviewDoesNotPromiseToSaveALockFileThatIsNotThere is the preview
+// half of TestRetreatWithoutALockFileSavesNothing. A project with a stray .lnpm/
+// and no lock file has nothing to save, and --force says nothing about it, so
+// the preview of that same run must not announce a snapshot either.
+func TestRetreatPreviewDoesNotPromiseToSaveALockFileThatIsNotThere(t *testing.T) {
+	env := setupTest(t)
+
+	projectDir := env.newProject("no-lock-preview-project")
+	if err := os.MkdirAll(filepath.Join(projectDir, ".lnpm"), 0755); err != nil {
+		t.Fatalf("Failed to create .lnpm/: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := cli.RunRetreat(false, false); err != nil {
+			t.Fatalf("Retreat without force failed: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "lnpm.lock") {
+		t.Errorf("Expected the preview to make no claim about a lock file there is none of, got:\n%s", out)
+	}
+}
+
+// TestRetreatMergeKeepsAnOriginalVersionTheNewerEntryLost covers the one field a
+// merge must not decide by "newest wins".
+//
+// Every other field of an entry describes the link, which the newer entry
+// describes better. The original version describes what package.json held before
+// lnpm ever touched it, and it goes missing exactly when a retreat could not
+// write package.json - which retreat only warns about. package.json is then left
+// holding the lnpm reference, so the next 'lnpm add' reads that as the original
+// version and records nothing, and an empty field allowed to win would take the
+// user's range with it for good: every later retreat would drop the package from
+// package.json instead of restoring the range.
+func TestRetreatMergeKeepsAnOriginalVersionTheNewerEntryLost(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("keep-range-pkg")
+	projectDir := env.newProject("keep-range-project")
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":         "keep-range-project",
+		"version":      "1.0.0",
+		"dependencies": map[string]interface{}{"keep-range-pkg": "^1.0.0"},
+	})
+	env.addPkg(projectDir, "keep-range-pkg", false, false)
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+	if snapshot, err := lockfile.LoadRetreat(projectDir); err != nil {
+		t.Fatalf("Failed to load the retreat snapshot: %v", err)
+	} else if entry, _ := snapshot.Get("keep-range-pkg"); entry.OriginalVersion != "^1.0.0" {
+		t.Fatalf("Expected the snapshot to record ^1.0.0, got %q", entry.OriginalVersion)
+	}
+
+	// The state a retreat whose package.json write failed leaves behind: the
+	// lnpm reference is still in package.json, so the add that follows has no
+	// original version to read.
+	env.writePackageJSON(projectDir, map[string]interface{}{
+		"name":         "keep-range-project",
+		"version":      "1.0.0",
+		"dependencies": map[string]interface{}{"keep-range-pkg": "file:.lnpm/keep-range-pkg"},
+	})
+	env.addPkg(projectDir, "keep-range-pkg", false, false)
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		if entry, _ := lock.Get("keep-range-pkg"); entry.OriginalVersion != "" {
+			t.Fatalf("Expected the re-add to record no original version, got %q", entry.OriginalVersion)
+		}
+	})
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat a second time: %v", err)
+	}
+
+	snapshot, err := lockfile.LoadRetreat(projectDir)
+	if err != nil {
+		t.Fatalf("Failed to load the retreat snapshot: %v", err)
+	}
+	if snapshot == nil {
+		t.Fatal("Expected a retreat snapshot after the second retreat, got none")
+	}
+	entry, ok := snapshot.Get("keep-range-pkg")
+	if !ok {
+		t.Fatalf("Expected keep-range-pkg in the snapshot, it holds %v", snapshot.List())
+	}
+	if entry.OriginalVersion != "^1.0.0" {
+		t.Errorf("OriginalVersion = %q, want the ^1.0.0 the earlier retreat recorded", entry.OriginalVersion)
+	}
+}
+
+// TestRetreatKeepsTheSnapshotWhenTheMergeCannotBeWritten covers the merge's
+// failure path, which the rename branch's message does not fit.
+//
+// When a rename cannot save lnpm.lock there is no snapshot and restore really
+// does have nothing to work from. When a merge cannot be written there is one,
+// holding everything the earlier retreat unlinked; it is only this retreat's own
+// additions that are missing, and they are still in lnpm.lock, which is still in
+// place. Saying otherwise pushes the user towards deleting the file the merge
+// exists to protect.
+//
+// And the snapshot has to be intact to say so: the write goes through a temp
+// file and a rename precisely so that a failure cannot leave the record it was
+// merging into truncated.
+func TestRetreatKeepsTheSnapshotWhenTheMergeCannotBeWritten(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("merge-fail-old")
+	env.simplePkg("merge-fail-new")
+	projectDir := env.newProject("merge-fail-project")
+	env.addPkg(projectDir, "merge-fail-old", false, false)
+
+	if err := cli.RunRetreat(true, false); err != nil {
+		t.Fatalf("Failed to retreat: %v", err)
+	}
+
+	// Read-only snapshot: the merge can read it and cannot write it back.
+	snapshotPath := lockfile.RetreatPath(projectDir)
+	if err := os.Chmod(snapshotPath, 0444); err != nil {
+		t.Fatalf("Failed to chmod the snapshot: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(snapshotPath, 0644) })
+
+	env.addPkg(projectDir, "merge-fail-new", false, false)
+	env.chdir(projectDir)
+	out := captureStdout(t, func() {
+		if err := cli.RunRetreat(true, false); err != nil {
+			t.Fatalf("Failed to retreat a second time: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "has nothing to work from") {
+		t.Errorf("Expected no claim that restore has nothing to work from; the snapshot is right there. Got:\n%s", out)
+	}
+	if !strings.Contains(out, "still holds the earlier retreat") {
+		t.Errorf("Expected the report to say the snapshot survived, got:\n%s", out)
+	}
+
+	// Both records survive: lnpm.lock was not removed, and the snapshot the
+	// merge could not write still holds what the first retreat unlinked.
+	env.AssertLockfileExists(projectDir, true)
+	snapshot, err := lockfile.LoadRetreat(projectDir)
+	if err != nil {
+		t.Fatalf("Failed to load the retreat snapshot: %v", err)
+	}
+	if snapshot == nil {
+		t.Fatal("Expected the snapshot to survive a failed merge, got none")
+	}
+	if !snapshot.Has("merge-fail-old") {
+		t.Errorf("Expected the earlier retreat's record to survive intact, snapshot holds %v", snapshot.List())
+	}
+}


### PR DESCRIPTION
Closes #190.

`lnpm retreat --force` deleted `lnpm.lock` outright, so once it ran there was no
record of what had been linked. Returning to local-linked development meant
re-running `lnpm add <pkg>` for every package from memory. This adds the reverse
operation.

`retreat` now saves the lock file as `lnpm.lock.retreat` instead of deleting it,
and `lnpm restore` re-links everything it records — recreating `.lnpm/<pkg>`, the
`node_modules` symlink, and the `file:.lnpm/<pkg>` package.json entry for each,
then removing the snapshot.

## Behaviour worth knowing about

**Merge, not replace.** If you `lnpm add` something between `retreat` and
`restore`, the newer add wins for that name; snapshot-only packages are restored;
nothing is removed. This was the issue's one open question — decided as its own
"simplest option", and non-destructive.

**A second `retreat` merges into an unconsumed snapshot** rather than renaming
over it. Without that, the sequence `restore` itself recommends after a partial
failure — retreat, restore, some packages fail, retreat again — would silently
drop every package the first retreat unlinked.

**A partial restore is resumable.** Each name is dropped from the snapshot as it
is dealt with, and the lock entry is written only after the package.json write
succeeds, so a re-run finishes what failed rather than skipping it.

## Two fidelity limits, both inherent

The lock format records neither link-vs-copy nor dev-vs-prod, and lock-format
changes were out of scope.

- **`--link` becomes a copy.** Acceptance criterion 2 asks for the
  `file:.lnpm/<pkg>` entry, which is the copy form, so the spec settles this. Run
  `lnpm add --link <pkg>` again for anything you want pointed back at its live
  source. Documented in the README and in `restore --help`.
- **A package that was never in package.json restores into `dependencies`**, with
  a warning naming the package. Dev-ness is otherwise recovered by reading which
  field the package currently sits in. For a `--pure` package the entry is
  spurious and the warning now says so.

## `lnpm check` gained a guard

`retreat` now leaves a file behind where it used to leave nothing, and that file
records an absolute source path per linked package. `lnpm publish` excludes it,
but `npm publish` knows nothing about it — and the README documents
`retreat` → `check` → `npm publish` as the release flow.

So `check` fails when the snapshot is present *and* nothing in the project would
keep it out of a tarball, judged by the rules npm itself reads: the `files`
field, and `.npmignore` falling back to `.gitignore`. Presence alone is not a
failure — that would fire immediately after the command the README tells you to
run, on every project that uses `restore`.

## Notes

`lockfile.Save`/`SaveRetreat` now write through a temp file and rename. The
previous `os.WriteFile` truncated before writing, so a failed write to the
snapshot destroyed the only copy of the record. That change made two existing
tests pass for the wrong reason — they induce a save failure with a `0444` file,
and a rename replaces the destination regardless of mode — so `write` grew an
explicit read-only refusal, mirroring the one `internal/gitignore` already
carries. The tests are unmodified.

## Verification

`go test ./... -count=1`, `go vet`, `golangci-lint`, `gofmt -l`, plus build and
vet for windows/amd64, darwin/arm64 and linux/arm64 — all clean, and re-run under
a symlinked `TMPDIR` to catch path-fragile assertions.

Every new test was revert-checked against the change it pins. No pre-existing
test was weakened; the one pre-existing test that changed
(`TestRetreatNoForceFlag`) gained assertions and kept all of its old ones.

Local gates cross-compile for Windows but never execute there, so Windows
behaviour rests on CI.
