### PR TITLE
feat(link): relink only the files that changed since the last link

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -404,6 +404,17 @@ reading every file, which is the cost this exists to remove, and in hardlink mod
 an in-place edit has already written through the shared inode into the store
 entry itself: `lnpm gc` and a re-publish are what fix that.
 
+The location it records is the directory as the filesystem knows it — absolute,
+with the links along the way resolved — rather than the path the command that
+wrote it happened to be given. Commands do not agree on that path: `add`, `pull`,
+`remove` and `restore` build their linker from the working directory, while
+`push` and `publish` build theirs from the project path the database recorded,
+which is stored with its symlinks already resolved. Every spelling names the same
+directory, and a relink that rejected the manifest because the previous command
+spelled the path differently would rewrite the whole package — which is what
+add-then-push did on Windows, where the working directory keeps the 8.3 short
+names (`C:\Users\RUNNER~1\…`) that the database's normalization expands.
+
 The name is reserved, exactly as `.lnpm-complete` is reserved by the store. The
 store keeps its marker out of what `GetFiles` hands to consumers because the
 marker belongs to the store and not to the package; the same holds a level down,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,6 +53,9 @@
 project/
 ├── .lnpm/                       # Local package cache (hard linked)
 │   └── {package-name}/
+│       ├── .lnpm-linked         # What the last link put here (see below)
+│       ├── package.json
+│       ├── dist/
 │       └── ...
 ├── lnpm.lock                    # Lock file (YAML)
 ├── node_modules/
@@ -291,7 +294,13 @@ lnpm add my-package --link
 **Process:**
 1. Find package in store (latest or specified version)
 2. Create a temporary directory alongside `.lnpm/{package}/`
-3. Hard link all files from store into it, then rename it to `.lnpm/{package}/`
+3. Hard link all files from store into it, write the `.lnpm-linked` manifest,
+   then rename it to `.lnpm/{package}/`
+
+   A first `add` into a project has nothing to compare against and so links the
+   whole package. Re-running it against a package already linked there takes the
+   incremental path described under `lnpm push`.
+
 4. Create symlink `node_modules/{package}` → `.lnpm/{package}`
 5. Update `lnpm.lock`, recording the current `package.json` specifier as the
    original version
@@ -358,7 +367,14 @@ lnpm push --skip-hooks
    - Skip it if it is live-linked (`.lnpm/{package}` is a link, not a
      directory): it already resolves to the source directory being pushed, and
      relinking would swap its live link for a snapshot copy
-   - Create new hard links in a temporary directory alongside `.lnpm/{package}/`
+   - Compare the package against `.lnpm/{package}/.lnpm-linked`. If every file
+     is unchanged and the directory holds nothing else, there is nothing to do:
+     the directory is left exactly as it is, no file changes identity, and only
+     the `node_modules` symlink is checked
+   - Otherwise create a temporary directory alongside `.lnpm/{package}/` and
+     fill it: an unchanged file is hard linked across from the package already
+     in place, one syscall and no data moved; a changed one is materialised out
+     of the store
    - Rename it over `.lnpm/{package}/`, then delete the old directory
    - Preserve `node_modules` symlink
 
@@ -366,6 +382,32 @@ lnpm push --skip-hooks
    until the new one is fully built, so a consumer building against
    `node_modules/{package}` never sees an empty or half-written package, and a
    failed or interrupted push leaves the previous package in place.
+
+   A push therefore costs each project the size of the change rather than the
+   size of the package, and reports both: `3 changed, 1997 unchanged`.
+
+#### The link manifest (`.lnpm-linked`)
+
+Every materialised `.lnpm/{package}/` carries a `.lnpm-linked` file recording
+what the link put there: the path, content hash and permissions of each file,
+the link type the link achieved, and the directory's own location. It is the
+counterpart of the store's `.lnpm-complete` marker and is written the same way —
+last, inside the temporary directory — so it commits with the content it
+describes and can never outlive a swap that did not happen or survive one that
+did.
+
+A relink reads it to decide what it can leave alone. It is compared by name, not
+by content, so relinking still repairs a file deleted from under it or replaced
+by something that is not a regular file, and still drops a stray the package does
+not list — but it does not detect a file edited in place. Finding that out means
+reading every file, which is the cost this exists to remove, and in hardlink mode
+an in-place edit has already written through the shared inode into the store
+entry itself: `lnpm gc` and a re-publish are what fix that.
+
+The file is lnpm's, not the package's. A package that ships a file at that path
+keeps it, and simply relinks in full every time. The recorded location is what
+tells the two apart on the way back: a published file cannot name the project it
+will be linked into, so a `.lnpm-linked` naming this one was written here.
 
 ### `lnpm pull [package...]`
 
@@ -390,8 +432,9 @@ lnpm pull my-package other-pkg
    relinking it would silently swap the live link for a snapshot copy
 3. For each remaining package, look it up in the store; skip it when the lock
    entry already matches the store's version and content hash
-4. Hard link the store's current files into a temporary directory and rename it
-   over `.lnpm/{package}/`, exactly as `add` does
+4. Relink it from the store, exactly as `add` and `push` do — including the
+   incremental path, so a `pull` that finds only a few files changed rewrites
+   only those
 5. Update the entry in `lnpm.lock`, preserving the original `package.json`
    specifier recorded by `add`
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -404,10 +404,25 @@ reading every file, which is the cost this exists to remove, and in hardlink mod
 an in-place edit has already written through the shared inode into the store
 entry itself: `lnpm gc` and a re-publish are what fix that.
 
-The file is lnpm's, not the package's. A package that ships a file at that path
-keeps it, and simply relinks in full every time. The recorded location is what
-tells the two apart on the way back: a published file cannot name the project it
-will be linked into, so a `.lnpm-linked` naming this one was written here.
+The name is reserved, exactly as `.lnpm-complete` is reserved by the store. The
+store keeps its marker out of what `GetFiles` hands to consumers because the
+marker belongs to the store and not to the package; the same holds a level down,
+so a package that ships a file called `.lnpm-linked` at its root will **not** find
+it in `.lnpm/{package}` — the file is dropped from the set being linked. Nothing
+else about the package changes.
+
+Reserving it rather than yielding it is what makes the collision impossible
+rather than merely detectable. One path cannot hold two files, and a
+`.lnpm-linked` that is sometimes the record of a link and sometimes package
+content that looks like one leaves nothing on the way back in able to tell them
+apart — a version shipping a manifest that named the next version's hashes could
+then describe its own successor's relink.
+
+The recorded location is a separate, smaller thing: a manifest describes one
+directory, and is only acted on in the directory it names. Copying a project's
+`.lnpm/` into another checkout is the case that happens in practice — the
+manifest travels with it, still describing files by hash — and the mismatch costs
+one full relink, after which the manifest names its new home.
 
 ### `lnpm pull [package...]`
 

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -370,6 +370,16 @@ func linkTypeLabel(t link.LinkType) string {
 // A file the manifest does not cover keeps an empty hash and is simply always
 // rewritten, which is also why a manifest that cannot be read is logged rather
 // than returned: it costs the next relink its shortcut and nothing else.
+//
+// A manifest that describes some other generation of the package is refused
+// outright rather than used for the paths it happens to share. The package row
+// and its file rows are written in one transaction now, so a mismatch is no
+// longer reachable, but a database written before that was true can still hold
+// one - and stamping a superseded generation's hashes onto the current store
+// entry would mark a genuinely changed file reusable and carry stale content
+// into the project. Recomputing the package content hash from the file rows
+// costs no I/O and answers exactly that question, and falling back to hashless
+// files costs one full relink.
 func storeFilesForLink(database *db.DB, s *store.Store, pkg *db.Package) ([]*pack.FileInfo, error) {
 	files, err := s.GetFiles(pkg.Name, pkg.ContentHash)
 	if err != nil {
@@ -381,6 +391,10 @@ func storeFilesForLink(database *db.DB, s *store.Store, pkg *db.Package) ([]*pac
 		debug.Logf("cli: no file manifest for %s, relinking it in full: %v", pkg.Name, err)
 		return files, nil
 	}
+	if got := fileManifestHash(entries); got != pkg.ContentHash {
+		debug.Logf("cli: file manifest for %s describes %s, not the recorded %s; relinking it in full", pkg.Name, got, pkg.ContentHash)
+		return files, nil
+	}
 
 	hashes := make(map[string]string, len(entries))
 	for _, e := range entries {
@@ -390,6 +404,24 @@ func storeFilesForLink(database *db.DB, s *store.Store, pkg *db.Package) ([]*pac
 		f.ContentHash = hashes[f.RelPath]
 	}
 	return files, nil
+}
+
+// fileManifestHash is the package content hash the recorded file rows describe.
+//
+// It is pack.HashFiles over the same three fields publish and push hash to
+// produce the package row's content hash - path, content hash, permissions - so
+// a manifest that belongs to the package row reproduces it exactly and one that
+// belongs to another generation does not.
+func fileManifestHash(entries []*db.FileEntry) string {
+	infos := make([]*pack.FileInfo, len(entries))
+	for i, e := range entries {
+		infos[i] = &pack.FileInfo{
+			RelPath:     e.RelativePath,
+			ContentHash: e.ContentHash,
+			Mode:        e.Mode,
+		}
+	}
+	return pack.HashFiles(infos)
 }
 
 // linkPackage points the project at pkg. With useLink the project resolves to

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -11,9 +11,11 @@ import (
 
 	"github.com/pedrosousa13/lnpm/internal/config"
 	"github.com/pedrosousa13/lnpm/internal/db"
+	"github.com/pedrosousa13/lnpm/internal/debug"
 	"github.com/pedrosousa13/lnpm/internal/gitignore"
 	"github.com/pedrosousa13/lnpm/internal/hooks"
 	"github.com/pedrosousa13/lnpm/internal/link"
+	"github.com/pedrosousa13/lnpm/internal/pack"
 	"github.com/pedrosousa13/lnpm/internal/pkgjson"
 	"github.com/pedrosousa13/lnpm/internal/store"
 	"github.com/pedrosousa13/lnpm/pkg/lockfile"
@@ -113,14 +115,14 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 
 			result.pkg = pkg
 
-			linkType, err := linkPackage(linker, s, pkg, useLink)
+			linkRes, err := linkPackage(database, linker, s, pkg, useLink)
 			if err != nil {
 				result.err = err
 				results <- result
 				return
 			}
 
-			result.linkType = linkType
+			result.linkType = linkRes.Type
 			results <- result
 		}(spec)
 	}
@@ -356,28 +358,62 @@ func linkTypeLabel(t link.LinkType) string {
 	return string(t)
 }
 
+// storeFilesForLink returns the files of pkg's store entry, each carrying the
+// content hash the database recorded for it.
+//
+// Walking the store is what says which files the entry holds; the database is
+// what says what is in them. Link needs both: it compares those hashes against
+// the ones it last linked into the project to decide which files it can leave
+// alone, and a caller that hands it files with no hashes makes every relink
+// rewrite the whole package.
+//
+// A file the manifest does not cover keeps an empty hash and is simply always
+// rewritten, which is also why a manifest that cannot be read is logged rather
+// than returned: it costs the next relink its shortcut and nothing else.
+func storeFilesForLink(database *db.DB, s *store.Store, pkg *db.Package) ([]*pack.FileInfo, error) {
+	files, err := s.GetFiles(pkg.Name, pkg.ContentHash)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := database.GetFilesForPackage(pkg.ID)
+	if err != nil {
+		debug.Logf("cli: no file manifest for %s, relinking it in full: %v", pkg.Name, err)
+		return files, nil
+	}
+
+	hashes := make(map[string]string, len(entries))
+	for _, e := range entries {
+		hashes[e.RelativePath] = e.ContentHash
+	}
+	for _, f := range files {
+		f.ContentHash = hashes[f.RelPath]
+	}
+	return files, nil
+}
+
 // linkPackage points the project at pkg. With useLink the project resolves to
 // pkg's live source directory, so later source edits reach it with no further
 // command; otherwise the published snapshot is materialised out of the store.
-func linkPackage(linker *link.Linker, s *store.Store, pkg *db.Package, useLink bool) (link.LinkType, error) {
+func linkPackage(database *db.DB, linker *link.Linker, s *store.Store, pkg *db.Package, useLink bool) (link.Result, error) {
 	if useLink {
 		linkType, err := linker.LinkSource(pkg.Name, pkg.SourcePath)
 		if err != nil {
-			return "", fmt.Errorf("failed to link package source: %w", err)
+			return link.Result{}, fmt.Errorf("failed to link package source: %w", err)
 		}
-		return linkType, nil
+		return link.Result{Type: linkType}, nil
 	}
 
-	files, err := s.GetFiles(pkg.Name, pkg.ContentHash)
+	files, err := storeFilesForLink(database, s, pkg)
 	if err != nil {
-		return "", fmt.Errorf("failed to get package files: %w", err)
+		return link.Result{}, fmt.Errorf("failed to get package files: %w", err)
 	}
 
-	linkType, err := linker.Link(pkg.Name, pkg.StorePath, files)
+	res, err := linker.Link(pkg.Name, pkg.StorePath, files)
 	if err != nil {
-		return "", fmt.Errorf("failed to link package: %w", err)
+		return link.Result{}, fmt.Errorf("failed to link package: %w", err)
 	}
-	return linkType, nil
+	return res, nil
 }
 
 // runAddSingle adds a single package (internal implementation)
@@ -430,10 +466,11 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useL
 
 	// Link the package
 	linker := link.New(cwd)
-	linkType, err := linkPackage(linker, s, pkg, useLink)
+	linkRes, err := linkPackage(database, linker, s, pkg, useLink)
 	if err != nil {
 		return err
 	}
+	linkType := linkRes.Type
 
 	// Update .gitignore if enabled
 	cfg := config.Get()

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -359,13 +359,22 @@ func linkTypeLabel(t link.LinkType) string {
 }
 
 // storeFilesForLink returns the files of pkg's store entry, each carrying the
-// content hash the database recorded for it.
+// content hash and permissions the database recorded for it.
 //
 // Walking the store is what says which files the entry holds; the database is
 // what says what is in them. Link needs both: it compares those hashes against
 // the ones it last linked into the project to decide which files it can leave
 // alone, and a caller that hands it files with no hashes makes every relink
 // rewrite the whole package.
+//
+// The mode comes from the same row as the hash, and not from the store file's
+// own stat, so that this and push - which links from pack.FileInfoFromStore over
+// the same recorded rows - describe a file identically. The two are compared
+// against each other across a command boundary, through the manifest a link
+// writes and the next one reads, and a mode that disagreed would mark every file
+// changed. Statting the store agrees only for as long as the store's copy holds
+// exactly the permissions the file was published with, which entries written
+// before copyFile chmod'd past the umask do not.
 //
 // A file the manifest does not cover keeps an empty hash and is simply always
 // rewritten, which is also why a manifest that cannot be read is logged rather
@@ -396,12 +405,17 @@ func storeFilesForLink(database *db.DB, s *store.Store, pkg *db.Package) ([]*pac
 		return files, nil
 	}
 
-	hashes := make(map[string]string, len(entries))
+	recorded := make(map[string]*db.FileEntry, len(entries))
 	for _, e := range entries {
-		hashes[e.RelativePath] = e.ContentHash
+		recorded[e.RelativePath] = e
 	}
 	for _, f := range files {
-		f.ContentHash = hashes[f.RelPath]
+		e, ok := recorded[f.RelPath]
+		if !ok {
+			continue
+		}
+		f.ContentHash = e.ContentHash
+		f.Mode = e.Mode
 	}
 	return files, nil
 }

--- a/internal/cli/add_test.go
+++ b/internal/cli/add_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/db"
+	"github.com/pedrosousa13/lnpm/internal/pack"
 	"github.com/pedrosousa13/lnpm/internal/store"
 )
 
@@ -109,5 +110,161 @@ func TestStoreFilesForLinkStampsAManifestThatMatches(t *testing.T) {
 	}
 	if files[0].ContentHash != "aaaaaaaaaaaaaaaa" {
 		t.Errorf("storeFilesForLink() stamped %q onto index.js, want the recorded hash: a matching manifest is what the incremental relink runs on", files[0].ContentHash)
+	}
+}
+
+// publishForLink publishes a package built from files at a fresh source
+// directory and returns its database row, which is what add, pull and push each
+// start from when they link it.
+func publishForLink(t *testing.T, database *db.DB, name string, files map[string]os.FileMode) *db.Package {
+	t.Helper()
+
+	src := t.TempDir()
+	for rel, mode := range files {
+		path := filepath.Join(src, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatalf("seed source dir: %v", err)
+		}
+		if err := os.WriteFile(path, []byte("// "+rel+"\n"), mode); err != nil {
+			t.Fatalf("seed source file: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(src, "package.json"), []byte(`{"name":"`+name+`","version":"1.0.0"}`), 0644); err != nil {
+		t.Fatalf("seed package.json: %v", err)
+	}
+
+	pkgJSON, collected, err := pack.Pack(src)
+	if err != nil {
+		t.Fatalf("pack source: %v", err)
+	}
+	if err := finishPublish(src, pkgJSON, collected, database, false); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	pkg, err := database.GetPackageByName(name)
+	if err != nil || pkg == nil {
+		t.Fatalf("look up published package: %v", err)
+	}
+	return pkg
+}
+
+// pushFilesForLink is the file set push and publish --push hand to Link, built
+// the way both of them build it: pack.FileInfoFromStore over the rows recorded
+// for the package.
+func pushFilesForLink(t *testing.T, database *db.DB, pkg *db.Package) []*pack.FileInfo {
+	t.Helper()
+
+	entries, err := database.GetFilesForPackage(pkg.ID)
+	if err != nil {
+		t.Fatalf("read recorded files: %v", err)
+	}
+	data := make([]pack.FileEntryData, len(entries))
+	for i, e := range entries {
+		data[i] = pack.FileEntryData{RelPath: e.RelativePath, Size: e.Size, Mode: e.Mode, Hash: e.ContentHash}
+	}
+	return pack.FileInfoFromStore(pkg.StorePath, data)
+}
+
+// TestStoreFilesForLinkAgreesWithThePushProducer pins the invariant the
+// incremental relink rests on: the two file sets handed to Link describe the
+// same package identically.
+//
+// They are built by different commands from different sources - add and pull
+// walk the store entry, push and publish --push carry the packed source's
+// files forward - and Link compares one against the other across that boundary,
+// through the manifest one link writes and the next one reads. A field they
+// disagree about marks every file changed, and the whole package is rewritten
+// on every push: exactly the optimisation this exists to deliver, silently off.
+//
+// The comparison is platform-independent on purpose. A producer that disagreed
+// only on Windows, where a mode collapses to a read-only bit, would fail here on
+// the machine the developer is actually using.
+func TestStoreFilesForLinkAgreesWithThePushProducer(t *testing.T) {
+	_, database := newGCStore(t)
+
+	pkg := publishForLink(t, database, "agreeing-pkg", map[string]os.FileMode{
+		"index.js":     0644,
+		"lib/util.js":  0644,
+		"bin/cli.js":   0755,
+		"docs/read.md": 0644,
+	})
+
+	s, err := store.New()
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+
+	linkFiles, err := storeFilesForLink(database, s, pkg)
+	if err != nil {
+		t.Fatalf("storeFilesForLink() error = %v", err)
+	}
+	pushFiles := pushFilesForLink(t, database, pkg)
+
+	fromPush := make(map[string]*pack.FileInfo, len(pushFiles))
+	for _, f := range pushFiles {
+		fromPush[f.RelPath] = f
+	}
+	if len(linkFiles) != len(pushFiles) {
+		t.Fatalf("the store walk yielded %d files and the recorded rows %d", len(linkFiles), len(pushFiles))
+	}
+
+	for _, got := range linkFiles {
+		want, ok := fromPush[got.RelPath]
+		if !ok {
+			t.Errorf("%s is in the store entry but not in what push links, so a push would drop it", got.RelPath)
+			continue
+		}
+		if got.ContentHash != want.ContentHash {
+			t.Errorf("%s: add links it as %q and push as %q; a relink across the two rewrites it however little changed", got.RelPath, got.ContentHash, want.ContentHash)
+		}
+		if got.Mode != want.Mode {
+			t.Errorf("%s: add links it with mode %v and push with mode %v; a relink across the two rewrites it however little changed", got.RelPath, got.Mode, want.Mode)
+		}
+	}
+}
+
+// TestStoreFilesForLinkTakesTheRecordedModeNotTheStoresOwn is the mechanism
+// behind that agreement: the mode comes from the row the hash comes from, so it
+// is the mode the package was published with rather than whatever the store's
+// copy happens to stat as now.
+//
+// Those two parted company for real. copyFile gained its explicit chmod because
+// os.OpenFile's mode argument is masked by the umask, so a store entry written
+// before that carries permissions the package was never published with - and a
+// producer reading them would disagree with push about every file in it for as
+// long as the entry lives.
+func TestStoreFilesForLinkTakesTheRecordedModeNotTheStoresOwn(t *testing.T) {
+	_, database := newGCStore(t)
+
+	pkg := publishForLink(t, database, "drifted-mode-pkg", map[string]os.FileMode{"index.js": 0644})
+
+	stored := filepath.Join(pkg.StorePath, "index.js")
+	if err := os.Chmod(stored, 0600); err != nil {
+		t.Fatalf("chmod store file: %v", err)
+	}
+	info, err := os.Stat(stored)
+	if err != nil {
+		t.Fatalf("stat store file: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Skipf("this platform does not model the permission bits the drift is made of: the store file stats as %v", info.Mode())
+	}
+
+	s, err := store.New()
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	files, err := storeFilesForLink(database, s, pkg)
+	if err != nil {
+		t.Fatalf("storeFilesForLink() error = %v", err)
+	}
+
+	for _, f := range files {
+		if f.RelPath != "index.js" {
+			continue
+		}
+		if f.Mode.Perm() != 0644 {
+			t.Errorf("storeFilesForLink() reports index.js as %v, want the published 0644: push reports the recorded mode, and a relink across the two rewrites every file they disagree about", f.Mode)
+		}
 	}
 }

--- a/internal/cli/add_test.go
+++ b/internal/cli/add_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/db"
+	"github.com/pedrosousa13/lnpm/internal/store"
+)
+
+// seedStoreEntry writes a store entry holding one file and returns its path.
+func seedStoreEntry(t *testing.T, storeRoot, name, hash, relPath, content string) string {
+	t.Helper()
+
+	entry := filepath.Join(storeRoot, name, hash)
+	if err := os.MkdirAll(entry, 0755); err != nil {
+		t.Fatalf("seed store entry: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entry, relPath), []byte(content), 0644); err != nil {
+		t.Fatalf("seed store file: %v", err)
+	}
+	return entry
+}
+
+// TestStoreFilesForLinkRefusesAManifestFromAnotherGeneration pins the one thing
+// that makes a relink's file-level decisions safe: the hashes it stamps onto the
+// store's files have to describe those files.
+//
+// The package row and its file rows are written in one transaction, so they can
+// no longer name different generations - but a database written before that was
+// true can still hold the mismatch, and stamping a superseded generation's
+// hashes onto the current one would mark a genuinely changed file reusable and
+// carry stale content into the consumer's project. Recomputing the package
+// content hash from the file rows costs no I/O and catches exactly that, and
+// falling back to hashless files costs one full relink.
+func TestStoreFilesForLinkRefusesAManifestFromAnotherGeneration(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+
+	entry := seedStoreEntry(t, storeRoot, "drifted-pkg", "2222222222222222", "index.js", "module.exports = 'v2';")
+
+	// The file rows describe the previous generation: the same path, the hash
+	// it used to hold.
+	stale := []*db.FileEntry{{RelativePath: "index.js", ContentHash: "aaaaaaaaaaaaaaaa", Size: 3, Mode: 0644}}
+
+	pkg := &db.Package{
+		Name:        "drifted-pkg",
+		Version:     "2.0.0",
+		ContentHash: "2222222222222222",
+		StorePath:   entry,
+	}
+	if err := database.InsertPackage(pkg); err != nil {
+		t.Fatalf("insert package: %v", err)
+	}
+	if err := database.InsertFiles(pkg.ID, stale); err != nil {
+		t.Fatalf("insert files: %v", err)
+	}
+
+	s, err := store.New()
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+
+	files, err := storeFilesForLink(database, s, pkg)
+	if err != nil {
+		t.Fatalf("storeFilesForLink() error = %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("storeFilesForLink() returned %d files, want 1", len(files))
+	}
+	if files[0].ContentHash != "" {
+		t.Errorf("storeFilesForLink() stamped %q onto index.js from a file manifest that describes another generation; a relink would then treat a changed file as reusable", files[0].ContentHash)
+	}
+}
+
+// TestStoreFilesForLinkStampsAManifestThatMatches is the other half: a file
+// manifest that does describe the package row's generation must still be used,
+// or every relink falls back to rewriting the whole package and the incremental
+// path never runs.
+func TestStoreFilesForLinkStampsAManifestThatMatches(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+
+	entries := []*db.FileEntry{{RelativePath: "index.js", ContentHash: "aaaaaaaaaaaaaaaa", Size: 3, Mode: 0644}}
+	hash := fileManifestHash(entries)
+
+	entry := seedStoreEntry(t, storeRoot, "matched-pkg", hash, "index.js", "module.exports = 'v1';")
+
+	pkg := &db.Package{
+		Name:        "matched-pkg",
+		Version:     "1.0.0",
+		ContentHash: hash,
+		StorePath:   entry,
+	}
+	if err := database.InsertPackageWithFiles(pkg, entries); err != nil {
+		t.Fatalf("insert package with files: %v", err)
+	}
+
+	s, err := store.New()
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+
+	files, err := storeFilesForLink(database, s, pkg)
+	if err != nil {
+		t.Fatalf("storeFilesForLink() error = %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("storeFilesForLink() returned %d files, want 1", len(files))
+	}
+	if files[0].ContentHash != "aaaaaaaaaaaaaaaa" {
+		t.Errorf("storeFilesForLink() stamped %q onto index.js, want the recorded hash: a matching manifest is what the incremental relink runs on", files[0].ContentHash)
+	}
+}

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -86,7 +86,19 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 		// Re-check links after filtering orphans
 		validLinks := len(links) - countLinksForPackage(linksToRemove, pkg.ID)
 
-		// Package is orphaned if no valid links
+		// Package is orphaned if no valid links.
+		//
+		// Note for whoever adds pruning of superseded store generations: an
+		// incremental relink carries an unchanged file across from the package
+		// already in the project with a hard link, so .lnpm/{package} keeps the
+		// inode - and therefore the store generation - that first materialised
+		// each file, however many versions have been published since. Today that
+		// costs nothing, because what gets removed here is the whole package and
+		// only when no valid link remains, so nothing a project still points at
+		// is ever deleted. Start deleting entries a linked project no longer
+		// names and it becomes one extra copy per unchanged file per project:
+		// the last reference to the old generation's inode is the consumer's,
+		// and the disk it shared with the store stops being shared.
 		if validLinks == 0 {
 			// Check age if specified
 			if maxAge > 0 {

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -230,15 +230,13 @@ func finishPublish(pkgPath string, pkgJSON *pack.PackageJSON, files []*pack.File
 		TotalSize:   totalSize,
 	}
 
-	if err := database.InsertPackage(pkg); err != nil {
-		return fmt.Errorf("failed to record package: %w", err)
-	}
-
-	// Store file manifest
+	// The package row and its file manifest go in together. A relink reads the
+	// file rows to decide which files it can leave alone, so a package row that
+	// named this generation while the file rows still described the previous one
+	// would let a changed file be carried over unchanged.
 	fileEntries := make([]*db.FileEntry, len(files))
 	for i, f := range files {
 		fileEntries[i] = &db.FileEntry{
-			PackageID:    pkg.ID,
 			RelativePath: f.RelPath,
 			ContentHash:  f.ContentHash,
 			Size:         f.Size,
@@ -246,8 +244,8 @@ func finishPublish(pkgPath string, pkgJSON *pack.PackageJSON, files []*pack.File
 			ModTime:      f.ModTime,
 		}
 	}
-	if err := database.InsertFiles(pkg.ID, fileEntries); err != nil {
-		return fmt.Errorf("failed to record files: %w", err)
+	if err := database.InsertPackageWithFiles(pkg, fileEntries); err != nil {
+		return fmt.Errorf("failed to record package: %w", err)
 	}
 
 	fmt.Printf("%s Published %s@%s\n", iconOK(), pkgJSON.Name, pkgJSON.Version)

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -286,6 +286,7 @@ func pushToLinkedProjects(database *db.DB, pkg *db.Package, s *store.Store) erro
 	type result struct {
 		path    string
 		skipped bool
+		link    link.Result
 		err     error
 	}
 	results := make(chan result, len(projects))
@@ -295,8 +296,8 @@ func pushToLinkedProjects(database *db.DB, pkg *db.Package, s *store.Store) erro
 		wg.Add(1)
 		go func(p *db.Project) {
 			defer wg.Done()
-			skipped, err := pushToProject(p, pkg, s)
-			results <- result{path: p.Path, skipped: skipped, err: err}
+			linkRes, skipped, err := pushToProject(database, p, pkg, s)
+			results <- result{path: p.Path, skipped: skipped, link: linkRes, err: err}
 		}(proj)
 	}
 
@@ -317,7 +318,7 @@ func pushToLinkedProjects(database *db.DB, pkg *db.Package, s *store.Store) erro
 			fmt.Printf("  %s %s: skipped (live link to source)\n", iconOK(), res.path)
 			skippedCount++
 		default:
-			fmt.Printf("  %s %s\n", iconOK(), res.path)
+			fmt.Printf("  %s %s (%d changed, %d unchanged)\n", iconOK(), res.path, res.link.Changed, res.link.Unchanged)
 			successCount++
 		}
 	}
@@ -336,8 +337,9 @@ func pushToLinkedProjects(database *db.DB, pkg *db.Package, s *store.Store) erro
 }
 
 // pushToProject pushes a package update to a single project, reporting whether
-// the project was skipped rather than relinked.
-func pushToProject(proj *db.Project, pkg *db.Package, s *store.Store) (skipped bool, err error) {
+// the project was skipped rather than relinked and, when it was relinked, how
+// much of the package the relink actually had to rewrite.
+func pushToProject(database *db.DB, proj *db.Project, pkg *db.Package, s *store.Store) (res link.Result, skipped bool, err error) {
 	// A project that added this package with --link already resolves to the
 	// source directory just published. Relinking it from the store would replace
 	// its live link with a snapshot copy and silently end the live updates it
@@ -345,18 +347,18 @@ func pushToProject(proj *db.Project, pkg *db.Package, s *store.Store) (skipped b
 	// `publish --push`.
 	linker := link.New(proj.Path)
 	if linker.IsLiveLinked(pkg.Name) {
-		return true, nil
+		return link.Result{}, true, nil
 	}
 
 	// Get files from store
-	files, err := s.GetFiles(pkg.Name, pkg.ContentHash)
+	files, err := storeFilesForLink(database, s, pkg)
 	if err != nil {
-		return false, err
+		return link.Result{}, false, err
 	}
 
 	// Re-link the package
-	_, err = linker.Link(pkg.Name, pkg.StorePath, files)
-	return false, err
+	res, err = linker.Link(pkg.Name, pkg.StorePath, files)
+	return res, false, err
 }
 
 // shortHash returns the first 8 characters of a hash

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -105,7 +105,7 @@ func RunPull(packageNames []string) error {
 		// Every path out of here closes the "Pulling <name>... " line, so a
 		// failure names itself where it happened instead of leaving the line
 		// dangling until the end-of-run report.
-		files, err := s.GetFiles(pkg.Name, pkg.ContentHash)
+		files, err := storeFilesForLink(database, s, pkg)
 		if err != nil {
 			fmt.Printf("failed to get package files: %v\n", err)
 			failed = append(failed, fmt.Errorf("%s: failed to get package files: %w", name, err))

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -115,8 +115,12 @@ func RunPull(packageNames []string) error {
 		// The link type Link reports is deliberately dropped, and no db link row
 		// is written: publishing updates the existing package row in place, so
 		// the row add recorded still points at the package pull just linked, and
-		// no command surfaces the stored link type.
-		if _, err := linker.Link(pkg.Name, pkg.StorePath, files); err != nil {
+		// no command surfaces the stored link type. The per-file counts are
+		// kept: pull runs the same incremental relink push does, and reporting
+		// nothing would make it the one command that leaves the user guessing
+		// whether the refresh cost the whole package.
+		linkRes, err := linker.Link(pkg.Name, pkg.StorePath, files)
+		if err != nil {
 			fmt.Printf("failed to link package: %v\n", err)
 			failed = append(failed, fmt.Errorf("%s: failed to link package: %w", name, err))
 			continue
@@ -134,7 +138,7 @@ func RunPull(packageNames []string) error {
 		})
 		lockChanged = true
 
-		fmt.Printf("updated %s -> %s\n", entry.Version, pkg.Version)
+		fmt.Printf("updated %s -> %s (%d changed, %d unchanged)\n", entry.Version, pkg.Version, linkRes.Changed, linkRes.Unchanged)
 		refreshed++
 		lastVersion = pkg.Version
 	}

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -173,6 +173,7 @@ func RunPush(skipHooks bool) error {
 	type result struct {
 		path    string
 		skipped bool
+		link    link.Result
 		err     error
 	}
 	results := make(chan result, len(projects))
@@ -191,8 +192,8 @@ func RunPush(skipHooks bool) error {
 				results <- result{path: p.Path, skipped: true}
 				return
 			}
-			_, err := linker.Link(pkg.Name, storePath, storeFiles)
-			results <- result{path: p.Path, err: err}
+			linkRes, err := linker.Link(pkg.Name, storePath, storeFiles)
+			results <- result{path: p.Path, link: linkRes, err: err}
 		}(proj)
 	}
 
@@ -213,7 +214,7 @@ func RunPush(skipHooks bool) error {
 			fmt.Printf("  %s %s: skipped (live link to source)\n", iconOK(), res.path)
 			skippedCount++
 		default:
-			fmt.Printf("  %s %s\n", iconOK(), res.path)
+			fmt.Printf("  %s %s (%d changed, %d unchanged)\n", iconOK(), res.path, res.link.Changed, res.link.Unchanged)
 			successCount++
 		}
 	}

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -112,7 +112,6 @@ func RunPush(skipHooks bool) error {
 	}
 
 	// Update package in database
-	hashChanged := pkg.ContentHash != newHash
 	pkg.Version = pkgJSON.Version
 	pkg.ContentHash = newHash
 	pkg.SourcePath = cwd
@@ -120,26 +119,23 @@ func RunPush(skipHooks bool) error {
 	pkg.FilesCount = len(files)
 	pkg.TotalSize = totalSize
 
-	if err := database.InsertPackage(pkg); err != nil {
-		return fmt.Errorf("failed to update package: %w", err)
+	// The package row and its file manifest go in together, for the reason
+	// finishPublish gives. The manifest is rewritten whether or not the content
+	// hash moved: skipping it when nothing changed would save one bucket write
+	// and make "the file rows always describe the package row" conditional,
+	// which is the property a relink's file-level decisions rest on.
+	fileEntries := make([]*db.FileEntry, len(files))
+	for i, f := range files {
+		fileEntries[i] = &db.FileEntry{
+			RelativePath: f.RelPath,
+			ContentHash:  f.ContentHash,
+			Size:         f.Size,
+			Mode:         f.Mode,
+			ModTime:      f.ModTime,
+		}
 	}
-
-	// Only update file manifest if content hash changed
-	if hashChanged {
-		fileEntries := make([]*db.FileEntry, len(files))
-		for i, f := range files {
-			fileEntries[i] = &db.FileEntry{
-				PackageID:    pkg.ID,
-				RelativePath: f.RelPath,
-				ContentHash:  f.ContentHash,
-				Size:         f.Size,
-				Mode:         f.Mode,
-				ModTime:      f.ModTime,
-			}
-		}
-		if err := database.InsertFiles(pkg.ID, fileEntries); err != nil {
-			return fmt.Errorf("failed to update files: %w", err)
-		}
+	if err := database.InsertPackageWithFiles(pkg, fileEntries); err != nil {
+		return fmt.Errorf("failed to update package: %w", err)
 	}
 
 	// Get linked projects

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -156,7 +156,7 @@ func RunRestore() error {
 			originalVersion = entry.OriginalVersion
 		}
 
-		linkType, err := linkPackage(linker, s, pkg, false)
+		linkRes, err := linkPackage(database, linker, s, pkg, false)
 		if err != nil {
 			fmt.Printf("  %s %s: %v\n", iconFail(), name, err)
 			failed++
@@ -205,7 +205,7 @@ func RunRestore() error {
 		}
 		consumeSnapshotEntry(snapshot, cwd, name)
 
-		recordRestoredLink(database, cwd, pkg, linkType)
+		recordRestoredLink(database, cwd, pkg, linkRes.Type)
 
 		fmt.Printf("%s Restored %s@%s\n", iconOK(), name, pkg.Version)
 		restored++

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -251,62 +251,96 @@ func (db *DB) nextID(tx *bolt.Tx) (int64, error) {
 
 // --- Package operations ---
 
-// InsertPackage inserts or updates a package
+// InsertPackage inserts or updates a package.
+//
+// A package whose file manifest is being written at the same time must go
+// through InsertPackageWithFiles instead: the two rows describe one generation
+// of one package, and committing them separately lets a failure between them
+// leave a package row naming content its file rows do not describe.
 func (db *DB) InsertPackage(pkg *Package) error {
 	debug.Logf("db: insert package %s@%s", pkg.Name, pkg.Version)
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
 	return db.db.Update(func(tx *bolt.Tx) error {
-		packages := tx.Bucket(bucketPackages)
-		byName := tx.Bucket(bucketPackagesByName)
+		return db.insertPackageTx(tx, pkg)
+	})
+}
 
-		// Check if package with same name exists (update case)
-		if existingIDBytes := byName.Get([]byte(pkg.Name)); existingIDBytes != nil {
-			existingID := btoi(existingIDBytes)
-			if data := packages.Get(itob(existingID)); data != nil {
-				var existing Package
-				if err := json.Unmarshal(data, &existing); err == nil {
-					// Update existing package
-					existing.Version = pkg.Version
-					existing.ContentHash = pkg.ContentHash
-					existing.SourcePath = pkg.SourcePath
-					existing.StorePath = pkg.StorePath
-					existing.FilesCount = pkg.FilesCount
-					existing.TotalSize = pkg.TotalSize
-					existing.UpdatedAt = time.Now()
-					pkg.ID = existing.ID
+// InsertPackageWithFiles records a package and the files it contains in a single
+// transaction, so the two either both land or neither does.
+//
+// This is not tidiness. A relink decides which files it can leave alone by
+// comparing the hashes in the file rows against the ones it last linked into the
+// project, so a package row that names a new generation while the file rows
+// still describe the previous one is enough to mark a genuinely changed file
+// reusable and carry stale content into a consumer's project. Bolt gives one
+// transaction per write, and one transaction is what makes that state
+// unreachable.
+func (db *DB) InsertPackageWithFiles(pkg *Package, files []*FileEntry) error {
+	debug.Logf("db: insert package %s@%s with %d files", pkg.Name, pkg.Version, len(files))
+	db.mu.Lock()
+	defer db.mu.Unlock()
 
-					data, err := json.Marshal(&existing)
-					if err != nil {
-						return err
-					}
-					return packages.Put(itob(existing.ID), data)
+	return db.db.Update(func(tx *bolt.Tx) error {
+		if err := db.insertPackageTx(tx, pkg); err != nil {
+			return err
+		}
+		return db.insertFilesTx(tx, pkg.ID, files)
+	})
+}
+
+// insertPackageTx is InsertPackage's body, taking the transaction from its
+// caller so it can share one with insertFilesTx.
+func (db *DB) insertPackageTx(tx *bolt.Tx, pkg *Package) error {
+	packages := tx.Bucket(bucketPackages)
+	byName := tx.Bucket(bucketPackagesByName)
+
+	// Check if package with same name exists (update case)
+	if existingIDBytes := byName.Get([]byte(pkg.Name)); existingIDBytes != nil {
+		existingID := btoi(existingIDBytes)
+		if data := packages.Get(itob(existingID)); data != nil {
+			var existing Package
+			if err := json.Unmarshal(data, &existing); err == nil {
+				// Update existing package
+				existing.Version = pkg.Version
+				existing.ContentHash = pkg.ContentHash
+				existing.SourcePath = pkg.SourcePath
+				existing.StorePath = pkg.StorePath
+				existing.FilesCount = pkg.FilesCount
+				existing.TotalSize = pkg.TotalSize
+				existing.UpdatedAt = time.Now()
+				pkg.ID = existing.ID
+
+				data, err := json.Marshal(&existing)
+				if err != nil {
+					return err
 				}
+				return packages.Put(itob(existing.ID), data)
 			}
 		}
+	}
 
-		// Insert new package
-		id, err := db.nextID(tx)
-		if err != nil {
-			return err
-		}
-		pkg.ID = id
-		pkg.CreatedAt = time.Now()
-		pkg.UpdatedAt = time.Now()
+	// Insert new package
+	id, err := db.nextID(tx)
+	if err != nil {
+		return err
+	}
+	pkg.ID = id
+	pkg.CreatedAt = time.Now()
+	pkg.UpdatedAt = time.Now()
 
-		data, err := json.Marshal(pkg)
-		if err != nil {
-			return err
-		}
+	data, err := json.Marshal(pkg)
+	if err != nil {
+		return err
+	}
 
-		if err := packages.Put(itob(id), data); err != nil {
-			return err
-		}
+	if err := packages.Put(itob(id), data); err != nil {
+		return err
+	}
 
-		// Index by name
-		return byName.Put([]byte(pkg.Name), itob(id))
-	})
+	// Index by name
+	return byName.Put([]byte(pkg.Name), itob(id))
 }
 
 // GetPackageByName returns the latest package with the given name
@@ -837,39 +871,48 @@ func (db *DB) GetProjectsForPackage(packageID int64) ([]*Project, error) {
 
 // --- File operations ---
 
-// InsertFiles inserts file entries for a package
+// InsertFiles inserts file entries for a package.
+//
+// A package being written at the same time must go through
+// InsertPackageWithFiles instead, for the reason given there.
 func (db *DB) InsertFiles(packageID int64, files []*FileEntry) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
 	return db.db.Batch(func(tx *bolt.Tx) error {
-		b := tx.Bucket(bucketFiles)
-
-		// Assign IDs - pre-allocate to avoid multiple ID generations
-		startID, err := db.nextID(tx)
-		if err != nil {
-			return err
-		}
-
-		// Batch assign IDs
-		for i, f := range files {
-			f.ID = startID + int64(i)
-			f.PackageID = packageID
-		}
-
-		// Update next ID counter once for all files
-		meta := tx.Bucket(bucketMeta)
-		if err := meta.Put([]byte("next_id"), itob(startID+int64(len(files)))); err != nil {
-			return err
-		}
-
-		data, err := json.Marshal(files)
-		if err != nil {
-			return err
-		}
-
-		return b.Put(itob(packageID), data)
+		return db.insertFilesTx(tx, packageID, files)
 	})
+}
+
+// insertFilesTx is InsertFiles' body, taking the transaction from its caller so
+// it can share one with insertPackageTx.
+func (db *DB) insertFilesTx(tx *bolt.Tx, packageID int64, files []*FileEntry) error {
+	b := tx.Bucket(bucketFiles)
+
+	// Assign IDs - pre-allocate to avoid multiple ID generations
+	startID, err := db.nextID(tx)
+	if err != nil {
+		return err
+	}
+
+	// Batch assign IDs
+	for i, f := range files {
+		f.ID = startID + int64(i)
+		f.PackageID = packageID
+	}
+
+	// Update next ID counter once for all files
+	meta := tx.Bucket(bucketMeta)
+	if err := meta.Put([]byte("next_id"), itob(startID+int64(len(files)))); err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(files)
+	if err != nil {
+		return err
+	}
+
+	return b.Put(itob(packageID), data)
 }
 
 // GetFilesForPackage returns all files for a package

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -97,13 +97,13 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	}
 	reusable := reusableFiles(prior, files)
 
-	// Nothing to do at all: every file is already there, and the package it is
-	// already holding contains nothing else. Skipping the swap is the point -
-	// the directory the consumer is building against is not touched, so no file
-	// changes identity and none is rewritten. The node_modules link is still
-	// checked, since a caller may be relinking precisely because that went
-	// missing.
-	if len(reusable) == len(files) && len(prior) == len(files) && len(files) > 0 {
+	// Nothing to do at all: every file the package lists is already there, the
+	// package already linked holds nothing else, and all of it is still on disk.
+	// Skipping the swap is the point - the directory the consumer is building
+	// against is not touched, so no file changes identity and none is rewritten.
+	// The node_modules link is still checked, since a caller may be relinking
+	// precisely because that went missing.
+	if len(reusable) == len(files) && len(prior) == len(files) && len(files) > 0 && allPresent(lnpmPath, files) {
 		debug.Logf("link: %s is already up to date (%d files)", packageName, len(files))
 		if err := l.createNodeModulesSymlink(packageName); err != nil {
 			return Result{}, err
@@ -177,15 +177,16 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 				// the store - is not in play. Preserving identity across a
 				// relink is the behaviour every mode wants.
 				if reusable[f.RelPath] {
-					if err := os.Link(filepath.Join(lnpmPath, f.RelPath), dstPath); err == nil {
+					err := os.Link(filepath.Join(lnpmPath, f.RelPath), dstPath)
+					if err == nil {
 						atomic.AddInt32(&reusedCount, 1)
 						continue
-					} else {
-						// Reuse is only ever an optimisation - a filesystem
-						// that will not hard link, or a file that has since
-						// gone - so fall through and materialise it as usual.
-						debug.Logf("link: cannot reuse %s, materialising it: %v", f.RelPath, err)
 					}
+					// Reuse is only ever an optimisation - a filesystem that
+					// will not hard link, or a file that has gone since the
+					// check above - so fall through and materialise it as
+					// usual rather than failing the link over it.
+					debug.Logf("link: cannot reuse %s, materialising it: %v", f.RelPath, err)
 				}
 
 				linked := false

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -333,7 +333,7 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	// temp directory, so it commits with the content and can never describe a
 	// tree that is not there.
 	if keepManifest {
-		writeManifest(tempPath, files)
+		writeManifest(tempPath, lnpmPath, files)
 	}
 
 	// Swap the completed package into place. The previous directory is renamed

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -86,6 +86,14 @@ func New(projectPath string) *Linker {
 // in-place edit has already written through the shared inode into the store
 // entry itself, so no relink ever repaired it: `lnpm gc` and a re-publish are
 // what fix that.
+//
+// The manifest is kept at .lnpm-linked inside the linked package, and that name
+// is the linker's. A package that ships a file called .lnpm-linked at its root
+// does not get it: the file is dropped from the set being linked, exactly as the
+// store drops its own .lnpm-complete marker from what it hands to consumers.
+// What .lnpm/{package} holds is the package plus the record of the link that put
+// it there, and reserving the name is what keeps those two from ever being the
+// same path.
 func (l *Linker) Link(packageName string, storePath string, files []*pack.FileInfo) (Result, error) {
 	debug.Logf("link: linking %s from %s (%d files)", packageName, storePath, len(files))
 
@@ -94,6 +102,10 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	if err := pack.ValidatePackageName(packageName); err != nil {
 		return Result{}, err
 	}
+
+	// The manifest's name is reserved before anything else reads the file set,
+	// so nothing below has to consider a package's file competing for it.
+	files = withoutManifestName(files)
 
 	// Determine link type based on config and filesystem
 	linkType := l.determineLinkType(storePath)
@@ -108,13 +120,9 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 
 	// What the last link into this project left behind, what of that is still on
 	// disk, and which of the files now being linked it already holds.
-	keepManifest := !shipsManifestName(files)
-	var prior *linkManifest
 	var present map[string]bool
 	var unexpected int
-	if keepManifest {
-		prior = readManifest(lnpmPath)
-	}
+	prior := readManifest(lnpmPath)
 	if prior != nil {
 		present, unexpected = scanLinked(lnpmPath)
 	}
@@ -348,10 +356,9 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 
 	// Record what is in the tree about to be swapped in. Written last inside the
 	// temp directory, so it commits with the content and can never describe a
-	// tree that is not there.
-	if keepManifest {
-		writeManifest(tempPath, lnpmPath, actualType, files)
-	}
+	// tree that is not there. Nothing can already occupy the path: the name is
+	// reserved, so no worker was given a file to materialise there.
+	writeManifest(tempPath, lnpmPath, actualType, files)
 
 	// Swap the completed package into place. The previous directory is renamed
 	// aside rather than deleted first, so .lnpm/{package} is missing for a

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -68,6 +68,16 @@ func New(projectPath string) *Linker {
 // data moved, so the cost of a relink follows the size of the change rather than
 // the size of the package. When nothing differs at all there is nothing to swap
 // and the package is left exactly as it is.
+//
+// Relinking repairs a deletion, not a modification. What is on disk is compared
+// against the manifest by name, not by content: a file that has gone, or that is
+// no longer a regular file, is materialised again out of the store, and a stray
+// the package does not list is dropped, but a file whose bytes have been edited
+// in place is left as it is and carried forward. Reading every file to find that
+// out is precisely the cost this exists to remove, and in hardlink mode an
+// in-place edit has already written through the shared inode into the store
+// entry itself, so no relink ever repaired it: `lnpm gc` and a re-publish are
+// what fix that.
 func (l *Linker) Link(packageName string, storePath string, files []*pack.FileInfo) (Result, error) {
 	debug.Logf("link: linking %s from %s (%d files)", packageName, storePath, len(files))
 
@@ -88,22 +98,33 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	// behind permanently.
 	lnpmPath := filepath.Join(l.projectPath, ".lnpm", packageName)
 
-	// What the last link into this project left behind, and which of the files
-	// now being linked it already holds.
+	// What the last link into this project left behind, what of that is still on
+	// disk, and which of the files now being linked it already holds.
 	keepManifest := !shipsManifestName(files)
 	var prior map[string]linkedFile
+	var present map[string]bool
+	var unexpected int
 	if keepManifest {
 		prior = readManifest(lnpmPath)
 	}
-	reusable := reusableFiles(prior, files)
+	if prior != nil {
+		present, unexpected = scanLinked(lnpmPath)
+	}
+	reusable := reusableFiles(prior, present, files)
 
-	// Nothing to do at all: every file the package lists is already there, the
-	// package already linked holds nothing else, and all of it is still on disk.
+	// Nothing to do at all: every file the package lists is already there and
+	// unchanged, and the directory holds nothing besides those files and the
+	// manifest describing them - which is the one more entry the count allows
+	// for. That second half is what keeps a relink a full repair: a stray the
+	// package does not list answers none of the manifest's questions, and before
+	// there was anything to skip, every relink swapped in a tree built from the
+	// package alone and so removed it.
+	//
 	// Skipping the swap is the point - the directory the consumer is building
 	// against is not touched, so no file changes identity and none is rewritten.
 	// The node_modules link is still checked, since a caller may be relinking
 	// precisely because that went missing.
-	if len(reusable) == len(files) && len(prior) == len(files) && len(files) > 0 && allPresent(lnpmPath, files) {
+	if len(files) > 0 && len(reusable) == len(files) && unexpected == 0 && len(present) == len(files)+1 {
 		debug.Logf("link: %s is already up to date (%d files)", packageName, len(files))
 		if err := l.createNodeModulesSymlink(packageName); err != nil {
 			return Result{}, err

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -35,6 +35,14 @@ const (
 // always add up to the package's file count, so a caller can report the size of
 // a push's actual effect rather than the size of the package.
 //
+// Type is how the linked package is held: what the workers achieved, which is
+// not always what the configuration asked for - a copy that a reflink satisfied
+// is reported as a hard link, and a hard link that the filesystem refused as a
+// copy. A relink that materialised nothing reports how the tree it left in place
+// was built, not a fresh prediction, so re-running a command against an already
+// current package does not turn the recorded type over with nothing having
+// changed.
+//
 // LinkSource has no counterpart because it materialises nothing: there is no
 // per-file work for it to have avoided.
 type Result struct {
@@ -101,7 +109,7 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	// What the last link into this project left behind, what of that is still on
 	// disk, and which of the files now being linked it already holds.
 	keepManifest := !shipsManifestName(files)
-	var prior map[string]linkedFile
+	var prior *linkManifest
 	var present map[string]bool
 	var unexpected int
 	if keepManifest {
@@ -129,7 +137,16 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 		if err := l.createNodeModulesSymlink(packageName); err != nil {
 			return Result{}, err
 		}
-		return Result{Type: linkType, Unchanged: len(files)}, nil
+		// The type reported is the one the tree was built with, not the one
+		// determineLinkType has just predicted: nothing here was materialised,
+		// so the prediction describes work that did not happen. A manifest
+		// written before the type was recorded has none to give, and the
+		// prediction is then the best answer available.
+		reported := linkType
+		if prior.LinkType != "" {
+			reported = prior.LinkType
+		}
+		return Result{Type: reported, Unchanged: len(files)}, nil
 	}
 
 	parentDir := filepath.Dir(lnpmPath)
@@ -333,7 +350,7 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	// temp directory, so it commits with the content and can never describe a
 	// tree that is not there.
 	if keepManifest {
-		writeManifest(tempPath, lnpmPath, files)
+		writeManifest(tempPath, lnpmPath, actualType, files)
 	}
 
 	// Swap the completed package into place. The previous directory is renamed

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -28,6 +28,21 @@ const (
 	Live LinkType = "link"
 )
 
+// Result reports what a Link did.
+//
+// Changed counts the files it materialised out of the store, Unchanged the ones
+// it carried over from the previous link without rewriting them. Together they
+// always add up to the package's file count, so a caller can report the size of
+// a push's actual effect rather than the size of the package.
+//
+// LinkSource has no counterpart because it materialises nothing: there is no
+// per-file work for it to have avoided.
+type Result struct {
+	Type      LinkType
+	Changed   int
+	Unchanged int
+}
+
 // Linker handles linking packages to projects
 type Linker struct {
 	projectPath string
@@ -47,13 +62,19 @@ func New(projectPath string) *Linker {
 // and corrupts that entry for every other consumer. Propagation is therefore
 // one-way by design: linked packages are read-only from the consumer's side,
 // and `push` is the supported way to update them.
-func (l *Linker) Link(packageName string, storePath string, files []*pack.FileInfo) (LinkType, error) {
+//
+// Only the files that differ from the last link are materialised. The rest are
+// hard linked across from the package already in place, one syscall each and no
+// data moved, so the cost of a relink follows the size of the change rather than
+// the size of the package. When nothing differs at all there is nothing to swap
+// and the package is left exactly as it is.
+func (l *Linker) Link(packageName string, storePath string, files []*pack.FileInfo) (Result, error) {
 	debug.Logf("link: linking %s from %s (%d files)", packageName, storePath, len(files))
 
 	// Guard against path traversal: packageName is joined into .lnpm/<name>
 	// (which we replace) and node_modules/<name>.
 	if err := pack.ValidatePackageName(packageName); err != nil {
-		return "", err
+		return Result{}, err
 	}
 
 	// Determine link type based on config and filesystem
@@ -66,13 +87,37 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	// half-written package, and an interrupted link would leave that state
 	// behind permanently.
 	lnpmPath := filepath.Join(l.projectPath, ".lnpm", packageName)
+
+	// What the last link into this project left behind, and which of the files
+	// now being linked it already holds.
+	keepManifest := !shipsManifestName(files)
+	var prior map[string]linkedFile
+	if keepManifest {
+		prior = readManifest(lnpmPath)
+	}
+	reusable := reusableFiles(prior, files)
+
+	// Nothing to do at all: every file is already there, and the package it is
+	// already holding contains nothing else. Skipping the swap is the point -
+	// the directory the consumer is building against is not touched, so no file
+	// changes identity and none is rewritten. The node_modules link is still
+	// checked, since a caller may be relinking precisely because that went
+	// missing.
+	if len(reusable) == len(files) && len(prior) == len(files) && len(files) > 0 {
+		debug.Logf("link: %s is already up to date (%d files)", packageName, len(files))
+		if err := l.createNodeModulesSymlink(packageName); err != nil {
+			return Result{}, err
+		}
+		return Result{Type: linkType, Unchanged: len(files)}, nil
+	}
+
 	parentDir := filepath.Dir(lnpmPath)
 	if err := os.MkdirAll(parentDir, 0755); err != nil {
-		return "", fmt.Errorf("failed to create .lnpm directory: %w", err)
+		return Result{}, fmt.Errorf("failed to create .lnpm directory: %w", err)
 	}
 	tempPath, err := newTempDir(parentDir)
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp .lnpm directory: %w", err)
+		return Result{}, fmt.Errorf("failed to create temp .lnpm directory: %w", err)
 	}
 	// Remove the temp dir unless it is successfully committed via rename.
 	committed := false
@@ -83,7 +128,7 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	}()
 
 	// Track what methods we actually used (atomic for parallel access)
-	var reflinkCount, hardLinkCount, copyCount int32
+	var reflinkCount, hardLinkCount, copyCount, reusedCount int32
 	actualType := linkType
 	var warnedAboutFallback int32
 	var filesToCopyMu sync.Mutex
@@ -119,6 +164,28 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 					default:
 					}
 					return
+				}
+
+				// 0. Carry the file over from the package already linked here,
+				// when that copy is already the one wanted. A hard link moves
+				// no data and keeps the inode, so a consumer sees the file it
+				// had rather than an identical replacement.
+				//
+				// The link mode does not gate this. What is being linked is a
+				// file the project already has at that path, not a store entry,
+				// so copy mode's reason to exist - never sharing an inode with
+				// the store - is not in play. Preserving identity across a
+				// relink is the behaviour every mode wants.
+				if reusable[f.RelPath] {
+					if err := os.Link(filepath.Join(lnpmPath, f.RelPath), dstPath); err == nil {
+						atomic.AddInt32(&reusedCount, 1)
+						continue
+					} else {
+						// Reuse is only ever an optimisation - a filesystem
+						// that will not hard link, or a file that has since
+						// gone - so fall through and materialise it as usual.
+						debug.Logf("link: cannot reuse %s, materialising it: %v", f.RelPath, err)
+					}
 				}
 
 				linked := false
@@ -169,7 +236,7 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	// Check for errors
 	select {
 	case err := <-errChan:
-		return "", err
+		return Result{}, err
 	default:
 	}
 
@@ -228,13 +295,23 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 		// Check for copy errors
 		select {
 		case err := <-errChan2:
-			return "", err
+			return Result{}, err
 		default:
 		}
 	}
 
 	if reflinkCount > 0 || hardLinkCount > 0 {
 		debug.Logf("link: reflinked %d, hard linked %d, copied %d files", reflinkCount, hardLinkCount, copyCount)
+	}
+	if reusedCount > 0 {
+		debug.Logf("link: carried %d unchanged files over from the previous link", reusedCount)
+	}
+
+	// Record what is in the tree about to be swapped in. Written last inside the
+	// temp directory, so it commits with the content and can never describe a
+	// tree that is not there.
+	if keepManifest {
+		writeManifest(tempPath, files)
 	}
 
 	// Swap the completed package into place. The previous directory is renamed
@@ -245,7 +322,7 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	hadPrevious := false
 	if _, err := os.Lstat(lnpmPath); err == nil {
 		if err := os.Rename(lnpmPath, retiredPath); err != nil {
-			return "", fmt.Errorf("failed to move aside existing linked package: %w", err)
+			return Result{}, fmt.Errorf("failed to move aside existing linked package: %w", err)
 		}
 		hadPrevious = true
 	}
@@ -255,10 +332,10 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 			// retiredPath. Name it in the error so it can be recovered by hand;
 			// deleting it here would destroy the user's only copy.
 			if rollbackErr := os.Rename(retiredPath, lnpmPath); rollbackErr != nil {
-				return "", fmt.Errorf("failed to finalize linked package: %w (the previous package could not be restored: %v, and is preserved at %s)", err, rollbackErr, retiredPath)
+				return Result{}, fmt.Errorf("failed to finalize linked package: %w (the previous package could not be restored: %v, and is preserved at %s)", err, rollbackErr, retiredPath)
 			}
 		}
-		return "", fmt.Errorf("failed to finalize linked package: %w", err)
+		return Result{}, fmt.Errorf("failed to finalize linked package: %w", err)
 	}
 	committed = true
 	if hadPrevious {
@@ -267,10 +344,15 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 
 	// Create symlink in node_modules
 	if err := l.createNodeModulesSymlink(packageName); err != nil {
-		return "", err
+		return Result{}, err
 	}
 
-	return actualType, nil
+	// Counted from what the workers actually did, not from what the diff
+	// predicted: a reuse that failed and fell through to the store is a file
+	// this link wrote, and saying otherwise would report work that did happen as
+	// work avoided.
+	reused := int(reusedCount)
+	return Result{Type: actualType, Changed: len(files) - reused, Unchanged: reused}, nil
 }
 
 // LinkSource points a project at a package's live source directory instead of

--- a/internal/link/link_incremental_test.go
+++ b/internal/link/link_incremental_test.go
@@ -29,18 +29,50 @@ func writeHashedStoreFiles(t *testing.T, storePath string, contents map[string]s
 	return files
 }
 
-// statLinked returns os.Stat of each relPath inside a linked package, keyed by
-// the relative path, for comparison with os.SameFile across a relink.
+// fileIdentity returns a FileInfo describing the file at path as it is now, so
+// that os.SameFile still answers about that file after path has been replaced.
+//
+// os.Stat is not enough, because os.SameFile is not everywhere the eager
+// comparison it looks like. On unix a FileInfo carries the inode from the moment
+// it was taken. On Windows the fast path of os.stat calls GetFileAttributesEx,
+// which returns no file index, so os.fileStat keeps the path instead
+// (saveInfoFromPath) and os.SameFile resolves it to a volume and file index only
+// when it is called (loadFileId, which opens the path afresh). A FileInfo
+// captured before a relink would therefore describe whatever the relink left at
+// that path, and a before/after comparison would report the same file however
+// much had changed - which makes the "this file was rewritten" half of the
+// assertion unfalsifiable and the "this file was not" half true for the wrong
+// reason.
+//
+// Statting through an open file closes that gap on every platform: Windows takes
+// that FileInfo from GetFileInformationByHandle, which fills the volume and file
+// index in immediately and leaves nothing for os.SameFile to resolve later, and
+// unix does an fstat on the same descriptor. Either way the identity is the one
+// the file had when it was read.
+func fileIdentity(t *testing.T, path string) os.FileInfo {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open %s: %v", path, err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("failed to stat %s: %v", path, err)
+	}
+	return info
+}
+
+// statLinked returns the identity of each relPath inside a linked package, keyed
+// by the relative path, for comparison with os.SameFile across a relink.
 func statLinked(t *testing.T, lnpmPath string, relPaths ...string) map[string]os.FileInfo {
 	t.Helper()
 
 	stats := make(map[string]os.FileInfo, len(relPaths))
 	for _, rel := range relPaths {
-		info, err := os.Stat(filepath.Join(lnpmPath, filepath.FromSlash(rel)))
-		if err != nil {
-			t.Fatalf("failed to stat linked %s: %v", rel, err)
-		}
-		stats[rel] = info
+		stats[rel] = fileIdentity(t, filepath.Join(lnpmPath, filepath.FromSlash(rel)))
 	}
 	return stats
 }
@@ -133,10 +165,7 @@ func TestLink_UnchangedPackageIsNotRewritten(t *testing.T) {
 	}
 
 	lnpmPath := filepath.Join(projectPath, ".lnpm", "my-package")
-	dirBefore, err := os.Stat(lnpmPath)
-	if err != nil {
-		t.Fatalf("failed to stat linked package: %v", err)
-	}
+	dirBefore := fileIdentity(t, lnpmPath)
 	before := statLinked(t, lnpmPath, "package.json", "dist/index.js", "dist/utils.js")
 
 	res, err := linker.Link("my-package", storePath, files)
@@ -147,10 +176,7 @@ func TestLink_UnchangedPackageIsNotRewritten(t *testing.T) {
 		t.Errorf("Link() reported %d changed / %d unchanged, want 0 / 3", res.Changed, res.Unchanged)
 	}
 
-	dirAfter, err := os.Stat(lnpmPath)
-	if err != nil {
-		t.Fatalf("failed to stat linked package after relink: %v", err)
-	}
+	dirAfter := fileIdentity(t, lnpmPath)
 	if !os.SameFile(dirBefore, dirAfter) {
 		t.Error(".lnpm/my-package is a different directory after relinking an unchanged package, so it was rebuilt and swapped in")
 	}

--- a/internal/link/link_incremental_test.go
+++ b/internal/link/link_incremental_test.go
@@ -1,6 +1,7 @@
 package link
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -440,13 +441,16 @@ func TestLink_DoesNotReuseThroughALiveLink(t *testing.T) {
 	}
 
 	// The source directory holds the same paths with edits that were never
-	// published, under a manifest claiming they are the published ones.
+	// published, under a manifest claiming they are the published ones. The
+	// manifest is written as if for the linked package directory, so it passes
+	// every other check a relink makes and only the refusal to read through a
+	// live link can stop it.
 	sourcePath := filepath.Join(tmpDir, "source")
 	writeStoreFiles(t, sourcePath, map[string]string{
 		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
 		"dist/index.js": "module.exports = 'edited but never published';\n",
 	})
-	writeManifest(sourcePath, files)
+	writeManifest(sourcePath, filepath.Join(projectPath, ".lnpm", "my-package"), files)
 
 	if _, err := linker.LinkSource("my-package", sourcePath); err != nil {
 		t.Fatalf("LinkSource() error: %v", err)
@@ -580,5 +584,80 @@ func TestLink_PackageShippingTheManifestNameKeepsItsOwnFile(t *testing.T) {
 	}
 	if string(got) != "this file belongs to the package\n" {
 		t.Errorf("linked %s = %q, want the package's own content", manifestName, string(got))
+	}
+}
+
+// TestLink_DoesNotTrustAManifestThePackageShipped covers the transition out of
+// that collision, which is where the one-sided version of the check gave way.
+// The guard asked only whether the package being linked now ships the manifest's
+// name; it could not ask whether the file already at that path was the last
+// link's manifest or the last version's package content.
+//
+// So: a version that ships a file at that path, whose bytes are a manifest
+// naming the hashes the next version will have, followed by a version that drops
+// it. The relink would read the package's own file, find every path already
+// accounted for, and hand the consumer the previous version's bytes while
+// everything else reported the new one.
+//
+// The forged manifest here records the linked package's real location, which a
+// published file cannot do - one file cannot name every project it will be
+// linked into - so what the test pins is the check rather than the attacker's
+// ignorance of where the package lands.
+func TestLink_DoesNotTrustAManifestThePackageShipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	lnpmPath := filepath.Join(projectPath, ".lnpm", "my-package")
+
+	// v2 first, so v1 can ship a manifest naming its hashes.
+	v2 := filepath.Join(tmpDir, "store", "v2")
+	files2 := writeHashedStoreFiles(t, v2, map[string]string{
+		"package.json":  `{"name":"my-package","version":"2.0.0"}`,
+		"dist/index.js": "module.exports = 'v2';\n",
+	})
+
+	forged := linkManifest{SchemaVersion: manifestSchemaVersion, Files: map[string]linkedFile{}}
+	for _, f := range files2 {
+		forged.Files[f.RelPath] = linkedFile{Hash: f.ContentHash, Mode: f.Mode}
+	}
+	payload, err := json.Marshal(forged)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v1 := filepath.Join(tmpDir, "store", "v1")
+	files1 := writeHashedStoreFiles(t, v1, map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 'v1';\n",
+		manifestName:    string(payload),
+	})
+
+	linker := New(projectPath)
+	if _, err := linker.Link("my-package", v1, files1); err != nil {
+		t.Fatalf("first Link() error: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(lnpmPath, manifestName)); err != nil || string(got) != string(payload) {
+		t.Fatalf("the package's own %s did not reach the linked package, so the transition under test never happened (err = %v)", manifestName, err)
+	}
+
+	res, err := linker.Link("my-package", v2, files2)
+	if err != nil {
+		t.Fatalf("second Link() error: %v", err)
+	}
+	if res.Unchanged != 0 {
+		t.Errorf("Link() reported %d unchanged, want 0: nothing recorded by a file the package shipped may be reused", res.Unchanged)
+	}
+
+	got, err := os.ReadFile(filepath.Join(lnpmPath, "dist", "index.js"))
+	if err != nil {
+		t.Fatalf("failed to read relinked dist/index.js: %v", err)
+	}
+	if string(got) != "module.exports = 'v2';\n" {
+		t.Errorf("relinked dist/index.js = %q, want v2's content: the consumer kept the previous version's bytes", string(got))
+	}
+	if _, err := os.Stat(filepath.Join(lnpmPath, manifestName)); err != nil {
+		t.Errorf("the linked package carries no %s after the relink: %v", manifestName, err)
 	}
 }

--- a/internal/link/link_incremental_test.go
+++ b/internal/link/link_incremental_test.go
@@ -552,39 +552,78 @@ func TestLink_FailedIncrementalRelinkLeavesPreviousPackageIntact(t *testing.T) {
 	assertNoTempDirs(t, filepath.Join(projectPath, ".lnpm"))
 }
 
-// TestLink_PackageShippingTheManifestNameKeepsItsOwnFile covers the name
-// collision: a package that ships a file at the manifest's path keeps that file,
-// and relinks in full every time instead.
-func TestLink_PackageShippingTheManifestNameKeepsItsOwnFile(t *testing.T) {
+// TestLink_DoesNotLinkAPackageFileAtTheManifestsName covers the name collision.
+// The name belongs to the linker, so a package that ships a file at it does not
+// see that file in .lnpm/{package}: what sits there is the record of the link,
+// exactly as the store keeps its own completeness marker out of what it hands to
+// consumers.
+//
+// Reserving the name rather than yielding it is what makes the collision a
+// question that cannot be asked. One path cannot hold two files, and a linked
+// package whose .lnpm-linked is sometimes the linker's record and sometimes
+// content that merely looks like one leaves nothing on the way back in able to
+// tell which it is reading.
+//
+// The rest of the package links normally, and because the manifest is the
+// linker's on every link, the relink after it reuses like any other.
+func TestLink_DoesNotLinkAPackageFileAtTheManifestsName(t *testing.T) {
 	tmpDir := t.TempDir()
 	projectPath := filepath.Join(tmpDir, "project")
 	if err := os.MkdirAll(projectPath, 0755); err != nil {
 		t.Fatal(err)
 	}
+	lnpmPath := filepath.Join(projectPath, ".lnpm", "my-package")
 
 	storePath := filepath.Join(tmpDir, "store", "my-package")
 	files := writeHashedStoreFiles(t, storePath, map[string]string{
-		"package.json": `{"name":"my-package","version":"1.0.0"}`,
-		manifestName:   "this file belongs to the package\n",
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 1;\n",
+		manifestName:    "this file belongs to the package\n",
 	})
 
 	linker := New(projectPath)
-	for i := 0; i < 2; i++ {
-		res, err := linker.Link("my-package", storePath, files)
-		if err != nil {
-			t.Fatalf("Link() attempt %d error: %v", i+1, err)
-		}
-		if res.Unchanged != 0 {
-			t.Errorf("Link() attempt %d reported %d unchanged, want 0: the collision must disable reuse", i+1, res.Unchanged)
-		}
+	res, err := linker.Link("my-package", storePath, files)
+	if err != nil {
+		t.Fatalf("first Link() error: %v", err)
+	}
+	if res.Changed != 2 || res.Unchanged != 0 {
+		t.Errorf("Link() reported %d changed / %d unchanged, want 2 / 0: the reserved name is not one of the package's files", res.Changed, res.Unchanged)
 	}
 
-	got, err := os.ReadFile(filepath.Join(projectPath, ".lnpm", "my-package", manifestName))
+	// What is at the reserved path is the link's own manifest, not the bytes the
+	// package shipped there.
+	raw, err := os.ReadFile(filepath.Join(lnpmPath, manifestName))
 	if err != nil {
 		t.Fatalf("failed to read linked %s: %v", manifestName, err)
 	}
-	if string(got) != "this file belongs to the package\n" {
-		t.Errorf("linked %s = %q, want the package's own content", manifestName, string(got))
+	if string(raw) == "this file belongs to the package\n" {
+		t.Fatalf("linked %s holds the package's own content: the name was not reserved", manifestName)
+	}
+	m := readManifest(lnpmPath)
+	if m == nil {
+		t.Fatalf("linked %s does not read as a manifest: %s", manifestName, raw)
+	}
+	if len(m.Files) != 2 {
+		t.Errorf("the manifest describes %d files, want the 2 the package actually ships", len(m.Files))
+	}
+	if _, ok := m.Files[manifestName]; ok {
+		t.Errorf("the manifest describes %s as one of the package's files", manifestName)
+	}
+
+	// The package's other files are linked, and the file it shipped at the
+	// reserved name is simply absent, as the store's marker is.
+	if got, err := os.ReadFile(filepath.Join(lnpmPath, "dist", "index.js")); err != nil || string(got) != "module.exports = 1;\n" {
+		t.Errorf("dist/index.js = %q (err %v), want the store's content", string(got), err)
+	}
+
+	// Reuse is not lost to the collision the way it was when the package's file
+	// won the path.
+	again, err := linker.Link("my-package", storePath, files)
+	if err != nil {
+		t.Fatalf("second Link() error: %v", err)
+	}
+	if again.Unchanged != 2 {
+		t.Errorf("relink reported %d unchanged, want 2: reserving the name keeps the manifest readable across links", again.Unchanged)
 	}
 }
 
@@ -641,23 +680,20 @@ func TestLink_UnchangedPackageReportsTheTypeItWasBuiltWith(t *testing.T) {
 	}
 }
 
-// TestLink_DoesNotTrustAManifestThePackageShipped covers the transition out of
-// that collision, which is where the one-sided version of the check gave way.
-// The guard asked only whether the package being linked now ships the manifest's
-// name; it could not ask whether the file already at that path was the last
-// link's manifest or the last version's package content.
+// TestLink_APackageCannotDescribeItsOwnRelink covers the transition out of the
+// collision, which is where yielding the name gave way.
 //
-// So: a version that ships a file at that path, whose bytes are a manifest
-// naming the hashes the next version will have, followed by a version that drops
-// it. The relink would read the package's own file, find every path already
-// accounted for, and hand the consumer the previous version's bytes while
-// everything else reported the new one.
+// A version ships a file at the manifest's path whose bytes are a manifest
+// naming the hashes the next version will have, and the version after it drops
+// the file. If the package's file could occupy that path, the relink would read
+// it, find every path already accounted for, and hand the consumer the previous
+// version's bytes while everything else reported the new one.
 //
-// The forged manifest here records the linked package's real location, which a
-// published file cannot do - one file cannot name every project it will be
-// linked into - so what the test pins is the check rather than the attacker's
-// ignorance of where the package lands.
-func TestLink_DoesNotTrustAManifestThePackageShipped(t *testing.T) {
+// The forged manifest records the linked package's real location, so the test
+// pins the reservation rather than the fact that a published file cannot usually
+// guess where it will be linked. Reserving the name means the file never reaches
+// .lnpm/{package} at all and the question of trusting it never arises.
+func TestLink_APackageCannotDescribeItsOwnRelink(t *testing.T) {
 	tmpDir := t.TempDir()
 	projectPath := filepath.Join(tmpDir, "project")
 	if err := os.MkdirAll(projectPath, 0755); err != nil {
@@ -672,7 +708,12 @@ func TestLink_DoesNotTrustAManifestThePackageShipped(t *testing.T) {
 		"dist/index.js": "module.exports = 'v2';\n",
 	})
 
-	forged := linkManifest{SchemaVersion: manifestSchemaVersion, Files: map[string]linkedFile{}}
+	forged := linkManifest{
+		SchemaVersion: manifestSchemaVersion,
+		Path:          manifestPath(lnpmPath),
+		LinkType:      HardLink,
+		Files:         map[string]linkedFile{},
+	}
 	for _, f := range files2 {
 		forged.Files[f.RelPath] = linkedFile{Hash: f.ContentHash, Mode: f.Mode}
 	}
@@ -692,8 +733,8 @@ func TestLink_DoesNotTrustAManifestThePackageShipped(t *testing.T) {
 	if _, err := linker.Link("my-package", v1, files1); err != nil {
 		t.Fatalf("first Link() error: %v", err)
 	}
-	if got, err := os.ReadFile(filepath.Join(lnpmPath, manifestName)); err != nil || string(got) != string(payload) {
-		t.Fatalf("the package's own %s did not reach the linked package, so the transition under test never happened (err = %v)", manifestName, err)
+	if got, err := os.ReadFile(filepath.Join(lnpmPath, manifestName)); err != nil || string(got) == string(payload) {
+		t.Fatalf("the package's own %s occupies the reserved path (err = %v)", manifestName, err)
 	}
 
 	res, err := linker.Link("my-package", v2, files2)
@@ -701,7 +742,7 @@ func TestLink_DoesNotTrustAManifestThePackageShipped(t *testing.T) {
 		t.Fatalf("second Link() error: %v", err)
 	}
 	if res.Unchanged != 0 {
-		t.Errorf("Link() reported %d unchanged, want 0: nothing recorded by a file the package shipped may be reused", res.Unchanged)
+		t.Errorf("Link() reported %d unchanged, want 0: v1 and v2 share no file", res.Unchanged)
 	}
 
 	got, err := os.ReadFile(filepath.Join(lnpmPath, "dist", "index.js"))

--- a/internal/link/link_incremental_test.go
+++ b/internal/link/link_incremental_test.go
@@ -1,0 +1,440 @@
+package link
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/pack"
+)
+
+// writeHashedStoreFiles is writeStoreFiles with each file's content hash filled
+// in, which is what a relink compares against the last link to tell an unchanged
+// file from a changed one. pack.HashFile rather than a literal, so "same
+// content" and "same hash" cannot drift apart inside a test.
+func writeHashedStoreFiles(t *testing.T, storePath string, contents map[string]string) []*pack.FileInfo {
+	t.Helper()
+
+	files := writeStoreFiles(t, storePath, contents)
+	for _, f := range files {
+		hash, err := pack.HashFile(f.Path)
+		if err != nil {
+			t.Fatalf("failed to hash %s: %v", f.RelPath, err)
+		}
+		f.ContentHash = hash
+	}
+	return files
+}
+
+// statLinked returns os.Stat of each relPath inside a linked package, keyed by
+// the relative path, for comparison with os.SameFile across a relink.
+func statLinked(t *testing.T, lnpmPath string, relPaths ...string) map[string]os.FileInfo {
+	t.Helper()
+
+	stats := make(map[string]os.FileInfo, len(relPaths))
+	for _, rel := range relPaths {
+		info, err := os.Stat(filepath.Join(lnpmPath, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("failed to stat linked %s: %v", rel, err)
+		}
+		stats[rel] = info
+	}
+	return stats
+}
+
+// TestLink_ReusesUnchangedFilesFromThePreviousLink is acceptance criterion 2: a
+// relink that changes one file must touch only that file. An unchanged file is
+// carried over from the previous link rather than re-materialised, so it keeps
+// the identity the consumer already had.
+func TestLink_ReusesUnchangedFilesFromThePreviousLink(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	v1 := filepath.Join(tmpDir, "store", "v1")
+	files1 := writeHashedStoreFiles(t, v1, map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 1;\n",
+		"dist/utils.js": "module.exports = 2;\n",
+	})
+
+	linker := New(projectPath)
+	if _, err := linker.Link("my-package", v1, files1); err != nil {
+		t.Fatalf("first Link() error: %v", err)
+	}
+
+	lnpmPath := filepath.Join(projectPath, ".lnpm", "my-package")
+	before := statLinked(t, lnpmPath, "package.json", "dist/index.js", "dist/utils.js")
+
+	// Only dist/utils.js differs from v1.
+	v2 := filepath.Join(tmpDir, "store", "v2")
+	files2 := writeHashedStoreFiles(t, v2, map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 1;\n",
+		"dist/utils.js": "module.exports = 99;\n",
+	})
+
+	res, err := linker.Link("my-package", v2, files2)
+	if err != nil {
+		t.Fatalf("second Link() error: %v", err)
+	}
+	if res.Changed != 1 || res.Unchanged != 2 {
+		t.Errorf("Link() reported %d changed / %d unchanged, want 1 / 2", res.Changed, res.Unchanged)
+	}
+
+	after := statLinked(t, lnpmPath, "package.json", "dist/index.js", "dist/utils.js")
+	for _, rel := range []string{"package.json", "dist/index.js"} {
+		if !os.SameFile(before[rel], after[rel]) {
+			t.Errorf("unchanged %s is a different file after the relink, so it was rewritten", rel)
+		}
+	}
+	if os.SameFile(before["dist/utils.js"], after["dist/utils.js"]) {
+		t.Error("changed dist/utils.js kept its identity, so the new content was never written")
+	}
+
+	got, err := os.ReadFile(filepath.Join(lnpmPath, "dist", "utils.js"))
+	if err != nil {
+		t.Fatalf("failed to read relinked dist/utils.js: %v", err)
+	}
+	if string(got) != "module.exports = 99;\n" {
+		t.Errorf("relinked dist/utils.js = %q, want the v2 content", string(got))
+	}
+}
+
+// TestLink_UnchangedPackageIsNotRewritten is acceptance criterion 1: relinking
+// a package nothing has changed in must rewrite no file at all.
+//
+// The package directory's own identity is the assertion that carries it. A
+// relink that did any work would have built a replacement and renamed it into
+// place, and .lnpm/{package} would be a different directory afterwards however
+// identical its contents.
+func TestLink_UnchangedPackageIsNotRewritten(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	storePath := filepath.Join(tmpDir, "store", "my-package")
+	files := writeHashedStoreFiles(t, storePath, map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 1;\n",
+		"dist/utils.js": "module.exports = 2;\n",
+	})
+
+	linker := New(projectPath)
+	if _, err := linker.Link("my-package", storePath, files); err != nil {
+		t.Fatalf("first Link() error: %v", err)
+	}
+
+	lnpmPath := filepath.Join(projectPath, ".lnpm", "my-package")
+	dirBefore, err := os.Stat(lnpmPath)
+	if err != nil {
+		t.Fatalf("failed to stat linked package: %v", err)
+	}
+	before := statLinked(t, lnpmPath, "package.json", "dist/index.js", "dist/utils.js")
+
+	res, err := linker.Link("my-package", storePath, files)
+	if err != nil {
+		t.Fatalf("second Link() error: %v", err)
+	}
+	if res.Changed != 0 || res.Unchanged != 3 {
+		t.Errorf("Link() reported %d changed / %d unchanged, want 0 / 3", res.Changed, res.Unchanged)
+	}
+
+	dirAfter, err := os.Stat(lnpmPath)
+	if err != nil {
+		t.Fatalf("failed to stat linked package after relink: %v", err)
+	}
+	if !os.SameFile(dirBefore, dirAfter) {
+		t.Error(".lnpm/my-package is a different directory after relinking an unchanged package, so it was rebuilt and swapped in")
+	}
+
+	after := statLinked(t, lnpmPath, "package.json", "dist/index.js", "dist/utils.js")
+	for rel, was := range before {
+		if !os.SameFile(was, after[rel]) {
+			t.Errorf("%s is a different file after relinking an unchanged package, so it was rewritten", rel)
+		}
+	}
+}
+
+// TestLink_DropsFilesRemovedFromThePackage is acceptance criterion 3. It holds
+// because the relink builds a fresh directory and swaps it in, so a file the new
+// package does not list simply never enters it. The test pins that the reuse
+// path does not quietly turn the rebuild into an in-place update, which would
+// leave removed files behind.
+func TestLink_DropsFilesRemovedFromThePackage(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	v1 := filepath.Join(tmpDir, "store", "v1")
+	files1 := writeHashedStoreFiles(t, v1, map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 1;\n",
+		"dist/gone.js":  "module.exports = 'gone';\n",
+	})
+
+	linker := New(projectPath)
+	if _, err := linker.Link("my-package", v1, files1); err != nil {
+		t.Fatalf("first Link() error: %v", err)
+	}
+
+	// v2 is v1 without dist/gone.js. Every remaining file is unchanged, which is
+	// exactly the case a reuse-everything shortcut would get wrong.
+	v2 := filepath.Join(tmpDir, "store", "v2")
+	files2 := writeHashedStoreFiles(t, v2, map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 1;\n",
+	})
+
+	if _, err := linker.Link("my-package", v2, files2); err != nil {
+		t.Fatalf("second Link() error: %v", err)
+	}
+
+	lnpmPath := filepath.Join(projectPath, ".lnpm", "my-package")
+	if _, err := os.Stat(filepath.Join(lnpmPath, "dist", "gone.js")); !os.IsNotExist(err) {
+		t.Errorf("dist/gone.js survived a relink of a package that no longer lists it (stat err = %v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(lnpmPath, "dist", "index.js")); err != nil {
+		t.Errorf("dist/index.js did not survive the relink: %v", err)
+	}
+}
+
+// TestLink_RelinkOnAModeChangeAlone rewrites the file whose only change is its
+// mode. Reuse is a hard link, so a carried-over file keeps the mode of the one
+// already linked - a package whose bin script has just been made executable
+// would stay unexecutable if the mode were not part of the comparison.
+func TestLink_RelinkOnAModeChangeAlone(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - the executable bit is not modelled there")
+	}
+
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	contents := map[string]string{
+		"package.json": `{"name":"my-package","version":"1.0.0"}`,
+		"bin/cli.js":   "#!/usr/bin/env node\n",
+	}
+
+	v1 := filepath.Join(tmpDir, "store", "v1")
+	files1 := writeHashedStoreFiles(t, v1, contents)
+
+	linker := New(projectPath)
+	if _, err := linker.Link("my-package", v1, files1); err != nil {
+		t.Fatalf("first Link() error: %v", err)
+	}
+
+	// Same bytes, now executable.
+	v2 := filepath.Join(tmpDir, "store", "v2")
+	files2 := writeHashedStoreFiles(t, v2, contents)
+	for _, f := range files2 {
+		if f.RelPath != "bin/cli.js" {
+			continue
+		}
+		if err := os.Chmod(f.Path, 0755); err != nil {
+			t.Fatal(err)
+		}
+		f.Mode = 0755
+	}
+
+	res, err := linker.Link("my-package", v2, files2)
+	if err != nil {
+		t.Fatalf("second Link() error: %v", err)
+	}
+	if res.Changed != 1 {
+		t.Errorf("Link() reported %d changed, want 1: the mode change must not count as unchanged", res.Changed)
+	}
+
+	info, err := os.Stat(filepath.Join(projectPath, ".lnpm", "my-package", "bin", "cli.js"))
+	if err != nil {
+		t.Fatalf("failed to stat relinked bin/cli.js: %v", err)
+	}
+	if info.Mode().Perm()&0111 == 0 {
+		t.Errorf("relinked bin/cli.js has mode %v, want the executable bits the new package carries", info.Mode().Perm())
+	}
+}
+
+// TestLink_DoesNotReuseThroughALiveLink covers the one way reuse could reach
+// content nobody published. After LinkSource, .lnpm/{package} is a link at the
+// package's own source directory, so the paths a relink would reuse from resolve
+// into a tree the author is still editing. Hard linking out of it would both
+// serve unpublished content and hand the consumer an inode inside the author's
+// working copy, where an edit through node_modules writes straight back into the
+// source.
+//
+// The source tree here is given a manifest of its own so the refusal has to be
+// deliberate. Without one the relink would find nothing to trust and reuse
+// nothing by accident, which would prove only that the accident happens to hold.
+func TestLink_DoesNotReuseThroughALiveLink(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	published := map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 'published';\n",
+	}
+
+	storePath := filepath.Join(tmpDir, "store", "my-package")
+	files := writeHashedStoreFiles(t, storePath, published)
+
+	linker := New(projectPath)
+	if _, err := linker.Link("my-package", storePath, files); err != nil {
+		t.Fatalf("Link() error: %v", err)
+	}
+
+	// The source directory holds the same paths with edits that were never
+	// published, under a manifest claiming they are the published ones.
+	sourcePath := filepath.Join(tmpDir, "source")
+	writeStoreFiles(t, sourcePath, map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 'edited but never published';\n",
+	})
+	writeManifest(sourcePath, files)
+
+	if _, err := linker.LinkSource("my-package", sourcePath); err != nil {
+		t.Fatalf("LinkSource() error: %v", err)
+	}
+
+	res, err := linker.Link("my-package", storePath, files)
+	if err != nil {
+		t.Fatalf("Link() back from source error: %v", err)
+	}
+	if res.Unchanged != 0 {
+		t.Errorf("Link() reported %d unchanged after a live link, want 0: nothing in a source tree may be reused", res.Unchanged)
+	}
+
+	lnpmPath := filepath.Join(projectPath, ".lnpm", "my-package")
+	got, err := os.ReadFile(filepath.Join(lnpmPath, "dist", "index.js"))
+	if err != nil {
+		t.Fatalf("failed to read relinked dist/index.js: %v", err)
+	}
+	if string(got) != published["dist/index.js"] {
+		t.Errorf("relinked dist/index.js = %q, want the published content", string(got))
+	}
+
+	linked, err := os.Stat(filepath.Join(lnpmPath, "dist", "index.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.Stat(filepath.Join(sourcePath, "dist", "index.js"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(linked, source) {
+		t.Error("the relinked dist/index.js is the same file as the one in the source tree, so an edit through node_modules would rewrite the author's source")
+	}
+}
+
+// TestLink_FailedIncrementalRelinkLeavesPreviousPackageIntact is acceptance
+// criterion 4 for the incremental path. The guarantee itself predates this:
+// Link has staged into a temp directory and swapped it in since #137, so the
+// live package is never touched until the replacement is complete. What this
+// pins is that carrying unchanged files over does not turn the rebuild into an
+// in-place update, which would let a failed relink leave a package mixing the
+// old and new content of the same file.
+func TestLink_FailedIncrementalRelinkLeavesPreviousPackageIntact(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	original := map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 1;\n",
+		"dist/utils.js": "module.exports = 2;\n",
+	}
+
+	v1 := filepath.Join(tmpDir, "store", "v1")
+	files1 := writeHashedStoreFiles(t, v1, original)
+
+	linker := New(projectPath)
+	if _, err := linker.Link("my-package", v1, files1); err != nil {
+		t.Fatalf("first Link() error: %v", err)
+	}
+
+	// v2 changes dist/utils.js and leaves the rest reusable, but the store is
+	// missing a file the package declares, so the relink fails part way through.
+	v2 := filepath.Join(tmpDir, "store", "v2")
+	files2 := writeHashedStoreFiles(t, v2, map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 1;\n",
+		"dist/utils.js": "module.exports = 99;\n",
+	})
+	files2 = append(files2, &pack.FileInfo{
+		Path:        filepath.Join(v2, "dist", "missing.js"),
+		RelPath:     "dist/missing.js",
+		Size:        10,
+		Mode:        0644,
+		ContentHash: "0000000000000000",
+	})
+
+	if _, err := linker.Link("my-package", v2, files2); err == nil {
+		t.Fatal("second Link() succeeded, want error: the failure injection did not reach the error path")
+	}
+
+	lnpmPath := filepath.Join(projectPath, ".lnpm", "my-package")
+	for rel, want := range original {
+		got, err := os.ReadFile(filepath.Join(lnpmPath, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Errorf("previously linked %s missing after a failed incremental relink: %v", rel, err)
+			continue
+		}
+		if string(got) != want {
+			t.Errorf("previously linked %s = %q, want %q", rel, string(got), want)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(lnpmPath, "dist", "missing.js")); !os.IsNotExist(err) {
+		t.Errorf("failed relink leaked dist/missing.js into %s", lnpmPath)
+	}
+	assertNoTempDirs(t, filepath.Join(projectPath, ".lnpm"))
+}
+
+// TestLink_PackageShippingTheManifestNameKeepsItsOwnFile covers the name
+// collision: a package that ships a file at the manifest's path keeps that file,
+// and relinks in full every time instead.
+func TestLink_PackageShippingTheManifestNameKeepsItsOwnFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	storePath := filepath.Join(tmpDir, "store", "my-package")
+	files := writeHashedStoreFiles(t, storePath, map[string]string{
+		"package.json": `{"name":"my-package","version":"1.0.0"}`,
+		manifestName:   "this file belongs to the package\n",
+	})
+
+	linker := New(projectPath)
+	for i := 0; i < 2; i++ {
+		res, err := linker.Link("my-package", storePath, files)
+		if err != nil {
+			t.Fatalf("Link() attempt %d error: %v", i+1, err)
+		}
+		if res.Unchanged != 0 {
+			t.Errorf("Link() attempt %d reported %d unchanged, want 0: the collision must disable reuse", i+1, res.Unchanged)
+		}
+	}
+
+	got, err := os.ReadFile(filepath.Join(projectPath, ".lnpm", "my-package", manifestName))
+	if err != nil {
+		t.Fatalf("failed to read linked %s: %v", manifestName, err)
+	}
+	if string(got) != "this file belongs to the package\n" {
+		t.Errorf("linked %s = %q, want the package's own content", manifestName, string(got))
+	}
+}

--- a/internal/link/link_incremental_test.go
+++ b/internal/link/link_incremental_test.go
@@ -161,6 +161,49 @@ func TestLink_UnchangedPackageIsNotRewritten(t *testing.T) {
 	}
 }
 
+// TestLink_RestoresAFileDeletedFromUnderIt keeps relinking a repair. A user who
+// has lost part of .lnpm/{package} - a build script that cleaned too much, a
+// half-finished delete - reaches for the command that put it there, and before
+// there was anything to skip, relinking always rebuilt the package and so always
+// fixed it. Trusting the manifest without looking would end that: it says the
+// file was linked, which is true, and says nothing about it still being there.
+func TestLink_RestoresAFileDeletedFromUnderIt(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	storePath := filepath.Join(tmpDir, "store", "my-package")
+	files := writeHashedStoreFiles(t, storePath, map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 1;\n",
+		"dist/utils.js": "module.exports = 2;\n",
+	})
+
+	linker := New(projectPath)
+	if _, err := linker.Link("my-package", storePath, files); err != nil {
+		t.Fatalf("first Link() error: %v", err)
+	}
+
+	lnpmPath := filepath.Join(projectPath, ".lnpm", "my-package")
+	if err := os.Remove(filepath.Join(lnpmPath, "dist", "utils.js")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := linker.Link("my-package", storePath, files); err != nil {
+		t.Fatalf("second Link() error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(lnpmPath, "dist", "utils.js"))
+	if err != nil {
+		t.Fatalf("relinking did not restore the deleted dist/utils.js: %v", err)
+	}
+	if string(got) != "module.exports = 2;\n" {
+		t.Errorf("restored dist/utils.js = %q, want the store's content", string(got))
+	}
+}
+
 // TestLink_DropsFilesRemovedFromThePackage is acceptance criterion 3. It holds
 // because the relink builds a fresh directory and swaps it in, so a file the new
 // package does not list simply never enters it. The test pins that the reuse

--- a/internal/link/link_incremental_test.go
+++ b/internal/link/link_incremental_test.go
@@ -204,6 +204,107 @@ func TestLink_RestoresAFileDeletedFromUnderIt(t *testing.T) {
 	}
 }
 
+// TestLink_RemovesAStrayLeftInTheLinkedPackage keeps relinking a full repair on
+// the side the manifest cannot see. Every question the shortcut asks is about a
+// file the manifest names, so a file the manifest does not name - dropped in by
+// a build script, or orphaned by a link made before manifests existed - would
+// answer none of them and survive, where before this every relink swapped in a
+// tree built from the package alone and so removed it.
+func TestLink_RemovesAStrayLeftInTheLinkedPackage(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	storePath := filepath.Join(tmpDir, "store", "my-package")
+	files := writeHashedStoreFiles(t, storePath, map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 1;\n",
+	})
+
+	linker := New(projectPath)
+	if _, err := linker.Link("my-package", storePath, files); err != nil {
+		t.Fatalf("first Link() error: %v", err)
+	}
+
+	lnpmPath := filepath.Join(projectPath, ".lnpm", "my-package")
+	stray := filepath.Join(lnpmPath, "dist", "stray.js")
+	if err := os.WriteFile(stray, []byte("module.exports = 'stray';\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := linker.Link("my-package", storePath, files); err != nil {
+		t.Fatalf("second Link() error: %v", err)
+	}
+
+	if _, err := os.Stat(stray); !os.IsNotExist(err) {
+		t.Errorf("dist/stray.js survived a relink of a package that does not list it (stat err = %v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(lnpmPath, "dist", "index.js")); err != nil {
+		t.Errorf("dist/index.js did not survive the relink: %v", err)
+	}
+}
+
+// TestLink_RepairsALinkedFileReplacedByASymlink covers the other thing an lstat
+// per file cannot tell apart from a healthy link. os.Link does not follow
+// symlinks, so a linked file something has replaced with a symlink would be
+// carried over as that symlink and survive the swap, and the consumer would go
+// on resolving the package's file to whatever it points at.
+func TestLink_RepairsALinkedFileReplacedByASymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - creating a symlink needs a privilege the test process may not hold")
+	}
+
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	storePath := filepath.Join(tmpDir, "store", "my-package")
+	files := writeHashedStoreFiles(t, storePath, map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 1;\n",
+	})
+
+	linker := New(projectPath)
+	if _, err := linker.Link("my-package", storePath, files); err != nil {
+		t.Fatalf("first Link() error: %v", err)
+	}
+
+	elsewhere := filepath.Join(tmpDir, "elsewhere.js")
+	if err := os.WriteFile(elsewhere, []byte("module.exports = 'elsewhere';\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	linkedFile := filepath.Join(projectPath, ".lnpm", "my-package", "dist", "index.js")
+	if err := os.Remove(linkedFile); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(elsewhere, linkedFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := linker.Link("my-package", storePath, files); err != nil {
+		t.Fatalf("second Link() error: %v", err)
+	}
+
+	info, err := os.Lstat(linkedFile)
+	if err != nil {
+		t.Fatalf("failed to stat relinked dist/index.js: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Error("relinked dist/index.js is still a symlink, so the relink carried the replacement forward instead of repairing it")
+	}
+	got, err := os.ReadFile(linkedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "module.exports = 1;\n" {
+		t.Errorf("relinked dist/index.js = %q, want the store's content", string(got))
+	}
+}
+
 // TestLink_DropsFilesRemovedFromThePackage is acceptance criterion 3. It holds
 // because the relink builds a fresh directory and swaps it in, so a file the new
 // package does not list simply never enters it. The test pins that the reuse

--- a/internal/link/link_incremental_test.go
+++ b/internal/link/link_incremental_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/pedrosousa13/lnpm/internal/config"
 	"github.com/pedrosousa13/lnpm/internal/pack"
 )
 
@@ -450,7 +451,7 @@ func TestLink_DoesNotReuseThroughALiveLink(t *testing.T) {
 		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
 		"dist/index.js": "module.exports = 'edited but never published';\n",
 	})
-	writeManifest(sourcePath, filepath.Join(projectPath, ".lnpm", "my-package"), files)
+	writeManifest(sourcePath, filepath.Join(projectPath, ".lnpm", "my-package"), HardLink, files)
 
 	if _, err := linker.LinkSource("my-package", sourcePath); err != nil {
 		t.Fatalf("LinkSource() error: %v", err)
@@ -584,6 +585,59 @@ func TestLink_PackageShippingTheManifestNameKeepsItsOwnFile(t *testing.T) {
 	}
 	if string(got) != "this file belongs to the package\n" {
 		t.Errorf("linked %s = %q, want the package's own content", manifestName, string(got))
+	}
+}
+
+// TestLink_UnchangedPackageReportsTheTypeItWasBuiltWith pins what Result.Type
+// means on the path that materialises nothing.
+//
+// Every other exit reports what the workers achieved, upgrading to a hard link
+// where a reflink landed and downgrading to a copy where hard linking would not.
+// Reporting determineLinkType's prediction instead would make the type turn over
+// with the configuration rather than with the tree: a caller records it in the
+// database link row and prints it, so re-running `add` against an already
+// current package would rewrite the recorded type with nothing having changed.
+func TestLink_UnchangedPackageReportsTheTypeItWasBuiltWith(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	storePath := filepath.Join(tmpDir, "store", "my-package")
+	files := writeHashedStoreFiles(t, storePath, map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 1;\n",
+	})
+
+	linker := New(projectPath)
+	built, err := linker.Link("my-package", storePath, files)
+	if err != nil {
+		t.Fatalf("first Link() error: %v", err)
+	}
+	if built.Type != HardLink {
+		t.Fatalf("first Link() built the package with %q, want %q: the test needs a tree the configuration below disagrees with", built.Type, HardLink)
+	}
+
+	// Ask for copies from here on. Nothing about the linked package changes, so
+	// the relink still has nothing to do.
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("link_mode: copy\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LNPM_CONFIG", configPath)
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+
+	res, err := linker.Link("my-package", storePath, files)
+	if err != nil {
+		t.Fatalf("second Link() error: %v", err)
+	}
+	if res.Unchanged != len(files) {
+		t.Fatalf("second Link() reported %d unchanged of %d, want all of them: the test needs the path that materialises nothing", res.Unchanged, len(files))
+	}
+	if res.Type != built.Type {
+		t.Errorf("Link() reported type %q for a package it did not touch, want %q: the tree is still the one the first link built", res.Type, built.Type)
 	}
 }
 

--- a/internal/link/link_incremental_test.go
+++ b/internal/link/link_incremental_test.go
@@ -726,6 +726,15 @@ func TestLink_APackageCannotDescribeItsOwnRelink(t *testing.T) {
 		t.Fatal(err)
 	}
 	lnpmPath := filepath.Join(projectPath, ".lnpm", "my-package")
+	// .lnpm up front, so the forged manifest below names the location the same
+	// way a read of it will: manifestPath resolves the links along the parent,
+	// which it can only do once the parent is there. Without this the forgery
+	// would be refused for naming the wrong place - on macOS, where the temp
+	// directory reaches /private/var through a link - rather than for being a
+	// forgery, which is what this test is about.
+	if err := os.MkdirAll(filepath.Dir(lnpmPath), 0755); err != nil {
+		t.Fatal(err)
+	}
 
 	// v2 first, so v1 can ship a manifest naming its hashes.
 	v2 := filepath.Join(tmpDir, "store", "v2")
@@ -780,5 +789,62 @@ func TestLink_APackageCannotDescribeItsOwnRelink(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(lnpmPath, manifestName)); err != nil {
 		t.Errorf("the linked package carries no %s after the relink: %v", manifestName, err)
+	}
+}
+
+// TestLink_ReusesWhenTheProjectIsReachedByAnotherSpellingOfItsPath pins the
+// manifest's self-location check to the directory rather than to the string a
+// caller happened to name it by.
+//
+// The commands do not agree on that string. add, pull, remove and restore build
+// their linker from the working directory; push and publish build theirs from
+// the project path the database recorded, which is stored through
+// db.normalizePath and so has its symlinks resolved. Every spelling names the
+// same directory, and a relink that rejects the manifest because the previous
+// command spelled the path differently rewrites the whole package - which is
+// what add-then-push did on Windows, where the working directory keeps an 8.3
+// short name that the database's normalization expands.
+func TestLink_ReusesWhenTheProjectIsReachedByAnotherSpellingOfItsPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	realDir := filepath.Join(tmpDir, "real")
+	projectPath := filepath.Join(realDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A symlinked parent is this platform's version of the same thing: two
+	// paths, one directory, and only one of them what EvalSymlinks returns.
+	aliasDir := filepath.Join(tmpDir, "alias")
+	if err := os.Symlink(realDir, aliasDir); err != nil {
+		t.Skipf("cannot create a symlink to reach the project by a second path: %v", err)
+	}
+
+	storePath := filepath.Join(tmpDir, "store", "my-package")
+	files := writeHashedStoreFiles(t, storePath, map[string]string{
+		"package.json":  `{"name":"my-package","version":"1.0.0"}`,
+		"dist/index.js": "module.exports = 1;\n",
+		"dist/utils.js": "module.exports = 2;\n",
+	})
+
+	if _, err := New(projectPath).Link("my-package", storePath, files); err != nil {
+		t.Fatalf("first Link() error: %v", err)
+	}
+
+	lnpmPath := filepath.Join(projectPath, ".lnpm", "my-package")
+	before := statLinked(t, lnpmPath, "package.json", "dist/index.js", "dist/utils.js")
+
+	res, err := New(filepath.Join(aliasDir, "project")).Link("my-package", storePath, files)
+	if err != nil {
+		t.Fatalf("second Link() error: %v", err)
+	}
+	if res.Changed != 0 || res.Unchanged != 3 {
+		t.Errorf("Link() through a second spelling of the project path reported %d changed / %d unchanged, want 0 / 3: the manifest the first link wrote describes this directory", res.Changed, res.Unchanged)
+	}
+
+	after := statLinked(t, lnpmPath, "package.json", "dist/index.js", "dist/utils.js")
+	for rel, was := range before {
+		if !os.SameFile(was, after[rel]) {
+			t.Errorf("%s is a different file after relinking through a second spelling of the project path, so it was rewritten", rel)
+		}
 	}
 }

--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -45,14 +45,14 @@ func TestLinkAndUnlink(t *testing.T) {
 
 	// Create linker and link package
 	linker := New(projectPath)
-	linkType, err := linker.Link("my-package", storePath, files)
+	res, err := linker.Link("my-package", storePath, files)
 	if err != nil {
 		t.Fatalf("Link() error: %v", err)
 	}
 
 	// Verify link type (should be hardlink on same filesystem)
-	if linkType != HardLink && linkType != Copy {
-		t.Errorf("linkType = %q, want hardlink or copy", linkType)
+	if res.Type != HardLink && res.Type != Copy {
+		t.Errorf("linkType = %q, want hardlink or copy", res.Type)
 	}
 
 	// Verify .lnpm directory created

--- a/internal/link/manifest.go
+++ b/internal/link/manifest.go
@@ -40,9 +40,37 @@ type linkedFile struct {
 }
 
 // linkManifest is the manifest payload.
+//
+// Path is the manifest's own location, and is what tells a manifest lnpm wrote
+// from a file the package shipped at the same path. shipsManifestName only ever
+// answered half of that: it knows whether the package being linked now carries
+// the name, and cannot know whether the file already at that path is the last
+// link's manifest or the last version's content. A published file cannot name
+// the project it will be linked into - one file, every consumer - so a manifest
+// that names this one was written here, by a link.
+//
+// It is not a defence against an author who already knows where the package
+// lands, and it is not meant to be: the same author ships the code the project
+// then builds and runs. What it stops is a file that describes a link being
+// mistaken for one, wherever it came from - a package that ships one, a
+// .lnpm/{package} copied in from another checkout - and it costs one comparison
+// on read.
 type linkManifest struct {
 	SchemaVersion int                   `json:"schemaVersion"`
+	Path          string                `json:"path"`
 	Files         map[string]linkedFile `json:"files"`
+}
+
+// manifestPath is the location a manifest written for lnpmPath records as its
+// own. Absolute, so a caller that reaches the same project by a relative path
+// still reads its own manifest; the raw path when that cannot be resolved, which
+// at worst costs a full relink.
+func manifestPath(lnpmPath string) string {
+	abs, err := filepath.Abs(lnpmPath)
+	if err != nil {
+		return filepath.Clean(lnpmPath)
+	}
+	return abs
 }
 
 // readManifest returns what the last link recorded at lnpmPath, or nil when
@@ -73,19 +101,30 @@ func readManifest(lnpmPath string) map[string]linkedFile {
 		debug.Logf("link: ignoring manifest in %s written with schema %d", lnpmPath, m.SchemaVersion)
 		return nil
 	}
+	if want := manifestPath(lnpmPath); m.Path != want {
+		debug.Logf("link: ignoring manifest in %s, which records %q rather than %q as its own location", lnpmPath, m.Path, want)
+		return nil
+	}
 	return m.Files
 }
 
 // writeManifest records files in dir, which is the temp directory Link is about
-// to swap into place.
+// to swap into place, describing a link at lnpmPath, which is where that swap
+// will put it.
+//
+// The two paths differ because the manifest commits with the content it
+// describes: it is written inside the temp directory and renamed into place with
+// everything else. What it records is the destination, since that is where the
+// next relink will read it from and what it has to match.
 //
 // Failure is reported to the debug log and no further, per ADR-0001: the tree
 // being committed is complete and correct either way, and a manifest that could
 // not be written only costs the next relink the work this one saved. Failing the
 // link over it would undo something the caller did ask for.
-func writeManifest(dir string, files []*pack.FileInfo) {
+func writeManifest(dir, lnpmPath string, files []*pack.FileInfo) {
 	m := linkManifest{
 		SchemaVersion: manifestSchemaVersion,
+		Path:          manifestPath(lnpmPath),
 		Files:         make(map[string]linkedFile, len(files)),
 	}
 	for _, f := range files {

--- a/internal/link/manifest.go
+++ b/internal/link/manifest.go
@@ -55,9 +55,13 @@ type linkedFile struct {
 // mistaken for one, wherever it came from - a package that ships one, a
 // .lnpm/{package} copied in from another checkout - and it costs one comparison
 // on read.
+// LinkType is what the link that wrote the manifest achieved, not what it set
+// out to do, so a relink that materialises nothing can report the tree it left
+// alone rather than a fresh prediction that has nothing to do with it.
 type linkManifest struct {
 	SchemaVersion int                   `json:"schemaVersion"`
 	Path          string                `json:"path"`
+	LinkType      LinkType              `json:"linkType"`
 	Files         map[string]linkedFile `json:"files"`
 }
 
@@ -82,7 +86,7 @@ func manifestPath(lnpmPath string) string {
 // leaves a link to the package's live source there, and reusing "unchanged"
 // files through it would hard link whatever the author has since edited those
 // files to.
-func readManifest(lnpmPath string) map[string]linkedFile {
+func readManifest(lnpmPath string) *linkManifest {
 	if info, err := os.Lstat(lnpmPath); err != nil || !info.IsDir() {
 		return nil
 	}
@@ -105,7 +109,7 @@ func readManifest(lnpmPath string) map[string]linkedFile {
 		debug.Logf("link: ignoring manifest in %s, which records %q rather than %q as its own location", lnpmPath, m.Path, want)
 		return nil
 	}
-	return m.Files
+	return &m
 }
 
 // writeManifest records files in dir, which is the temp directory Link is about
@@ -121,10 +125,11 @@ func readManifest(lnpmPath string) map[string]linkedFile {
 // being committed is complete and correct either way, and a manifest that could
 // not be written only costs the next relink the work this one saved. Failing the
 // link over it would undo something the caller did ask for.
-func writeManifest(dir, lnpmPath string, files []*pack.FileInfo) {
+func writeManifest(dir, lnpmPath string, linkType LinkType, files []*pack.FileInfo) {
 	m := linkManifest{
 		SchemaVersion: manifestSchemaVersion,
 		Path:          manifestPath(lnpmPath),
+		LinkType:      linkType,
 		Files:         make(map[string]linkedFile, len(files)),
 	}
 	for _, f := range files {
@@ -156,14 +161,14 @@ func writeManifest(dir, lnpmPath string, files []*pack.FileInfo) {
 // files' hashes - a link driven straight off a walk of the store does not - and
 // treating "no hash recorded" as "matches the other file with no hash recorded"
 // would carry over stale content.
-func reusableFiles(prior map[string]linkedFile, present map[string]bool, files []*pack.FileInfo) map[string]bool {
+func reusableFiles(prior *linkManifest, present map[string]bool, files []*pack.FileInfo) map[string]bool {
 	if prior == nil {
 		return nil
 	}
 
 	reusable := make(map[string]bool, len(files))
 	for _, f := range files {
-		was, ok := prior[f.RelPath]
+		was, ok := prior.Files[f.RelPath]
 		if ok && present[f.RelPath] && f.ContentHash != "" && was.Hash == f.ContentHash && was.Mode == f.Mode {
 			reusable[f.RelPath] = true
 		}

--- a/internal/link/manifest.go
+++ b/internal/link/manifest.go
@@ -106,11 +106,18 @@ func writeManifest(dir string, files []*pack.FileInfo) {
 // already what the new link wants, so it can be carried over instead of
 // materialised again.
 //
-// An empty ContentHash is never reusable. Not every caller knows its files'
-// hashes - a link driven straight off a walk of the store does not - and
+// present is what scanLinked found on disk, and a path missing from it is never
+// reusable however well the manifest describes it. The manifest records what was
+// linked, not what survived: relinking has always been the way to repair a
+// .lnpm/{package} something else has damaged, and reuse is a hard link, which
+// would carry a file that is no longer a regular file straight into the
+// replacement.
+//
+// An empty ContentHash is never reusable either. Not every caller knows its
+// files' hashes - a link driven straight off a walk of the store does not - and
 // treating "no hash recorded" as "matches the other file with no hash recorded"
 // would carry over stale content.
-func reusableFiles(prior map[string]linkedFile, files []*pack.FileInfo) map[string]bool {
+func reusableFiles(prior map[string]linkedFile, present map[string]bool, files []*pack.FileInfo) map[string]bool {
 	if prior == nil {
 		return nil
 	}
@@ -118,27 +125,60 @@ func reusableFiles(prior map[string]linkedFile, files []*pack.FileInfo) map[stri
 	reusable := make(map[string]bool, len(files))
 	for _, f := range files {
 		was, ok := prior[f.RelPath]
-		if ok && f.ContentHash != "" && was.Hash == f.ContentHash && was.Mode == f.Mode {
+		if ok && present[f.RelPath] && f.ContentHash != "" && was.Hash == f.ContentHash && was.Mode == f.Mode {
 			reusable[f.RelPath] = true
 		}
 	}
 	return reusable
 }
 
-// allPresent reports whether every file is still where the last link put it.
+// scanLinked reports what a linked package directory actually holds: the regular
+// files under it, keyed by slash-separated relative path, and a count of
+// everything else it met.
 //
-// The manifest records what was linked, not what survived. Relinking has always
-// been the way to repair a .lnpm/{package} something else has damaged, so the
-// shortcut that skips a relink entirely has to look before it takes it. One
-// lstat per file is the cheapest question there is - no content is read - and it
-// is only asked once everything else already says there is nothing to do.
-func allPresent(lnpmPath string, files []*pack.FileInfo) bool {
-	for _, f := range files {
-		if _, err := os.Lstat(filepath.Join(lnpmPath, f.RelPath)); err != nil {
-			return false
+// That count is anything a link cannot have put there - an entry that is not a
+// regular file, a directory holding nothing, a directory that could not be read.
+// A link materialises regular files and creates only the directories those files
+// need, so any of those means the tree has been changed from outside, and the
+// shortcut that skips a relink entirely must not be taken over it.
+//
+// One walk answers both questions the shortcut needs - is every file still there,
+// and is anything there that should not be - where an lstat per file answers only
+// the first. Reading a directory returns its entries' types along with their
+// names, so neither answer costs a stat of its own.
+func scanLinked(lnpmPath string) (map[string]bool, int) {
+	found := make(map[string]bool)
+	unexpected := 0
+
+	var walk func(dir, rel string)
+	walk = func(dir, rel string) {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			unexpected++
+			return
+		}
+		if len(entries) == 0 && rel != "" {
+			unexpected++
+			return
+		}
+		for _, e := range entries {
+			childRel := e.Name()
+			if rel != "" {
+				childRel = rel + "/" + e.Name()
+			}
+			switch {
+			case e.IsDir():
+				walk(filepath.Join(dir, e.Name()), childRel)
+			case e.Type().IsRegular():
+				found[childRel] = true
+			default:
+				unexpected++
+			}
 		}
 	}
-	return true
+	walk(lnpmPath, "")
+
+	return found, unexpected
 }
 
 // shipsManifestName reports whether the package itself contains a file at the

--- a/internal/link/manifest.go
+++ b/internal/link/manifest.go
@@ -1,0 +1,141 @@
+package link
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/pedrosousa13/lnpm/internal/debug"
+	"github.com/pedrosousa13/lnpm/internal/pack"
+)
+
+// manifestName is the file a linked package carries recording what was linked
+// into it. A relink reads it to tell which files it can leave alone, which is
+// what stops a push costing the whole package every time.
+//
+// It lives inside .lnpm/{package} rather than beside it so that it commits with
+// the content: Link writes it into the temp directory and the swap renames both
+// into place at once, exactly as the store's own completeness marker is written
+// as the last file inside the entry it describes. A manifest kept outside the
+// directory could survive a swap that did not happen, or outlive one that did,
+// and would then claim a file holds content it does not - which is the one
+// failure mode an incremental relink must not have.
+const manifestName = ".lnpm-linked"
+
+// manifestSchemaVersion identifies the manifest payload's shape. A manifest
+// written by a different version is ignored rather than guessed at, which costs
+// one full relink and nothing else.
+const manifestSchemaVersion = 1
+
+// linkedFile is what the manifest records per file: enough to decide whether
+// the copy already sitting in .lnpm/{package} is the one the new link wants.
+//
+// Mode is part of that decision and not decoration. Reuse is a hard link, so the
+// carried-over file keeps the mode of the one already there; a package whose
+// only change is chmod +x on a bin script would otherwise be reported unchanged
+// and stay unexecutable.
+type linkedFile struct {
+	Hash string      `json:"hash"`
+	Mode os.FileMode `json:"mode"`
+}
+
+// linkManifest is the manifest payload.
+type linkManifest struct {
+	SchemaVersion int                   `json:"schemaVersion"`
+	Files         map[string]linkedFile `json:"files"`
+}
+
+// readManifest returns what the last link recorded at lnpmPath, or nil when
+// there is nothing trustworthy to read. Every failure returns nil: a missing,
+// unreadable, truncated or foreign-versioned manifest means the relink falls
+// back to materialising everything, which is what it did before this existed.
+//
+// A .lnpm/{package} that is not a real directory is refused outright. LinkSource
+// leaves a link to the package's live source there, and reusing "unchanged"
+// files through it would hard link whatever the author has since edited those
+// files to.
+func readManifest(lnpmPath string) map[string]linkedFile {
+	if info, err := os.Lstat(lnpmPath); err != nil || !info.IsDir() {
+		return nil
+	}
+
+	data, err := os.ReadFile(filepath.Join(lnpmPath, manifestName))
+	if err != nil {
+		return nil
+	}
+
+	var m linkManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		debug.Logf("link: ignoring unreadable manifest in %s: %v", lnpmPath, err)
+		return nil
+	}
+	if m.SchemaVersion != manifestSchemaVersion {
+		debug.Logf("link: ignoring manifest in %s written with schema %d", lnpmPath, m.SchemaVersion)
+		return nil
+	}
+	return m.Files
+}
+
+// writeManifest records files in dir, which is the temp directory Link is about
+// to swap into place.
+//
+// Failure is reported to the debug log and no further, per ADR-0001: the tree
+// being committed is complete and correct either way, and a manifest that could
+// not be written only costs the next relink the work this one saved. Failing the
+// link over it would undo something the caller did ask for.
+func writeManifest(dir string, files []*pack.FileInfo) {
+	m := linkManifest{
+		SchemaVersion: manifestSchemaVersion,
+		Files:         make(map[string]linkedFile, len(files)),
+	}
+	for _, f := range files {
+		m.Files[f.RelPath] = linkedFile{Hash: f.ContentHash, Mode: f.Mode}
+	}
+
+	payload, err := json.Marshal(m)
+	if err != nil {
+		debug.Logf("link: failed to encode manifest for %s: %v", dir, err)
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dir, manifestName), payload, 0644); err != nil {
+		debug.Logf("link: failed to write manifest for %s: %v", dir, err)
+	}
+}
+
+// reusableFiles returns the relative paths whose copy in the previous link is
+// already what the new link wants, so it can be carried over instead of
+// materialised again.
+//
+// An empty ContentHash is never reusable. Not every caller knows its files'
+// hashes - a link driven straight off a walk of the store does not - and
+// treating "no hash recorded" as "matches the other file with no hash recorded"
+// would carry over stale content.
+func reusableFiles(prior map[string]linkedFile, files []*pack.FileInfo) map[string]bool {
+	if prior == nil {
+		return nil
+	}
+
+	reusable := make(map[string]bool, len(files))
+	for _, f := range files {
+		was, ok := prior[f.RelPath]
+		if ok && f.ContentHash != "" && was.Hash == f.ContentHash && was.Mode == f.Mode {
+			reusable[f.RelPath] = true
+		}
+	}
+	return reusable
+}
+
+// shipsManifestName reports whether the package itself contains a file at the
+// path the manifest occupies. It does, very occasionally, happen that a name
+// collides; when it does the package's file wins and the relink simply goes
+// without a manifest, because there is no reading of one path holding two files
+// where both survive. The cost is a full relink every time, which is what every
+// relink cost before manifests existed.
+func shipsManifestName(files []*pack.FileInfo) bool {
+	for _, f := range files {
+		if f.RelPath == manifestName {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/link/manifest.go
+++ b/internal/link/manifest.go
@@ -125,6 +125,22 @@ func reusableFiles(prior map[string]linkedFile, files []*pack.FileInfo) map[stri
 	return reusable
 }
 
+// allPresent reports whether every file is still where the last link put it.
+//
+// The manifest records what was linked, not what survived. Relinking has always
+// been the way to repair a .lnpm/{package} something else has damaged, so the
+// shortcut that skips a relink entirely has to look before it takes it. One
+// lstat per file is the cheapest question there is - no content is read - and it
+// is only asked once everything else already says there is nothing to do.
+func allPresent(lnpmPath string, files []*pack.FileInfo) bool {
+	for _, f := range files {
+		if _, err := os.Lstat(filepath.Join(lnpmPath, f.RelPath)); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
 // shipsManifestName reports whether the package itself contains a file at the
 // path the manifest occupies. It does, very occasionally, happen that a name
 // collides; when it does the package's file wins and the relink simply goes

--- a/internal/link/manifest.go
+++ b/internal/link/manifest.go
@@ -41,20 +41,18 @@ type linkedFile struct {
 
 // linkManifest is the manifest payload.
 //
-// Path is the manifest's own location, and is what tells a manifest lnpm wrote
-// from a file the package shipped at the same path. shipsManifestName only ever
-// answered half of that: it knows whether the package being linked now carries
-// the name, and cannot know whether the file already at that path is the last
-// link's manifest or the last version's content. A published file cannot name
-// the project it will be linked into - one file, every consumer - so a manifest
-// that names this one was written here, by a link.
+// Path is the manifest's own location. A manifest describes one directory, and
+// what makes it safe to act on is that the directory it describes is the one it
+// is sitting in - so a .lnpm/{package} that arrived by some route other than a
+// link is not believed. Copying a project's .lnpm/ into another checkout is the
+// case that actually happens: the manifest comes along, still describing files
+// by hash, and without this the relink there would carry the copy's content
+// forward as though it had linked it. The check costs one comparison and the
+// mismatch costs one full relink, after which the manifest names its new home.
 //
-// It is not a defence against an author who already knows where the package
-// lands, and it is not meant to be: the same author ships the code the project
-// then builds and runs. What it stops is a file that describes a link being
-// mistaken for one, wherever it came from - a package that ships one, a
-// .lnpm/{package} copied in from another checkout - and it costs one comparison
-// on read.
+// It is not a security boundary, and does not need to be. A package cannot get a
+// file to this path at all - see withoutManifestName - so the only manifests
+// here are ones a link wrote.
 //
 // LinkType is what the link that wrote the manifest achieved, not what it set
 // out to do, so a relink that materialises nothing can report the tree it left
@@ -226,22 +224,36 @@ func scanLinked(lnpmPath string) (map[string]bool, int) {
 	return found, unexpected
 }
 
-// shipsManifestName reports whether the package itself contains a file at the
-// path the manifest occupies. It does, very occasionally, happen that a name
-// collides; when it does the package's file wins and the relink simply goes
-// without a manifest, because there is no reading of one path holding two files
-// where both survive. The cost is a full relink every time, which is what every
-// relink cost before manifests existed.
+// withoutManifestName returns files with any file at the manifest's own path
+// dropped, which is the set a link materialises.
 //
-// This is the write side of the collision only, and knows nothing about the file
-// already at that path. The read side is linkManifest.Path, which is what stops
-// a version that ships a manifest there from being believed by the version that
-// drops it.
-func shipsManifestName(files []*pack.FileInfo) bool {
-	for _, f := range files {
-		if f.RelPath == manifestName {
-			return true
+// The name is the linker's, exactly as .lnpm-complete is the store's: internal/
+// store's GetFiles keeps its marker out of what it hands to consumers on the
+// grounds that the marker belongs to the store and not to the package, and the
+// same holds a level down. What .lnpm/{package} holds is the package plus the
+// record of the link that put it there.
+//
+// Reserving the name is what makes the collision impossible rather than merely
+// detectable. One path cannot hold two files, and yielding it to the package
+// would mean .lnpm/{package}/.lnpm-linked is sometimes a record of the link and
+// sometimes content that looks like one, with nothing on the way back in able to
+// tell which - a version that shipped a manifest naming the next version's
+// hashes could then describe its own successor's relink.
+//
+// The cost is the one the store already pays for its marker: a package that
+// ships a file called .lnpm-linked at its root will not find it in
+// .lnpm/{package}. Nothing else about the package changes, and reuse is not lost
+// the way it was when the collision disabled the manifest.
+func withoutManifestName(files []*pack.FileInfo) []*pack.FileInfo {
+	for i, f := range files {
+		if f.RelPath != manifestName {
+			continue
 		}
+		debug.Logf("link: not linking the package's own %s, which is the link manifest's name", manifestName)
+		kept := make([]*pack.FileInfo, 0, len(files)-1)
+		kept = append(kept, files[:i]...)
+		kept = append(kept, files[i+1:]...)
+		return kept
 	}
-	return false
+	return files
 }

--- a/internal/link/manifest.go
+++ b/internal/link/manifest.go
@@ -65,15 +65,36 @@ type linkManifest struct {
 }
 
 // manifestPath is the location a manifest written for lnpmPath records as its
-// own. Absolute, so a caller that reaches the same project by a relative path
-// still reads its own manifest; the raw path when that cannot be resolved, which
+// own. It names the directory rather than the string a caller happened to reach
+// it by: absolute, so a relative path still reads its own manifest, and with the
+// links along the way resolved, so do two callers that spell the same directory
+// differently.
+//
+// They routinely do. add, pull, remove and restore build their linker from the
+// working directory; push and publish build theirs from the project path the
+// database recorded, which is stored through db.normalizePath and so already has
+// its symlinks resolved. On unix the working directory comes back from getcwd(3)
+// resolved too and the two agree by accident, but on Windows it keeps whatever
+// 8.3 short name it was given - C:\Users\RUNNER~1\... against the database's
+// C:\Users\runneradmin\... - and every add-then-push relink rejected its own
+// manifest and rewrote the whole package.
+//
+// The parent is what gets resolved, not lnpmPath itself. Link creates it before
+// writing the manifest and readManifest has just stat'd inside it, so it exists
+// at both ends where .lnpm/{package} need not; and .lnpm/{package} is itself a
+// link when the package was added with --link, which this must name rather than
+// follow into the package's source. The unresolved path when that fails, which
 // at worst costs a full relink.
 func manifestPath(lnpmPath string) string {
 	abs, err := filepath.Abs(lnpmPath)
 	if err != nil {
-		return filepath.Clean(lnpmPath)
+		abs = filepath.Clean(lnpmPath)
 	}
-	return abs
+	parent, err := filepath.EvalSymlinks(filepath.Dir(abs))
+	if err != nil {
+		return abs
+	}
+	return filepath.Join(parent, filepath.Base(abs))
 }
 
 // readManifest returns what the last link recorded at lnpmPath, or nil when

--- a/internal/link/manifest.go
+++ b/internal/link/manifest.go
@@ -55,6 +55,7 @@ type linkedFile struct {
 // mistaken for one, wherever it came from - a package that ships one, a
 // .lnpm/{package} copied in from another checkout - and it costs one comparison
 // on read.
+//
 // LinkType is what the link that wrote the manifest achieved, not what it set
 // out to do, so a relink that materialises nothing can report the tree it left
 // alone rather than a fresh prediction that has nothing to do with it.
@@ -231,6 +232,11 @@ func scanLinked(lnpmPath string) (map[string]bool, int) {
 // without a manifest, because there is no reading of one path holding two files
 // where both survive. The cost is a full relink every time, which is what every
 // relink cost before manifests existed.
+//
+// This is the write side of the collision only, and knows nothing about the file
+// already at that path. The read side is linkManifest.Path, which is what stops
+// a version that ships a manifest there from being believed by the version that
+// drops it.
 func shipsManifestName(files []*pack.FileInfo) bool {
 	for _, f := range files {
 		if f.RelPath == manifestName {

--- a/internal/store/store_isolation_test.go
+++ b/internal/store/store_isolation_test.go
@@ -12,7 +12,13 @@ import (
 // TestStore_DoesNotShareInodeWithSource verifies the store owns its own bytes:
 // a stored file must never be a hard link to the developer's source file.
 // os.SameFile is the portable identity check (inode on unix, volume + file
-// index on Windows), so this assertion holds on every platform.
+// index on Windows), so this assertion holds on every platform. It compares two
+// paths that both exist at the moment of the call, which is the shape os.SameFile
+// answers directly. Comparing a path against its own earlier self is the shape
+// that does not: on Windows os.Stat records no file index and os.SameFile
+// resolves the stored path when it is called, so a FileInfo taken before a
+// replacement describes the replacement. See fileIdentity in internal/link and
+// tests for what those comparisons have to do instead.
 func TestStore_DoesNotShareInodeWithSource(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("LNPM_STORE", tmpDir)

--- a/pkg/lockfile/lockfile_test.go
+++ b/pkg/lockfile/lockfile_test.go
@@ -303,6 +303,41 @@ func TestSaveRetreatWritesTheSnapshotBesideTheLockFile(t *testing.T) {
 	}
 }
 
+// fileIdentity returns a FileInfo describing the file at path as it is now, so
+// that os.SameFile still answers about that file after path has been replaced.
+//
+// os.Stat is not enough, because os.SameFile is not everywhere the eager
+// comparison it looks like. On unix a FileInfo carries the inode from the moment
+// it was taken. On Windows the fast path of os.stat calls GetFileAttributesEx,
+// which returns no file index, so os.fileStat keeps the path instead
+// (saveInfoFromPath) and os.SameFile resolves it to a volume and file index only
+// when it is called (loadFileId, which opens the path afresh). A FileInfo
+// captured before the snapshot was replaced would therefore describe the
+// replacement, and the comparison below would report the same file whether the
+// write was a rename or a truncation - which is the distinction it exists to
+// make.
+//
+// Statting through an open file closes that gap on every platform: Windows takes
+// that FileInfo from GetFileInformationByHandle, which fills the volume and file
+// index in immediately and leaves nothing for os.SameFile to resolve later, and
+// unix does an fstat on the same descriptor. Either way the identity is the one
+// the file had when it was read.
+func fileIdentity(t *testing.T, path string) os.FileInfo {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open(%s) error: %v", path, err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Stat(%s) error: %v", path, err)
+	}
+	return info
+}
+
 // TestSaveRetreatReplacesTheSnapshotRatherThanTruncatingIt pins the one property
 // that keeps a failed write from destroying an unconsumed snapshot: the file is
 // replaced, not opened and truncated.
@@ -324,19 +359,13 @@ func TestSaveRetreatReplacesTheSnapshotRatherThanTruncatingIt(t *testing.T) {
 	if err := lock.SaveRetreat(tmpDir); err != nil {
 		t.Fatalf("SaveRetreat() error: %v", err)
 	}
-	before, err := os.Stat(RetreatPath(tmpDir))
-	if err != nil {
-		t.Fatalf("Stat() error: %v", err)
-	}
+	before := fileIdentity(t, RetreatPath(tmpDir))
 
 	lock.Add("second-package", Package{Version: "1.0.0"})
 	if err := lock.SaveRetreat(tmpDir); err != nil {
 		t.Fatalf("SaveRetreat() error: %v", err)
 	}
-	after, err := os.Stat(RetreatPath(tmpDir))
-	if err != nil {
-		t.Fatalf("Stat() error: %v", err)
-	}
+	after := fileIdentity(t, RetreatPath(tmpDir))
 
 	if os.SameFile(before, after) {
 		t.Error("SaveRetreat() rewrote the snapshot in place; want a temp file renamed onto it, so a failed write cannot truncate the snapshot it is merging into")

--- a/tests/bench_test.go
+++ b/tests/bench_test.go
@@ -353,3 +353,73 @@ func BenchmarkLnpmPushMultipleProjects(b *testing.B) {
 		}
 	}
 }
+
+// benchPushSetup publishes a package of fileCount files, adds it to a fresh
+// project, and leaves the cwd inside the package directory ready to push.
+func benchPushSetup(b *testing.B, name string, fileCount int) string {
+	b.Helper()
+
+	storeDir := b.TempDir()
+	b.Setenv("LNPM_STORE", storeDir)
+	db.ResetForTesting()
+
+	pkgDir := createBenchPackage(b, name, fileCount)
+	if err := os.Chdir(pkgDir); err != nil {
+		b.Fatalf("Failed to chdir: %v", err)
+	}
+	if err := cli.RunPublish(false, false, true, true); err != nil {
+		b.Fatalf("Publish failed: %v", err)
+	}
+
+	projectDir := filepath.Join(b.TempDir(), "project")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		b.Fatalf("Failed to create project: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "package.json"),
+		[]byte(fmt.Sprintf(`{"name":"%s-project","version":"1.0.0"}`, name)), 0644); err != nil {
+		b.Fatalf("Failed to write package.json: %v", err)
+	}
+	if err := os.Chdir(projectDir); err != nil {
+		b.Fatalf("Failed to chdir: %v", err)
+	}
+	if err := cli.RunAdd(name, false, false, false); err != nil {
+		b.Fatalf("Add failed: %v", err)
+	}
+
+	if err := os.Chdir(pkgDir); err != nil {
+		b.Fatalf("Failed to chdir: %v", err)
+	}
+	return pkgDir
+}
+
+// BenchmarkLnpmPushLargeIncremental is the case the incremental relink exists
+// for: a package with many files where one of them changed. Only that file
+// should reach the linked project, so the relink's share of the push should
+// track the size of the edit rather than the size of the package.
+func BenchmarkLnpmPushLargeIncremental(b *testing.B) {
+	pkgDir := benchPushSetup(b, "bench-incremental", 2000)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		content := fmt.Sprintf("module.exports = { iteration: %d };", i)
+		if err := os.WriteFile(filepath.Join(pkgDir, "file-0.js"), []byte(content), 0644); err != nil {
+			b.Fatalf("Failed to modify file: %v", err)
+		}
+		if err := cli.RunPush(true); err != nil {
+			b.Fatalf("Push failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkLnpmPushLargeUnchanged pushes a large package nothing has changed
+// in, which is the case that should cost the linked project nothing at all.
+func BenchmarkLnpmPushLargeUnchanged(b *testing.B) {
+	benchPushSetup(b, "bench-unchanged", 2000)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := cli.RunPush(true); err != nil {
+			b.Fatalf("Push failed: %v", err)
+		}
+	}
+}

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -907,6 +907,41 @@ func (te *TestEnvironment) writeFile(path, content string) {
 	}
 }
 
+// fileIdentity returns a FileInfo describing the file at path as it is now, so
+// that os.SameFile still answers about that file after path has been replaced.
+//
+// os.Stat is not enough, because os.SameFile is not everywhere the eager
+// comparison it looks like. On unix a FileInfo carries the inode from the moment
+// it was taken. On Windows the fast path of os.stat calls GetFileAttributesEx,
+// which returns no file index, so os.fileStat keeps the path instead
+// (saveInfoFromPath) and os.SameFile resolves it to a volume and file index only
+// when it is called (loadFileId, which opens the path afresh). A FileInfo
+// captured before a push would therefore describe whatever the push left at that
+// path, and a before/after comparison would report the same file however much
+// had changed - which makes the "this file was rewritten" half of the assertion
+// unfalsifiable and the "this file was not" half true for the wrong reason.
+//
+// Statting through an open file closes that gap on every platform: Windows takes
+// that FileInfo from GetFileInformationByHandle, which fills the volume and file
+// index in immediately and leaves nothing for os.SameFile to resolve later, and
+// unix does an fstat on the same descriptor. Either way the identity is the one
+// the file had when it was read.
+func fileIdentity(t *testing.T, path string) os.FileInfo {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Failed to open %s: %v", path, err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Failed to stat %s: %v", path, err)
+	}
+	return info
+}
+
 // writePackageJSON writes a package.json into projectDir from the given map.
 func (te *TestEnvironment) writePackageJSON(projectDir string, content map[string]interface{}) {
 	te.t.Helper()

--- a/tests/publish_test.go
+++ b/tests/publish_test.go
@@ -384,3 +384,43 @@ func TestPublishExcludesTheRetreatSnapshot(t *testing.T) {
 	}
 	env.AssertFileExists(filepath.Join(pkg.StorePath, snapshotName), false)
 }
+
+// TestPublishWithPushReportsChangedAndUnchangedCounts covers acceptance
+// criterion 5 on `publish --push`'s relink loop, which is a separate one from
+// `push`'s and reports separately.
+func TestPublishWithPushReportsChangedAndUnchangedCounts(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("pub-counted-pkg", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'v1';",
+		"lib/a.js": "exports.a = 1;",
+	})
+	projectDir := env.newProject("pub-counted-project")
+	env.addPkg(projectDir, "pub-counted-pkg", false, false)
+
+	untouchedBefore, err := os.Stat(filepath.Join(projectDir, ".lnpm", "pub-counted-pkg", "lib", "a.js"))
+	if err != nil {
+		t.Fatalf("Failed to stat linked lib/a.js: %v", err)
+	}
+
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'v2';")
+	out := captureStdout(t, func() {
+		if err := cli.RunPublish(true, false, false, false); err != nil {
+			t.Fatalf("Failed to publish with push: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "(1 changed, 2 unchanged)") {
+		t.Errorf("Expected publish --push to report 1 changed of 3 files, got:\n%s", out)
+	}
+
+	untouchedAfter, err := os.Stat(filepath.Join(projectDir, ".lnpm", "pub-counted-pkg", "lib", "a.js"))
+	if err != nil {
+		t.Fatalf("Failed to stat linked lib/a.js after the push: %v", err)
+	}
+	if !os.SameFile(untouchedBefore, untouchedAfter) {
+		t.Error("lib/a.js is a different file after the push, so it was rewritten even though it did not change")
+	}
+	env.AssertLinkedFileContent(projectDir, "pub-counted-pkg", "index.js", "module.exports = 'v2';")
+}

--- a/tests/publish_test.go
+++ b/tests/publish_test.go
@@ -398,10 +398,7 @@ func TestPublishWithPushReportsChangedAndUnchangedCounts(t *testing.T) {
 	projectDir := env.newProject("pub-counted-project")
 	env.addPkg(projectDir, "pub-counted-pkg", false, false)
 
-	untouchedBefore, err := os.Stat(filepath.Join(projectDir, ".lnpm", "pub-counted-pkg", "lib", "a.js"))
-	if err != nil {
-		t.Fatalf("Failed to stat linked lib/a.js: %v", err)
-	}
+	untouchedBefore := fileIdentity(t, filepath.Join(projectDir, ".lnpm", "pub-counted-pkg", "lib", "a.js"))
 
 	env.chdir(pkgDir)
 	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'v2';")
@@ -415,10 +412,7 @@ func TestPublishWithPushReportsChangedAndUnchangedCounts(t *testing.T) {
 		t.Errorf("Expected publish --push to report 1 changed of 3 files, got:\n%s", out)
 	}
 
-	untouchedAfter, err := os.Stat(filepath.Join(projectDir, ".lnpm", "pub-counted-pkg", "lib", "a.js"))
-	if err != nil {
-		t.Fatalf("Failed to stat linked lib/a.js after the push: %v", err)
-	}
+	untouchedAfter := fileIdentity(t, filepath.Join(projectDir, ".lnpm", "pub-counted-pkg", "lib", "a.js"))
 	if !os.SameFile(untouchedBefore, untouchedAfter) {
 		t.Error("lib/a.js is a different file after the push, so it was rewritten even though it did not change")
 	}

--- a/tests/pull_test.go
+++ b/tests/pull_test.go
@@ -314,6 +314,36 @@ func TestPullReportsVersionChange(t *testing.T) {
 	}
 }
 
+// TestPullReportsChangedAndUnchangedCounts pins that a pull says how much of
+// the package it rewrote, as push and publish --push both do. pull runs the same
+// incremental relink, so a pull that reported nothing would be the one command
+// that left the user guessing whether the refresh cost the whole package.
+func TestPullReportsChangedAndUnchangedCounts(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("pull-counted-pkg", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'v1';",
+		"lib/a.js": "exports.a = 1;",
+		"lib/b.js": "exports.b = 2;",
+	})
+	projectDir := env.newProject("test-project")
+	env.addPkg(projectDir, "pull-counted-pkg", false, false)
+
+	// republish rewrites package.json and index.js and leaves lib/ alone.
+	env.republish(pkgDir, "pull-counted-pkg", "2.0.0", "module.exports = 'v2';")
+
+	env.chdir(projectDir)
+	out := captureStdout(t, func() {
+		if err := cli.RunPull([]string{"pull-counted-pkg"}); err != nil {
+			t.Errorf("RunPull: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "updated 1.0.0 -> 2.0.0 (2 changed, 2 unchanged)") {
+		t.Errorf("Expected the pull to report 2 changed of 4 files, got:\n%s", out)
+	}
+}
+
 // TestPullReportsPackageMissingFromStore covers a lock entry whose package is
 // gone from the store: it is reported and pull exits non-zero, while the
 // packages beside it are still refreshed.

--- a/tests/push_test.go
+++ b/tests/push_test.go
@@ -284,18 +284,14 @@ func TestPushReportsCoherentProjectCounts(t *testing.T) {
 	env.AssertLiveLink(liveProject, "count-lib", pkgDir)
 }
 
-// statLinkedFiles returns os.Stat of each relative path inside a linked
+// statLinkedFiles returns the identity of each relative path inside a linked
 // package, keyed by that path, for comparison with os.SameFile across a push.
 func statLinkedFiles(t *testing.T, projectDir, pkg string, rels ...string) map[string]os.FileInfo {
 	t.Helper()
 
 	stats := make(map[string]os.FileInfo, len(rels))
 	for _, rel := range rels {
-		info, err := os.Stat(filepath.Join(projectDir, ".lnpm", pkg, filepath.FromSlash(rel)))
-		if err != nil {
-			t.Fatalf("Failed to stat linked %s: %v", rel, err)
-		}
-		stats[rel] = info
+		stats[rel] = fileIdentity(t, filepath.Join(projectDir, ".lnpm", pkg, filepath.FromSlash(rel)))
 	}
 	return stats
 }

--- a/tests/push_test.go
+++ b/tests/push_test.go
@@ -283,3 +283,90 @@ func TestPushReportsCoherentProjectCounts(t *testing.T) {
 	env.AssertLinkedFileContent(copyProject, "count-lib", "index.js", "module.exports = 'v2';")
 	env.AssertLiveLink(liveProject, "count-lib", pkgDir)
 }
+
+// statLinkedFiles returns os.Stat of each relative path inside a linked
+// package, keyed by that path, for comparison with os.SameFile across a push.
+func statLinkedFiles(t *testing.T, projectDir, pkg string, rels ...string) map[string]os.FileInfo {
+	t.Helper()
+
+	stats := make(map[string]os.FileInfo, len(rels))
+	for _, rel := range rels {
+		info, err := os.Stat(filepath.Join(projectDir, ".lnpm", pkg, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("Failed to stat linked %s: %v", rel, err)
+		}
+		stats[rel] = info
+	}
+	return stats
+}
+
+// TestPushOnlyRewritesTheFilesThatChanged is acceptance criterion 2 end to end:
+// a push that changes one file leaves every other file in .lnpm/<pkg> exactly
+// as it was, identity included, rather than rebuilding the whole package.
+func TestPushOnlyRewritesTheFilesThatChanged(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("incremental-pkg", "1.0.0", map[string]string{
+		"index.js":  "module.exports = 'v1';",
+		"lib/a.js":  "exports.a = 1;",
+		"lib/b.js":  "exports.b = 2;",
+		"README.md": "# incremental-pkg\n",
+	})
+	projectDir := env.newProject("test-project")
+	env.addPkg(projectDir, "incremental-pkg", false, false)
+
+	untouched := []string{"package.json", "index.js", "lib/a.js", "README.md"}
+	before := statLinkedFiles(t, projectDir, "incremental-pkg", append(untouched, "lib/b.js")...)
+
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "lib", "b.js"), "exports.b = 99;")
+	if err := cli.RunPush(false); err != nil {
+		t.Fatalf("Failed to push: %v", err)
+	}
+
+	after := statLinkedFiles(t, projectDir, "incremental-pkg", append(untouched, "lib/b.js")...)
+	for _, rel := range untouched {
+		if !os.SameFile(before[rel], after[rel]) {
+			t.Errorf("%s is a different file after the push, so it was rewritten even though it did not change", rel)
+		}
+	}
+	if os.SameFile(before["lib/b.js"], after["lib/b.js"]) {
+		t.Error("lib/b.js kept its identity across the push, so the edit was never written")
+	}
+	env.AssertLinkedFileContent(projectDir, "incremental-pkg", filepath.Join("lib", "b.js"), "exports.b = 99;")
+}
+
+// TestPushReportsChangedAndUnchangedCounts is acceptance criterion 5: the push
+// summary says how much of the package it actually rewrote.
+func TestPushReportsChangedAndUnchangedCounts(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("counted-pkg", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'v1';",
+		"lib/a.js": "exports.a = 1;",
+		"lib/b.js": "exports.b = 2;",
+	})
+	projectDir := env.newProject("test-project")
+	env.addPkg(projectDir, "counted-pkg", false, false)
+
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "lib", "b.js"), "exports.b = 99;")
+	out := captureStdout(t, func() {
+		if err := cli.RunPush(false); err != nil {
+			t.Fatalf("RunPush: %v", err)
+		}
+	})
+	if !strings.Contains(out, "(1 changed, 3 unchanged)") {
+		t.Errorf("Expected the push to report 1 changed of 4 files, got:\n%s", out)
+	}
+
+	// A push with nothing to carry across says so rather than staying silent.
+	out = captureStdout(t, func() {
+		if err := cli.RunPush(false); err != nil {
+			t.Fatalf("RunPush: %v", err)
+		}
+	})
+	if !strings.Contains(out, "(0 changed, 4 unchanged)") {
+		t.Errorf("Expected an unchanged push to report 0 changed of 4 files, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
Closes #193.

Relinking a package rebuilt it in full every time: every file was materialised
into a temp directory and swapped into place, so a push cost O(total files) even
when one file had changed. This makes it cost O(changed files).

An unchanged file is now hard linked forward from the existing `.lnpm/<pkg>` —
one syscall, no data copy, and the inode is preserved. A relink where nothing
changed skips the swap entirely.

Measured on a 2000-file package: a no-op relink goes from ~214 ms to ~4.5 ms.

## Two corrections to the issue, both verified

The issue says `Link` does `os.RemoveAll` then recreates from scratch. **It has
not since #137 landed** — it already staged into a temp directory and renamed.
Two consequences:

- **Acceptance criterion 4 was already satisfied on `main`.** An interrupted push
  cannot mix old and new content, because the live directory is untouched until
  the swap. The test for it here is a regression pin, not new work, and says so.
- The atomic swap is preserved rather than traded away for in-place updates.

The issue also implies `store.GetFiles` returns files carrying `ContentHash`. It
does not — it sets only `Path`, `RelPath`, `Size` and `Mode`. Only `lnpm push`
supplied hashes, so without a fix `add`, `pull`, `publish --push` and `restore`
would have reported "N changed, 0 unchanged" forever. `storeFilesForLink`
attaches the recorded hashes, and an empty hash is never reusable, so a caller
that forgets degrades to a full relink rather than to wrong content.

## What decides "unchanged"

A manifest, `.lnpm-linked`, written **inside** `.lnpm/<pkg>`, recording each
file's hash and mode plus the achieved link type.

Keeping it inside the directory means it commits with the rename, so it can never
describe a tree that is not there. Storing it alongside `db.Link` has a crash
window that ends in silent wrong content: a link that commits its tree but dies
before the DB write leaves a record describing the *previous* tree, and a later
link can then hard link a file whose hash matches that stale record.

Mode is recorded because `pack.HashFiles` folds `Mode.Perm()` in, so a `chmod +x`
changes the package hash but no per-file `ContentHash` — comparing hashes alone
would carry an unexecutable bin script forward.

The name is **reserved**, mirroring how the store reserves `.lnpm-complete`
("the completeness marker belongs to the store, not to the package"). A package
shipping a root-level `.lnpm-linked` will not see it in `.lnpm/<pkg>`. That makes
a package-authored manifest structurally impossible rather than merely detectable
— detection was tried first and was not decisive.

## What relinking repairs, and what it does not

It repairs a deleted file, an entry that is no longer a regular file, and a
stray the manifest does not name. **It does not repair a modified file**, because
detecting modification means hashing every file, which is the cost this change
exists to remove. In hardlink mode an in-place edit already wrote through to the
store, so no relink ever repaired that. This is stated in `Link`'s doc comment
and in `ARCHITECTURE.md`.

## Also here

`InsertPackage` used to commit before `InsertFiles`, so a failed file-row write
left the package row naming the new store generation while the file rows
described the old one. That was harmless while those rows were informational;
this change makes them load-bearing for content decisions, so they now commit in
one transaction. `storeFilesForLink` additionally refuses to stamp hashes that do
not reproduce `pkg.ContentHash`, which degrades to a full relink rather than
carrying stale content forward on a database an older build already corrupted.

`ARCHITECTURE.md` is updated: its consumer-project tree omitted the manifest, and
its `lnpm push` description claimed an unconditional temp-dir-and-rename, which
the fast path makes false.

## Verification

`go test ./... -count=1`, `go vet`, `golangci-lint`, `gofmt -l`, plus build and
vet for windows/amd64, darwin/arm64 and linux/arm64 — all clean, and re-run under
a symlinked `TMPDIR`.

Every new test was revert-checked against the change it pins; three pass under a
full revert and each says in its own comment that it pins pre-existing behaviour.
No pre-existing test was weakened — the only one that changed is a mechanical
adaptation to `Link`'s new `Result` return, with its assertion intact.

**`-race` could not be run locally (no gcc), and this touches a parallel worker
pool.** The shared state is a read-only map built before the pool starts and an
atomic counter read after `wg.Wait()`, but CI is the actual evidence. Windows
behaviour likewise rests on CI; local gates cross-compile but never execute.
