### PR TITLE
feat(tag): add dist-tag support to publish, add, push and list

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -183,8 +183,19 @@ links              - Link data (key: ID, value: JSON)
 links_by_package   - Index (key: package_id, value: [link_ids])
 links_by_project   - Index (key: project_id, value: [link_ids])
 files              - File manifest (key: package_id, value: [FileEntry])
-meta               - Metadata (next_id counter)
+meta               - Metadata (next_id counter, schema_version)
+tags               - Dist-tags (key: name + NUL + tag, value: content hash)
 ```
+
+A package record is addressed by its name and content hash, so several versions
+of one name can be in the store at once. Which version a name resolves to is
+decided by the `tags` bucket: `packages_by_name` names the version tagged
+`latest`, and the two are written together so they cannot disagree.
+
+`meta.schema_version` records the shape above. A database written before tags
+existed carries none, and gains a `latest` tag per name when it is opened —
+`packages_by_name` was the only way to reach a package then, so the record it
+named was that package's latest by definition.
 
 ### Data Structures (JSON)
 
@@ -219,6 +230,7 @@ meta               - Metadata (next_id counter)
   "package_id": 1,
   "project_id": 1,
   "link_type": "hardlink",
+  "tag": "beta",  // channel followed; absent means latest
   "created_at": "2024-01-15T10:00:00Z",
   "updated_at": "2024-01-15T10:30:00Z"
 }
@@ -513,11 +525,16 @@ lnpm list my-package --projects
 
 Garbage collect unused packages from store.
 
+A version is collected when no valid link and no tag reaches it. `latest` does
+not count: every publish moves it onto what it just wrote, so treating it as a
+root would leave nothing collectable — see
+`docs/adr/0002-latest-is-not-a-garbage-collection-root.md`.
+
 ```bash
 # Dry run - show what would be removed
 lnpm gc --dry-run
 
-# Remove packages with no active links
+# Remove versions no link and no tag reaches
 lnpm gc
 
 # Remove packages older than 30 days

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -394,12 +394,20 @@ lnpm push --skip-hooks
 **Process:**
 1. Run prepare scripts (unless `--skip-hooks`)
 2. Calculate new content hash
-3. Work out which channel to push to, unless `--tag` said: the tags naming the
-   packed content answer it, since an unchanged working tree is the build they
-   name. One tag other than `latest` naming it wins; `latest` naming it, or no
-   tag naming it, means `latest`; several naming it is refused. Content the store
-   does not hold is named by nothing, so an edited pre-release still moves
-   `latest` unless `--tag` says otherwise
+3. Work out which channel to push to, unless `--tag` said. Two questions are
+   asked in order, and `latest` wins wherever it appears in either answer:
+   - which tags name the packed content — exact for an unchanged working tree,
+     since that is the build they name
+   - failing that, which tags name a stored record carrying the working tree's
+     version — a push loop edits files without touching `package.json`, so the
+     version still identifies the pre-release being worked on
+
+   One tag other than `latest` wins; several sharing a version is refused,
+   since each would move and carry its consumers. Several naming one content
+   hash is not refused: each already points at it, so every choice moves
+   nothing. A version bumped past everything in the store is answered by
+   neither question and goes to `latest`, with a warning naming the other
+   channels the package has
 4. Update store with new version, moving that tag onto it
 5. For each linked project:
    - Skip it if it is live-linked (`.lnpm/{package}` is a link, not a

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -250,7 +250,16 @@ lnpm publish
 
 # Publish and push to all linked projects
 lnpm publish --push
+
+# Publish to a channel other than latest, leaving latest where it is
+lnpm publish --tag beta
 ```
+
+`--tag` changes which tag is moved onto the version being written, and nothing
+else. The build is stored and recorded the same way; only `latest` stays put.
+The "already published with same content" shortcut is skipped unless the tag
+being published already names that content, because that shortcut is what would
+otherwise leave the tag unmoved.
 
 **Process:**
 1. Read `package.json` for name/version
@@ -290,8 +299,11 @@ Add a package from the store to current project.
 # Add latest published version
 lnpm add my-package
 
-# Add a specific version (must match the latest published version)
+# Add a specific version (must match the version latest names)
 lnpm add my-package@1.0.0
+
+# Add whatever the beta channel currently names
+lnpm add my-package@beta
 
 # Add without modifying package.json
 lnpm add my-package --pure
@@ -304,7 +316,10 @@ lnpm add my-package --link
 ```
 
 **Process:**
-1. Find package in store (latest or specified version)
+1. Find the version in the store. What follows the `@` is read as a dist-tag
+   first and as an exact version only when no tag by that name is set; a spec
+   with no `@` resolves through `latest`. The tag is recorded on the link row,
+   so a later move of `latest` does not carry this project onto it
 2. Create a temporary directory alongside `.lnpm/{package}/`
 3. Hard link all files from store into it, write the `.lnpm-linked` manifest,
    then rename it to `.lnpm/{package}/`
@@ -468,8 +483,11 @@ lnpm pull my-package other-pkg
 2. Skip any package that is live-linked (`.lnpm/{package}` is a link, not a
    directory): it resolves to its source, so there is nothing to refresh, and
    relinking it would silently swap the live link for a snapshot copy
-3. For each remaining package, look it up in the store; skip it when the lock
-   entry already matches the store's version and content hash
+3. For each remaining package, resolve the channel this project's link row
+   follows — `latest` for a link that names none — and skip the package when the
+   lock entry already matches that version and content hash. Resolving by name
+   instead would answer with `latest` for every project and quietly move a
+   tagged consumer onto the stable release
 4. Relink it from the store, exactly as `add` and `push` do — including the
    incremental path, so a `pull` that finds only a few files changed rewrites
    only those
@@ -478,8 +496,9 @@ lnpm pull my-package other-pkg
 
 `package.json` is never touched: the `file:.lnpm/{package}` reference it holds
 is already correct, and only the contents behind it change. Nothing is written
-to bbolt either — publishing updates the package row in place, so the link row
-`add` recorded still points at the right package.
+to bbolt either — a publish that moves a tag carries the links following that tag
+onto the version it now names, so the link row `add` recorded already points at
+the version `pull` just linked.
 
 ### `lnpm status`
 
@@ -520,6 +539,32 @@ lnpm list --store
 # List all projects using a package
 lnpm list my-package --projects
 ```
+
+`--store` marks each version with the tags naming it, as a trailing
+`[beta, latest]`. With more than one version of a name live at once that is the
+only place a user can see which build a channel points at; a version no tag names
+is left unmarked, and is what `lnpm gc` will collect once nothing links it.
+
+### `lnpm tag <package> <tag>`
+
+Manage a package's dist-tags without republishing it.
+
+```bash
+# Point beta at the version the package resolves to
+lnpm tag my-package beta
+
+# Remove the beta tag, leaving the version it named in the store
+lnpm tag my-package beta --delete
+```
+
+Setting names the version `packages_by_name` points at — the one tagged
+`latest` — because that is the version a publish just wrote and the only one a
+user can name without knowing content hashes. Moving a tag carries the projects
+following *that* tag onto the new version and leaves the others alone.
+
+`latest` cannot be deleted: `packages_by_name` mirrors it, so removing it would
+leave the package published, its files on disk, and every command that resolves
+by name unable to see it.
 
 ### `lnpm gc`
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -384,6 +384,9 @@ Push updates to all linked projects.
 # Push current package to all consumers
 lnpm push
 
+# Push to a channel other than the one the build already carries
+lnpm push --tag beta
+
 # Push, skipping prepare scripts
 lnpm push --skip-hooks
 ```
@@ -391,8 +394,14 @@ lnpm push --skip-hooks
 **Process:**
 1. Run prepare scripts (unless `--skip-hooks`)
 2. Calculate new content hash
-3. Update store with new version
-4. For each linked project:
+3. Work out which channel to push to, unless `--tag` said: the tags naming the
+   packed content answer it, since an unchanged working tree is the build they
+   name. One tag other than `latest` naming it wins; `latest` naming it, or no
+   tag naming it, means `latest`; several naming it is refused. Content the store
+   does not hold is named by nothing, so an edited pre-release still moves
+   `latest` unless `--tag` says otherwise
+4. Update store with new version, moving that tag onto it
+5. For each linked project:
    - Skip it if it is live-linked (`.lnpm/{package}` is a link, not a
      directory): it already resolves to the source directory being pushed, and
      relinking would swap its live link for a snapshot copy

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -320,6 +320,8 @@ lnpm add my-package --link
    first and as an exact version only when no tag by that name is set; a spec
    with no `@` resolves through `latest`. The tag is recorded on the link row,
    so a later move of `latest` does not carry this project onto it
+   (`--link` is refused with a tag: it resolves to the source directory, which
+   is not the build any tag names)
 2. Create a temporary directory alongside `.lnpm/{package}/`
 3. Hard link all files from store into it, write the `.lnpm-linked` manifest,
    then rename it to `.lnpm/{package}/`
@@ -495,10 +497,13 @@ lnpm pull my-package other-pkg
    specifier recorded by `add`
 
 `package.json` is never touched: the `file:.lnpm/{package}` reference it holds
-is already correct, and only the contents behind it change. Nothing is written
-to bbolt either — a publish that moves a tag carries the links following that tag
-onto the version it now names, so the link row `add` recorded already points at
-the version `pull` just linked.
+is already correct, and only the contents behind it change. The link row is
+usually left alone too — a publish that moves a tag carries the links following
+that tag onto the version it now names, so the row `add` wrote already points at
+the version `pull` just linked. It is repointed when it does not, which a publish
+leaves behind when the tag it moves was deleted and set again: there is then no
+previous version to carry links from. A project with no row for the package
+gains none; `pull` refreshes links rather than creating them.
 
 ### `lnpm status`
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -509,12 +509,13 @@ lnpm status
 
 # Output:
 # 📦 Published Packages
-# ┌──────────────┬─────────┬──────────┬─────────────────────┐
-# │ Package      │ Version │ Hash     │ Published           │
-# ├──────────────┼─────────┼──────────┼─────────────────────┤
-# │ my-package   │ 1.0.0   │ abc123   │ 2 minutes ago       │
-# │ other-pkg    │ 2.1.0   │ def456   │ 1 hour ago          │
-# └──────────────┴─────────┴──────────┴─────────────────────┘
+# ┌──────────────┬──────────────┬──────────┬──────────┬───────────────┐
+# │ Package      │ Version      │ Hash     │ Tags     │ Published     │
+# ├──────────────┼──────────────┼──────────┼──────────┼───────────────┤
+# │ my-package   │ 1.0.0        │ abc123   │ latest   │ 2 minutes ago │
+# │ my-package   │ 2.0.0-beta.1 │ abc789   │ beta     │ 1 minute ago  │
+# │ other-pkg    │ 2.1.0        │ def456   │ latest   │ 1 hour ago    │
+# └──────────────┴──────────────┴──────────┴──────────┴───────────────┘
 #
 # 🔗 Active Links
 # ┌──────────────┬─────────────────────────┬──────────┐
@@ -524,6 +525,10 @@ lnpm status
 # │ my-package   │ ~/code/other-app        │ hardlink │
 # └──────────────┴─────────────────────────┴──────────┘
 ```
+
+The published table lists one row per retained version, so it carries the tags
+naming each of them. Without that column two rows of one name say nothing about
+which build a plain `lnpm add` would give you.
 
 ### `lnpm list`
 
@@ -544,6 +549,11 @@ lnpm list my-package --projects
 `[beta, latest]`. With more than one version of a name live at once that is the
 only place a user can see which build a channel points at; a version no tag names
 is left unmarked, and is what `lnpm gc` will collect once nothing links it.
+
+`--projects` walks every version of the name rather than resolving the name to
+one record, and says which build each consumer is on. Resolving by name would
+answer with the version `latest` points at, leaving every project that asked for
+a channel out of the one listing whose job is naming who consumes this package.
 
 ### `lnpm tag <package> <tag>`
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ lnpm push
 | `lnpm push` | Push changes to all linked projects |
 | `lnpm status` | Show all published packages and active links across every project |
 | `lnpm list` | List this project's linked packages (`--store` lists the store, `--projects` lists consumers) |
+| `lnpm tag <pkg> <tag>` | Point a dist-tag at a published package (`--delete` removes one) |
 | `lnpm check` | Fail if lnpm has left anything an `npm publish` would ship (pre-publish guard) |
 | `lnpm doctor` | Diagnose issues |
 | `lnpm gc` | Garbage collect unused packages (`--dry-run`, `--older-than 30d`, `--fix-links`, `--yes`) |
@@ -127,6 +128,42 @@ and are not even committed. Prefer the default when you want a reproducible
 snapshot; use `--link` while you iterate. `lnpm pull` and `lnpm push` skip
 live-linked packages rather than replacing them with a snapshot, and
 `lnpm remove` / `lnpm retreat` delete only the link, never the source.
+
+### Dist-tags
+
+A publish moves the `latest` tag, and `lnpm add my-package` resolves through it.
+`--tag` publishes to another channel instead, leaving `latest` where it is, so an
+experimental build can sit in the store without reaching the projects that are on
+the stable release:
+
+```bash
+# In the package directory
+lnpm publish --tag beta
+
+# In a project that wants the experimental build
+lnpm add my-package@beta
+
+# Everyone else is unaffected
+lnpm add my-package        # still the latest release
+```
+
+What follows the `@` is read as a tag first and as an exact version only if no
+tag by that name is set. A project that added a package under a tag keeps
+following it: `lnpm pull` refreshes it to whatever that tag now names, never to
+`latest`.
+
+Tags can also be moved on a package already in the store, with no republish:
+
+```bash
+lnpm tag my-package beta            # Point beta at the published version
+lnpm tag my-package beta --delete   # Remove the beta tag
+lnpm list --store                   # Shows which tags name each stored version
+```
+
+`latest` cannot be deleted — it is what every lookup by name resolves through.
+It is also not a garbage-collection root: only a tag you set keeps a version
+alive, because `latest` moves onto everything a publish writes and treating it
+as a root would leave `lnpm gc` unable to reclaim anything.
 
 ### Monorepo Support
 

--- a/README.md
+++ b/README.md
@@ -155,10 +155,13 @@ my-package@beta` in a project already on `latest` moves it over, and dropping th
 tag moves it back. A tag cannot be combined with `--link`, which resolves to the
 source directory rather than to any published build.
 
-`lnpm push` goes to the channel the build already in the store carries, so
-pushing an unchanged pre-release keeps it a pre-release. Content the store does
-not hold yet is in no channel and goes to `latest`; pass `--tag` to say
-otherwise.
+`lnpm push` goes to the channel the build in the store already carries, so
+pushing a pre-release keeps it a pre-release. An edit gives the tree content no
+channel has ever named, and the version in `package.json` answers instead — a
+push loop does not bump it, so the tags naming the stored build with that
+version say which channel the tree is on. Bump past everything in the store and
+push has nothing left to go on: it goes to `latest` and says so. Pass `--tag` to
+say otherwise.
 
 Tags can also be moved on a package already in the store, with no republish:
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ lnpm push
 | `lnpm add <pkg...>` | Add package(s) from store to project |
 | `lnpm remove <pkg>` | Remove linked package |
 | `lnpm pull [pkg...]` | Sync linked packages with the store (all of them when no name is given) |
-| `lnpm push` | Push changes to all linked projects |
+| `lnpm push` | Push changes to all linked projects (`--tag` picks the channel) |
 | `lnpm status` | Show all published packages and active links across every project |
 | `lnpm list` | List this project's linked packages (`--store` lists the store, `--projects` lists consumers) |
 | `lnpm tag <pkg> <tag>` | Point a dist-tag at a published package (`--delete` removes one) |
@@ -150,7 +150,15 @@ lnpm add my-package        # still the latest release
 What follows the `@` is read as a tag first and as an exact version only if no
 tag by that name is set. A project that added a package under a tag keeps
 following it: `lnpm pull` refreshes it to whatever that tag now names, never to
-`latest`.
+`latest`. Switching channels is just another `lnpm add` — `lnpm add
+my-package@beta` in a project already on `latest` moves it over, and dropping the
+tag moves it back. A tag cannot be combined with `--link`, which resolves to the
+source directory rather than to any published build.
+
+`lnpm push` goes to the channel the build already in the store carries, so
+pushing an unchanged pre-release keeps it a pre-release. Content the store does
+not hold yet is in no channel and goes to `latest`; pass `--tag` to say
+otherwise.
 
 Tags can also be moved on a package already in the store, with no republish:
 

--- a/docs/adr/0002-latest-is-not-a-garbage-collection-root.md
+++ b/docs/adr/0002-latest-is-not-a-garbage-collection-root.md
@@ -1,0 +1,55 @@
+# `latest` is not a garbage collection root
+
+`lnpm gc` collects a stored version when no valid link and no tag reaches it.
+The `latest` tag is excluded from the tags that count.
+
+Every publish moves `latest` onto the version it just wrote, so `latest` always
+names something and names it without anyone deciding to. Counting it as a root
+would mean no current version of any package could ever be collected — and a
+store where nothing has been published twice holds only current versions, so
+`lnpm gc` would run, report nothing and free nothing. The command a user reaches
+for to reclaim disk would silently stop reclaiming any.
+
+A tag someone set is a decision to keep a build; `latest` is a side effect of
+the last publish. What `latest` names is still kept for as long as a project
+links it, which is the rule gc has always applied.
+
+## Consequences
+
+`lnpm publish` followed by `lnpm gc` with nothing linked still removes the
+package, exactly as before tags existed. `lnpm publish --tag beta` followed by
+the same `gc` keeps the build: nothing links it, but a tag names it. Removing it
+then takes two steps — drop the tag, then collect.
+
+A version can therefore outlive the package's name: if `latest` names an
+unlinked version and some other tag names an older one, gc takes the first,
+which clears `packages_by_name`. The package is still in the store under its
+other tag, and a tag-aware `add` still resolves it, but a lookup by name alone
+no longer finds it. That is the same state a store reaches by deleting the
+`latest` tag, which `db.DeleteTag` refuses for the same reason it is worth
+naming here.
+
+Superseded versions — the ones no tag names any more, because publishing moved
+the tag on — are collected. Before this they were unreachable from the database
+entirely, since the one record per name was overwritten, so their directories
+accumulated in the store with nothing able to name or remove them.
+
+## Considered options
+
+**Every tag is a root, `latest` included.** This is the rule as first stated. It
+was rejected on the evidence above: four existing gc tests assert that a
+published-but-never-linked package is collected, and they assert it because that
+is what the command is for.
+
+**Collect the whole name when no version of it is linked, and apply the tag rule
+only within a name that is still linked somewhere.** This keeps every existing
+test passing too, and it needs no exception for `latest`. It was rejected
+because it deletes a beta nobody has linked yet, which is the state a beta is in
+between being published and being tried — the case tags were added for. The rule
+also has to be stated in two clauses, and the second one silently overrides a
+tag the user set.
+
+**Never collect a tagged version, and let `lnpm tag --delete` be the only way to
+release one.** This is the conservative extreme and it is what the chosen rule
+does for every tag but `latest`. Extending it to `latest` is the first option
+again.

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -32,6 +32,10 @@ type addResult struct {
 	pkg         *db.Package
 	linkType    link.LinkType
 	origVersion string
+	// tag is the channel the spec asked for, empty for the default one. It is
+	// recorded on the link so that moving latest later does not drag a
+	// consumer that asked for another channel onto it.
+	tag string
 	// rolledBack records that this package's package.json handling failed and
 	// the package was undone, so every later step - the lock entry, the
 	// package.json write, the database link, the success line - skips it.
@@ -93,12 +97,11 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 
 			name, version := parsePackageSpec(pkgSpec)
 
-			// The store keeps the latest published version per package
-			// (latest-wins), so resolve by name and then check the requested
-			// version against what's stored, same as the single-package path.
-			pkg, lookupErr := database.GetPackageByName(name)
+			// Resolved exactly as the single-package path resolves it: a tag
+			// first, then the version latest names.
+			pkg, tag, lookupErr := resolveAddSpec(database, name, version)
 			if lookupErr != nil {
-				result.err = fmt.Errorf("failed to look up package: %w", lookupErr)
+				result.err = lookupErr
 				results <- result
 				return
 			}
@@ -107,13 +110,9 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 				results <- result
 				return
 			}
-			if version != "" && pkg.Version != version {
-				result.err = versionNotInStoreError(version, name, pkg.Version)
-				results <- result
-				return
-			}
 
 			result.pkg = pkg
+			result.tag = tag
 
 			linkRes, err := linkPackage(database, linker, s, pkg, useLink)
 			if err != nil {
@@ -272,6 +271,7 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 			PackageID: r.pkg.ID,
 			ProjectID: existingProj.ID,
 			LinkType:  string(r.linkType),
+			Tag:       r.tag,
 		}
 		if err := database.InsertLink(dbLink); err != nil {
 			fmt.Printf("  %s Failed to record link for %s: %v\n", iconWarn(), r.pkg.Name, err)
@@ -279,7 +279,7 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 
 		// Reported exactly as the single-package path reports it, so a live link
 		// is spelled out rather than shown as the bare type name "link".
-		fmt.Printf("%s Added %s@%s\n", iconOK(), r.pkg.Name, r.pkg.Version)
+		fmt.Printf("%s Added %s@%s%s\n", iconOK(), r.pkg.Name, r.pkg.Version, tagSuffix(r.tag))
 		fmt.Printf("  Link type: %s\n", linkTypeLabel(r.linkType))
 	}
 
@@ -485,23 +485,20 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useL
 		return fmt.Errorf("failed to open database: %w", err)
 	}
 
-	// Find package in store. The store keeps the latest published version per
-	// package (latest-wins), so a requested version must match what's stored.
-	pkg, err := database.GetPackageByName(name)
+	// Find the version in the store: a tag if the spec names one, otherwise the
+	// version latest points at, which a requested version must match.
+	pkg, tag, err := resolveAddSpec(database, name, version)
 	if err != nil {
-		return fmt.Errorf("failed to look up package: %w", err)
+		return err
 	}
 	if pkg == nil {
 		return fmt.Errorf("package %s not found in store. Did you run 'lnpm publish' in the package directory?", name)
 	}
-	if version != "" && pkg.Version != version {
-		return versionNotInStoreError(version, name, pkg.Version)
-	}
 
 	if useLink {
-		fmt.Printf("Adding %s@%s (linked to source)...\n", pkg.Name, pkg.Version)
+		fmt.Printf("Adding %s@%s (linked to source%s)...\n", pkg.Name, pkg.Version, tagClause(tag))
 	} else {
-		fmt.Printf("Adding %s@%s...\n", pkg.Name, pkg.Version)
+		fmt.Printf("Adding %s@%s%s...\n", pkg.Name, pkg.Version, tagSuffix(tag))
 	}
 
 	// Get store
@@ -602,12 +599,13 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useL
 		PackageID: pkg.ID,
 		ProjectID: existingProj.ID,
 		LinkType:  string(linkType),
+		Tag:       tag,
 	}
 	if err := database.InsertLink(dbLink); err != nil {
 		return fmt.Errorf("failed to record link: %w", err)
 	}
 
-	fmt.Printf("%s Added %s@%s\n", iconOK(), pkg.Name, pkg.Version)
+	fmt.Printf("%s Added %s@%s%s\n", iconOK(), pkg.Name, pkg.Version, tagSuffix(tag))
 	fmt.Printf("  Link type: %s\n", linkTypeLabel(linkType))
 	fmt.Printf("  Package manager: %s\n", pm)
 	if !pure {
@@ -644,6 +642,41 @@ func parsePackageSpec(spec string) (name, version string) {
 		return spec[:idx], spec[idx+1:]
 	}
 	return spec, ""
+}
+
+// resolveAddSpec works out which version of name an add should link, and which
+// channel the resulting link follows.
+//
+// requested is whatever followed the @ in the spec, and a tag is tried before a
+// version: `pkg@beta` has to mean the build beta names, and only a spec that
+// matches no tag falls through to the exact-version check that has always been
+// there. A returned tag of "" means the link follows the default one, which is
+// how every link written before tags existed reads.
+//
+// An unknown name is reported as a nil package rather than an error, because the
+// two add paths word that one differently and both wordings predate tags.
+func resolveAddSpec(database *db.DB, name, requested string) (*db.Package, string, error) {
+	if requested != "" {
+		tagged, err := database.ResolveTag(name, requested)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to resolve tag %s of %s: %w", requested, name, err)
+		}
+		if tagged != nil {
+			return tagged, requested, nil
+		}
+	}
+
+	pkg, err := database.GetPackageByName(name)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to look up package: %w", err)
+	}
+	if pkg == nil {
+		return nil, "", nil
+	}
+	if requested != "" && pkg.Version != requested {
+		return nil, "", versionNotInStoreError(requested, name, pkg.Version)
+	}
+	return pkg, "", nil
 }
 
 // versionNotInStoreError reports that the store holds a different version of

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -114,6 +114,12 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 			result.pkg = pkg
 			result.tag = tag
 
+			if useLink && !isDefaultTag(tag) {
+				result.err = liveLinkTagError(name, tag)
+				results <- result
+				return
+			}
+
 			linkRes, err := linkPackage(database, linker, s, pkg, useLink)
 			if err != nil {
 				result.err = err
@@ -495,6 +501,10 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useL
 		return fmt.Errorf("package %s not found in store. Did you run 'lnpm publish' in the package directory?", name)
 	}
 
+	if useLink && !isDefaultTag(tag) {
+		return liveLinkTagError(name, tag)
+	}
+
 	if useLink {
 		fmt.Printf("Adding %s@%s (linked to source%s)...\n", pkg.Name, pkg.Version, tagClause(tag))
 	} else {
@@ -677,6 +687,23 @@ func resolveAddSpec(database *db.DB, name, requested string) (*db.Package, strin
 		return nil, "", versionNotInStoreError(requested, name, pkg.Version)
 	}
 	return pkg, "", nil
+}
+
+// liveLinkTagError refuses a spec that names a dist-tag alongside --link.
+//
+// The two say different things about what to resolve to, and only one of them
+// can be honoured. A tag names a build in the store; --link points
+// .lnpm/<package> at the source directory the package was published from, which
+// holds whatever is in the working tree - unpublished, possibly uncommitted, and
+// not what any tag names. Doing both is impossible, and doing --link while
+// reporting the tag, which is what the summary line did, tells the user they are
+// on a channel when they are not.
+//
+// Refused rather than warned about because the two are a contradiction in the
+// request, not a risk in it: there is no version of this add that does what the
+// spec asks for, so the user has to decide which half to drop.
+func liveLinkTagError(name, tag string) error {
+	return fmt.Errorf("cannot add %s@%s with --link: --link resolves to the package's source directory, which is not the build any tag names (drop --link to get the %s build, or drop the tag to link the source)", name, tag, tag)
 }
 
 // versionNotInStoreError reports that the store holds a different version of

--- a/internal/cli/add_test.go
+++ b/internal/cli/add_test.go
@@ -137,7 +137,7 @@ func publishForLink(t *testing.T, database *db.DB, name string, files map[string
 	if err != nil {
 		t.Fatalf("pack source: %v", err)
 	}
-	if err := finishPublish(src, pkgJSON, collected, database, false); err != nil {
+	if err := finishPublish(src, pkgJSON, collected, database, false, db.DefaultTag); err != nil {
 		t.Fatalf("publish: %v", err)
 	}
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/pedrosousa13/lnpm/internal/db"
 )
 
 // publishCmd publishes a package to the local store
@@ -19,16 +21,22 @@ This command:
   4. Copies files to ~/.lnpm/store/{name}/{hash}/
   5. Records the package in the database
 
+With --tag the build is stored under that channel instead of moving 'latest', so
+consumers keep the release they are on until they ask for the channel by name
+with 'lnpm add <pkg>@<tag>'.
+
 Examples:
-  lnpm publish           # Publish current package
-  lnpm publish --push    # Publish and update all linked projects
-  lnpm publish --all     # Publish all packages in monorepo`,
+  lnpm publish            # Publish current package
+  lnpm publish --push     # Publish and update all linked projects
+  lnpm publish --all      # Publish all packages in monorepo
+  lnpm publish --tag beta # Publish to the beta channel, leaving latest alone`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		push, _ := cmd.Flags().GetBool("push")
 		all, _ := cmd.Flags().GetBool("all")
 		skipHooks, _ := cmd.Flags().GetBool("skip-hooks")
 		skipValidation, _ := cmd.Flags().GetBool("skip-validation")
-		return RunPublish(push, all, skipHooks, skipValidation)
+		tag, _ := cmd.Flags().GetString("tag")
+		return RunPublishTagged(push, all, skipHooks, skipValidation, tag)
 	},
 }
 
@@ -304,6 +312,7 @@ func init() {
 	publishCmd.Flags().Bool("all", false, "Publish all packages in monorepo")
 	publishCmd.Flags().Bool("skip-hooks", false, "Skip prepare scripts (prepare, prepublishOnly, prepack)")
 	publishCmd.Flags().Bool("skip-validation", false, "Skip package validation before publish")
+	publishCmd.Flags().String("tag", db.DefaultTag, "Channel to publish to; anything but "+db.DefaultTag+" leaves "+db.DefaultTag+" where it is")
 
 	// retreat flags
 	retreatCmd.Flags().Bool("force", false, "Actually remove everything (required)")

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -281,6 +281,30 @@ Examples:
 	},
 }
 
+// tagCmd manages dist-tags on a package already in the store
+var tagCmd = &cobra.Command{
+	Use:   "tag <package> <tag>",
+	Short: "Point a dist-tag at a published package, or remove one",
+	Long: `Manage the dist-tags of a package already in the store, without republishing
+it.
+
+Setting points the tag at the version the package currently resolves to - the
+one tagged ` + db.DefaultTag + ` - so 'lnpm add <pkg>@<tag>' from then on links that build.
+Removing takes the tag off and leaves the version it named in the store.
+
+The ` + db.DefaultTag + ` tag cannot be removed: it is what every lookup by name resolves
+through, so deleting it would leave the package published and invisible.
+
+Examples:
+  lnpm tag my-package beta            # Point beta at the published version
+  lnpm tag my-package beta --delete   # Remove the beta tag`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		del, _ := cmd.Flags().GetBool("delete")
+		return RunTag(args[0], args[1], del)
+	},
+}
+
 // checkCmd scans package.json for leftover lnpm references
 var checkCmd = &cobra.Command{
 	Use:   "check",
@@ -312,6 +336,12 @@ func init() {
 
 	// Register check command
 	rootCmd.AddCommand(checkCmd)
+
+	// Register tag command
+	rootCmd.AddCommand(tagCmd)
+
+	// tag flags
+	tagCmd.Flags().Bool("delete", false, "Remove the tag instead of setting it")
 
 	// publish flags
 	publishCmd.Flags().Bool("push", false, "Push to all linked projects after publish")

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -175,7 +175,8 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show current state of all links",
 	Long: `Show the current state of lnpm including:
-  - Published packages in the store
+  - Published packages in the store, one row per retained version, with the
+    dist-tags naming each
   - Active links between packages and projects
 
 This provides full visibility into what lnpm is managing.`,
@@ -189,6 +190,10 @@ var listCmd = &cobra.Command{
 	Use:   "list [package]",
 	Short: "List packages in project or store",
 	Long: `List packages linked in the current project or available in the store.
+
+--store marks each stored version with the dist-tags naming it, and --projects
+names every project consuming the package with the build each is on, whichever
+channel it followed to get there.
 
 Examples:
   lnpm list                      # List packages in current project

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -61,7 +61,8 @@ against files that have not been published, or even committed.
 What follows the @ in a spec is read as a dist-tag first and as an exact version
 only if no tag by that name is set, so 'lnpm add my-package@beta' links whatever
 build the beta channel currently names. A spec with no @ resolves to latest, as
-it always has.
+it always has. A tag cannot be combined with --link: that resolves to the
+package's source directory, which is not the build any tag names.
 
 Examples:
   lnpm add my-package            # Add latest version

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -3,9 +3,8 @@ package cli
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
-
 	"github.com/pedrosousa13/lnpm/internal/db"
+	"github.com/spf13/cobra"
 )
 
 // publishCmd publishes a package to the local store

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -59,10 +59,16 @@ project with no further command, and package.json uses link: instead of file:.
 That trades away the isolation the default gives you - the project then builds
 against files that have not been published, or even committed.
 
+What follows the @ in a spec is read as a dist-tag first and as an exact version
+only if no tag by that name is set, so 'lnpm add my-package@beta' links whatever
+build the beta channel currently names. A spec with no @ resolves to latest, as
+it always has.
+
 Examples:
   lnpm add my-package            # Add latest version
   lnpm add pkg1 pkg2 pkg3        # Add multiple packages
   lnpm add my-package@1.0.0      # Add specific version
+  lnpm add my-package@beta       # Add the build tagged beta
   lnpm add my-package --dev      # Add as devDependency
   lnpm add my-package --install  # Add and run npm install
   lnpm add my-package --pure     # Don't modify package.json

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -270,8 +270,13 @@ Everything comes back as a store copy (file:.lnpm/<pkg>), because the snapshot
 does not record which packages were added with --link. Run 'lnpm add --link
 <pkg>' again for the ones that should point back at their live source.
 
-A package whose recorded version is no longer the one in the store is reported
-and skipped; the snapshot is kept so restore can be re-run after publishing it.
+Each package comes back on the exact build the snapshot recorded, found by its
+content hash, so a project that was consuming a dist-tagged build gets that
+build and not whatever ` + db.DefaultTag + ` names now. The tag itself is not recorded
+anywhere, so the restored link follows ` + db.DefaultTag + ` and says so.
+
+A build that is no longer in the store is reported and skipped; the snapshot is
+kept so restore can be re-run after publishing it again.
 
 Examples:
   lnpm restore   # Undo the last 'lnpm retreat --force'`,

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -154,12 +154,19 @@ This command:
   3. Updates store
   4. Re-links to all linked projects
 
+Push goes to the channel the build already in the store carries, so pushing an
+unchanged pre-release keeps it a pre-release rather than moving ` + db.DefaultTag + ` onto
+it. Content the store does not hold yet is in no channel, so it goes to
+` + db.DefaultTag + `; use --tag to say otherwise.
+
 Examples:
   lnpm push              # Push to all linked projects
+  lnpm push --tag beta   # Push to the beta channel, leaving latest alone
   lnpm push --skip-hooks # Skip prepare scripts`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		skipHooks, _ := cmd.Flags().GetBool("skip-hooks")
-		return RunPush(skipHooks)
+		tag, _ := cmd.Flags().GetString("tag")
+		return RunPushTagged(skipHooks, tag)
 	},
 }
 
@@ -381,6 +388,7 @@ func init() {
 
 	// push flags
 	pushCmd.Flags().Bool("skip-hooks", false, "Skip prepare scripts before push")
+	pushCmd.Flags().String("tag", "", "Channel to push to (default: the channel the build already in the store carries)")
 
 	// list flags
 	listCmd.Flags().Bool("store", false, "List packages in store")

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -123,9 +123,13 @@ the store, picking up anything published since they were added.
 With no arguments every package in lnpm.lock is refreshed.
 
 This command:
-  1. Finds each package's current version in the store
+  1. Finds the version the channel each package follows now names
   2. Refreshes .lnpm/{package}/
   3. Updates lnpm.lock
+
+A package added as <pkg>@<tag> follows that channel, so pull moves it to
+whatever the tag names and never onto ` + db.DefaultTag + `. Everything else follows
+` + db.DefaultTag + `, as it always has.
 
 package.json is never modified: its reference already points at .lnpm/{package}.
 
@@ -200,8 +204,15 @@ var gcCmd = &cobra.Command{
 	Short: "Garbage collect unused packages",
 	Long: `Remove unused packages from the store.
 
+A stored version goes when no link and no dist-tag reaches it. The ` + db.DefaultTag + `
+tag does not count: every publish moves it onto what it just wrote, so treating
+it as a reason to keep a version would leave gc nothing it could ever collect.
+A version a tag you set names is kept even with nothing linked to it, which is
+what a build published to a channel is waiting for. Removing one of those takes
+two steps: 'lnpm tag <pkg> <tag> --delete', then 'lnpm gc'.
+
 Examples:
-  lnpm gc              # Remove packages with no links
+  lnpm gc              # Remove versions no link and no tag reaches
   lnpm gc --dry-run    # Show what would be removed
   lnpm gc --older-than 30d   # Remove packages older than 30 days
   lnpm gc --fix-links  # Clean up orphaned link records

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -72,13 +72,24 @@ func RunDoctor() error {
 		packages, _ := database.ListPackages()
 		tagsByName := make(map[string]map[string]string)
 		orphanedCount := 0
+		// Tags are what tells an orphan from a build lnpm is keeping on purpose,
+		// so a name whose tags cannot be read makes the count meaningless rather
+		// than approximate: every version of that name would be counted as an
+		// orphan and the user sent to a gc that would keep them. Reported as an
+		// issue and the check abandoned, which is what doctor does with anything
+		// it cannot answer.
+		var tagsErr error
 		for _, pkg := range packages {
 			links, _ := database.GetLinksForPackage(pkg.ID)
 			if len(links) > 0 {
 				continue
 			}
 			if _, ok := tagsByName[pkg.Name]; !ok {
-				tags, _ := database.TagsForPackage(pkg.Name)
+				tags, err := database.TagsForPackage(pkg.Name)
+				if err != nil {
+					tagsErr = fmt.Errorf("failed to read the tags of %s: %w", pkg.Name, err)
+					break
+				}
 				tagsByName[pkg.Name] = tags
 			}
 			if pinnedByTag(tagsByName[pkg.Name], pkg.ContentHash) {
@@ -86,7 +97,11 @@ func RunDoctor() error {
 			}
 			orphanedCount++
 		}
-		if orphanedCount > 0 {
+		if tagsErr != nil {
+			fmt.Printf("%s ERROR\n", iconFail())
+			fmt.Printf("  %v\n", tagsErr)
+			issues++
+		} else if orphanedCount > 0 {
 			fmt.Printf("%s %d orphaned package(s)\n", iconWarn(), orphanedCount)
 			fmt.Println("  Fix: Run 'lnpm gc' to remove unused packages")
 			warnings++

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -59,15 +59,32 @@ func RunDoctor() error {
 	} else {
 		fmt.Printf("%s OK\n", iconOK())
 
-		// Check 3: Orphaned packages (packages with no links)
+		// Check 3: Orphaned packages (versions no link and no tag reaches)
+		//
+		// A version a non-default tag names is not counted, and that is not
+		// cosmetic: this check's whole output is advice to run gc, and gc keeps
+		// exactly those versions. Counting one would send a user to a command
+		// that would then find nothing to do, which reads as lnpm being unable to
+		// clean up after itself rather than as it holding on to a build on
+		// purpose. Reachable only since publish learned --tag; before that no
+		// version could be tagged and unlinked at once.
 		fmt.Print("Checking for orphaned packages... ")
 		packages, _ := database.ListPackages()
+		tagsByName := make(map[string]map[string]string)
 		orphanedCount := 0
 		for _, pkg := range packages {
 			links, _ := database.GetLinksForPackage(pkg.ID)
-			if len(links) == 0 {
-				orphanedCount++
+			if len(links) > 0 {
+				continue
 			}
+			if _, ok := tagsByName[pkg.Name]; !ok {
+				tags, _ := database.TagsForPackage(pkg.Name)
+				tagsByName[pkg.Name] = tags
+			}
+			if pinnedByTag(tagsByName[pkg.Name], pkg.ContentHash) {
+				continue
+			}
+			orphanedCount++
 		}
 		if orphanedCount > 0 {
 			fmt.Printf("%s %d orphaned package(s)\n", iconWarn(), orphanedCount)

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -50,6 +50,11 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 	// Find packages to remove
 	var packagesToRemove []*db.Package
 	var linksToRemove []linkToRemove
+	// Tags of each package name, read once per name. They are reachability
+	// roots, so a failure to read them stops the whole run: this pass decides
+	// what gets deleted, and deciding it from tags gc could not read would be
+	// deleting a version it cannot show is unreachable.
+	tagsByName := make(map[string]map[string]string)
 	// Project directories still on disk, deduplicated: the temp-directory sweep
 	// reads each one once, however many packages are linked into it.
 	projectPaths := make(map[string]struct{})
@@ -85,6 +90,22 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 
 		// Re-check links after filtering orphans
 		validLinks := len(links) - countLinksForPackage(linksToRemove, pkg.ID)
+
+		if _, ok := tagsByName[pkg.Name]; !ok {
+			tags, err := database.TagsForPackage(pkg.Name)
+			if err != nil {
+				return fmt.Errorf("failed to read the tags of %s: %w", pkg.Name, err)
+			}
+			tagsByName[pkg.Name] = tags
+		}
+
+		// A version stays for as long as a tag names it, whatever its links
+		// say. That is the other half of the reachability rule: a build
+		// published to a channel is meant to be there when someone asks for
+		// the channel, and nothing need be linked to it yet.
+		if pinnedByTag(tagsByName[pkg.Name], pkg.ContentHash) {
+			continue
+		}
 
 		// Package is orphaned if no valid links.
 		//
@@ -187,6 +208,27 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 	}
 
 	return nil
+}
+
+// pinnedByTag reports whether a tag other than the default one names the version
+// with this content hash.
+//
+// The default tag is excluded, and that asymmetry is the whole of the rule worth
+// arguing about. Every publish moves it onto whatever it just wrote, so it
+// always names something and names it without anyone deciding to: counting it as
+// a root would leave gc unable to collect any current version of any package,
+// which is every package a store holds one version of — the command would still
+// run, report nothing and free nothing. A tag a user set is a decision to keep a
+// build; latest is a side effect of the last publish. What the default tag names
+// is still kept while a project links it, which is the rule gc has always
+// applied.
+func pinnedByTag(tags map[string]string, hash string) bool {
+	for tag, tagged := range tags {
+		if tag != db.DefaultTag && tagged == hash {
+			return true
+		}
+	}
+	return false
 }
 
 // removePackages deletes each package's store entry and then its database row.

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -107,19 +107,23 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 			continue
 		}
 
-		// Package is orphaned if no valid links.
+		// The version is orphaned if no valid links.
 		//
-		// Note for whoever adds pruning of superseded store generations: an
-		// incremental relink carries an unchanged file across from the package
-		// already in the project with a hard link, so .lnpm/{package} keeps the
-		// inode - and therefore the store generation - that first materialised
-		// each file, however many versions have been published since. Today that
-		// costs nothing, because what gets removed here is the whole package and
-		// only when no valid link remains, so nothing a project still points at
-		// is ever deleted. Start deleting entries a linked project no longer
-		// names and it becomes one extra copy per unchanged file per project:
-		// the last reference to the old generation's inode is the consumer's,
-		// and the disk it shared with the store stops being shared.
+		// A superseded version reaches this with no links of its own, because
+		// moving a tag carries them to the version it now names. That is what
+		// makes the generations a store used to accumulate collectable at all,
+		// and it has a cost worth stating. An incremental relink carries an
+		// unchanged file across from the package already in the project with a
+		// hard link, so .lnpm/{package} keeps the inode - and therefore the
+		// store generation - that first materialised each file, however many
+		// versions have been published since. Removing that generation's entry
+		// does not touch the project's files: the consumer's hard link keeps the
+		// inode alive. What it ends is the sharing. Those bytes are the
+		// consumer's alone afterwards, and publishing that exact content again
+		// copies them into the store again rather than finding them there.
+		//
+		// It stays a cost rather than a loss because nothing a link or a tag
+		// still reaches is removed.
 		if validLinks == 0 {
 			// Check age if specified
 			if maxAge > 0 {

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -60,7 +60,14 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 	projectPaths := make(map[string]struct{})
 
 	for _, pkg := range packages {
-		links, _ := database.GetLinksForPackage(pkg.ID)
+		// A failure to read the links stops the run, for the reason the tag read
+		// below stops it: this pass decides what gets deleted, and a read that
+		// failed is indistinguishable here from a version nothing links - so
+		// carrying on would delete a version gc cannot show is unreachable.
+		links, err := database.GetLinksForPackage(pkg.ID)
+		if err != nil {
+			return fmt.Errorf("failed to read the links of %s@%s: %w", pkg.Name, pkg.Version, err)
+		}
 
 		// Check for orphaned links
 		// Named lnk, not link, so it does not shadow the link package the

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -16,8 +16,20 @@ import (
 	"github.com/pedrosousa13/lnpm/internal/workspace"
 )
 
-// RunPublish executes the publish command
+// RunPublish executes the publish command, moving the default tag onto what it
+// writes.
 func RunPublish(push bool, all bool, skipHooks bool, skipValidation bool) error {
+	return RunPublishTagged(push, all, skipHooks, skipValidation, db.DefaultTag)
+}
+
+// RunPublishTagged is RunPublish, moving tag onto what it writes instead of the
+// default one. An empty tag means the default one, which is what the flag's own
+// default value carries.
+func RunPublishTagged(push bool, all bool, skipHooks bool, skipValidation bool, tag string) error {
+	if tag == "" {
+		tag = db.DefaultTag
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get current directory: %w", err)
@@ -25,14 +37,14 @@ func RunPublish(push bool, all bool, skipHooks bool, skipValidation bool) error 
 
 	// Handle --all for monorepo publishing
 	if all {
-		return publishAll(cwd, push, skipHooks, skipValidation)
+		return publishAll(cwd, push, skipHooks, skipValidation, tag)
 	}
 
-	return publishSingle(cwd, push, skipHooks, skipValidation)
+	return publishSingle(cwd, push, skipHooks, skipValidation, tag)
 }
 
 // publishAll publishes all packages in a monorepo workspace
-func publishAll(cwd string, push bool, skipHooks bool, skipValidation bool) error {
+func publishAll(cwd string, push bool, skipHooks bool, skipValidation bool, tag string) error {
 	ws, err := workspace.Detect(cwd)
 	if err != nil {
 		return fmt.Errorf("failed to detect workspace: %w", err)
@@ -81,7 +93,7 @@ func publishAll(cwd string, push bool, skipHooks bool, skipValidation bool) erro
 				fmt.Printf("%s %s@%s %s\n", sep, pkg.Name, pkg.Version, sep)
 				outputMu.Unlock()
 
-				err := publishSingle(pkg.Path, push, skipHooks, skipValidation)
+				err := publishSingle(pkg.Path, push, skipHooks, skipValidation, tag)
 
 				outputMu.Lock()
 				if err != nil {
@@ -122,7 +134,7 @@ func publishAll(cwd string, push bool, skipHooks bool, skipValidation bool) erro
 }
 
 // publishSingle publishes a single package
-func publishSingle(pkgPath string, push bool, skipHooks bool, skipValidation bool) error {
+func publishSingle(pkgPath string, push bool, skipHooks bool, skipValidation bool, tag string) error {
 	// Validate package before proceeding
 	if !skipValidation {
 		if err := validation.ValidatePackage(pkgPath); err != nil {
@@ -175,14 +187,24 @@ func publishSingle(pkgPath string, push bool, skipHooks bool, skipValidation boo
 		return fmt.Errorf("failed to check existing package: %w", err)
 	}
 
-	if existing != nil && !push {
+	// Nothing to do only if the content is already stored AND the tag being
+	// published already names it. The tag half is not a refinement: this return
+	// skips finishPublish, which is the only place a tag is ever moved, so
+	// without it `publish --tag beta` over an unchanged working tree would print
+	// a reassuring line and leave beta pointing wherever it was - or nowhere.
+	tagged, err := database.ResolveTag(pkgJSON.Name, tag)
+	if err != nil {
+		return fmt.Errorf("failed to read the %s tag of %s: %w", tag, pkgJSON.Name, err)
+	}
+
+	if existing != nil && !push && tagged != nil && tagged.ContentHash == contentHash {
 		fmt.Printf("%s Package %s@%s already published with same content (hash: %s)\n",
 			iconWarn(), pkgJSON.Name, pkgJSON.Version, shortHash(contentHash))
 		fmt.Println("Use --push to update linked projects anyway")
 		return nil
 	}
 
-	if err := finishPublish(pkgPath, pkgJSON, files, database, push); err != nil {
+	if err := finishPublish(pkgPath, pkgJSON, files, database, push, tag); err != nil {
 		return err
 	}
 
@@ -196,8 +218,9 @@ func publishSingle(pkgPath string, push bool, skipHooks bool, skipValidation boo
 	return nil
 }
 
-// finishPublish completes publishing with pre-packed data (used by push too)
-func finishPublish(pkgPath string, pkgJSON *pack.PackageJSON, files []*pack.FileInfo, database *db.DB, push bool) error {
+// finishPublish completes publishing with pre-packed data (used by push too),
+// moving tag onto the version it records.
+func finishPublish(pkgPath string, pkgJSON *pack.PackageJSON, files []*pack.FileInfo, database *db.DB, push bool, tag string) error {
 	contentHash := pack.HashFiles(files)
 
 	// Store the package
@@ -206,7 +229,7 @@ func finishPublish(pkgPath string, pkgJSON *pack.PackageJSON, files []*pack.File
 		return fmt.Errorf("failed to create store: %w", err)
 	}
 
-	fmt.Printf("Publishing %s@%s (%d files)...\n", pkgJSON.Name, pkgJSON.Version, len(files))
+	fmt.Printf("Publishing %s@%s (%d files%s)...\n", pkgJSON.Name, pkgJSON.Version, len(files), tagClause(tag))
 
 	storePath, err := s.Store(pkgJSON.Name, contentHash, files, pkgPath)
 	if err != nil {
@@ -244,11 +267,11 @@ func finishPublish(pkgPath string, pkgJSON *pack.PackageJSON, files []*pack.File
 			ModTime:      f.ModTime,
 		}
 	}
-	if err := database.InsertPackageWithFiles(pkg, fileEntries); err != nil {
+	if err := database.InsertPackageWithFilesTagged(pkg, fileEntries, tag); err != nil {
 		return fmt.Errorf("failed to record package: %w", err)
 	}
 
-	fmt.Printf("%s Published %s@%s\n", iconOK(), pkgJSON.Name, pkgJSON.Version)
+	fmt.Printf("%s Published %s@%s%s\n", iconOK(), pkgJSON.Name, pkgJSON.Version, tagSuffix(tag))
 	fmt.Printf("  Hash: %s\n", shortHash(contentHash))
 	fmt.Printf("  Files: %d\n", len(files))
 	fmt.Printf("  Size: %s\n", formatSize(totalSize))

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -57,6 +57,16 @@ func RunPull(packageNames []string) error {
 		}
 	}
 
+	// Which channel this project follows for each package. Resolving by name
+	// alone would answer with whatever latest points at, so a consumer that asked
+	// for beta would be relinked onto the stable release and have its lock
+	// rewritten to match - the carry-over onto latest that asking for a channel
+	// exists to prevent, reached through pull instead of through a moved tag.
+	followed, err := tagsFollowedByProject(database, cwd)
+	if err != nil {
+		return err
+	}
+
 	s, err := store.New()
 	if err != nil {
 		return fmt.Errorf("failed to access store: %w", err)
@@ -84,17 +94,34 @@ func RunPull(packageNames []string) error {
 			continue
 		}
 
-		pkg, err := database.GetPackageByName(name)
-		if err != nil {
-			failed = append(failed, fmt.Errorf("%s: failed to look up package: %w", name, err))
-			continue
-		}
-		if pkg == nil {
-			failed = append(failed, fmt.Errorf("%s: not found in store - did you run 'lnpm publish' in the package directory", name))
-			continue
+		tag := followed[name]
+		var pkg *db.Package
+		if tagNote(tag) != "" {
+			pkg, err = database.ResolveTag(name, tag)
+			if err != nil {
+				failed = append(failed, fmt.Errorf("%s: failed to resolve tag %s: %w", name, tag, err))
+				continue
+			}
+			if pkg == nil {
+				// Reported rather than quietly resolved by name: falling back
+				// would move the project onto latest, which is the one outcome
+				// this whole lookup exists to avoid.
+				failed = append(failed, fmt.Errorf("%s: tag %s is no longer set in the store - re-add it under a tag that is", name, tag))
+				continue
+			}
+		} else {
+			pkg, err = database.GetPackageByName(name)
+			if err != nil {
+				failed = append(failed, fmt.Errorf("%s: failed to look up package: %w", name, err))
+				continue
+			}
+			if pkg == nil {
+				failed = append(failed, fmt.Errorf("%s: not found in store - did you run 'lnpm publish' in the package directory", name))
+				continue
+			}
 		}
 
-		fmt.Printf("Pulling %s... ", name)
+		fmt.Printf("Pulling %s%s... ", name, tagSuffix(tag))
 
 		if entry.Version == pkg.Version && entry.Hash == pkg.ContentHash {
 			fmt.Printf("already up to date (%s)\n", pkg.Version)

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -62,7 +62,7 @@ func RunPull(packageNames []string) error {
 	// for beta would be relinked onto the stable release and have its lock
 	// rewritten to match - the carry-over onto latest that asking for a channel
 	// exists to prevent, reached through pull instead of through a moved tag.
-	followed, err := tagsFollowedByProject(database, cwd)
+	held, err := linksOfProject(database, cwd)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func RunPull(packageNames []string) error {
 			continue
 		}
 
-		tag := followed[name]
+		tag := held.tag(name)
 		var pkg *db.Package
 		if tagNote(tag) != "" {
 			pkg, err = database.ResolveTag(name, tag)

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -96,7 +96,7 @@ func RunPull(packageNames []string) error {
 
 		tag := held.tag(name)
 		var pkg *db.Package
-		if tagNote(tag) != "" {
+		if !isDefaultTag(tag) {
 			pkg, err = database.ResolveTag(name, tag)
 			if err != nil {
 				failed = append(failed, fmt.Errorf("%s: failed to resolve tag %s: %w", name, tag, err))

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -139,10 +139,8 @@ func RunPull(packageNames []string) error {
 			continue
 		}
 
-		// The link type Link reports is deliberately dropped, and no db link row
-		// is written: publishing updates the existing package row in place, so
-		// the row add recorded still points at the package pull just linked, and
-		// no command surfaces the stored link type. The per-file counts are
+		// The link type Link reports is deliberately dropped: no command surfaces
+		// the stored one, and pull does not change it. The per-file counts are
 		// kept: pull runs the same incremental relink push does, and reporting
 		// nothing would make it the one command that leaves the user guessing
 		// whether the refresh cost the whole package.
@@ -168,6 +166,32 @@ func RunPull(packageNames []string) error {
 		fmt.Printf("updated %s -> %s (%d changed, %d unchanged)\n", entry.Version, pkg.Version, linkRes.Changed, linkRes.Unchanged)
 		refreshed++
 		lastVersion = pkg.Version
+
+		// Leave the database describing what was just linked.
+		//
+		// Usually there is nothing to do: a publish that moves a tag carries the
+		// links following it onto the version it now names, so the row add wrote
+		// already names this one. That breaks down when a tag has been deleted
+		// and set again by a publish - there is no previous version to carry
+		// links from - and the row is then left on a build this project no longer
+		// has. That row is what remove deletes, what gc reads as a reason to keep
+		// that build, and what `publish --tag --push` decides whom to push to
+		// from, so all three would act on the wrong version.
+		//
+		// Only an existing row is repointed. pull refreshes links rather than
+		// creating them, and a project with no row for this package had none
+		// before pull ran either.
+		if l, ok := held[name]; ok && l.PackageID != pkg.ID {
+			repointed := &db.Link{
+				PackageID: pkg.ID,
+				ProjectID: l.ProjectID,
+				LinkType:  l.LinkType,
+				Tag:       l.Tag,
+			}
+			if err := database.InsertLink(repointed); err != nil {
+				fmt.Printf("  %s Failed to record the link for %s: %v\n", iconWarn(), name, err)
+			}
+		}
 	}
 
 	// A failed save must not swallow the per-package failures: both are

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/pedrosousa13/lnpm/internal/db"
@@ -12,8 +13,62 @@ import (
 	"github.com/pedrosousa13/lnpm/internal/store"
 )
 
-// RunPush executes the push command
+// pushTag works out which channel a push publishes to when the user has not
+// said.
+//
+// Push has no channel of its own to go on. It re-publishes the working tree, and
+// nothing records which channel that tree was last published to. What is
+// recorded is which tags name the build already in the store, and for an
+// unchanged working tree that answers the question exactly: a push over the
+// build tagged beta is a push to beta. That is the case worth getting right -
+// without it a bare push in a package whose current build is a pre-release moves
+// the default tag onto it and releases something nobody asked to release.
+//
+// Content the store does not hold is named by no tag and falls back to the
+// default one, so editing a pre-release and pushing it does still move the
+// default tag. Nothing in the store can be read to infer otherwise, and
+// inferring it from the last publish would mean inferring it from state lnpm
+// does not keep; --tag is what says it instead.
+//
+// Content several channels name is refused rather than resolved by picking one.
+// Which channel a build belongs to is not a thing to guess when the guess
+// releases software.
+func pushTag(database *db.DB, name, hash string) (string, error) {
+	tags, err := database.TagsForPackage(name)
+	if err != nil {
+		return "", fmt.Errorf("failed to read the tags of %s: %w", name, err)
+	}
+
+	var naming []string
+	for _, tag := range tagsNamingList(tags, hash) {
+		if tag == db.DefaultTag {
+			// Already what the default tag names, so this push moves nothing.
+			return db.DefaultTag, nil
+		}
+		naming = append(naming, tag)
+	}
+
+	switch len(naming) {
+	case 0:
+		return db.DefaultTag, nil
+	case 1:
+		return naming[0], nil
+	default:
+		return "", fmt.Errorf("the build of %s in your working tree is named by the tags %s, so which channel this push is for is ambiguous: re-run with --tag",
+			name, strings.Join(naming, ", "))
+	}
+}
+
+// RunPush executes the push command, publishing to the channel the build
+// already in the store carries.
 func RunPush(skipHooks bool) error {
+	return RunPushTagged(skipHooks, "")
+}
+
+// RunPushTagged is RunPush, publishing to tag. An empty tag means work the
+// channel out from the store, which is what a bare `lnpm push` does; see
+// pushTag.
+func RunPushTagged(skipHooks bool, tag string) error {
 	// Get current directory
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -58,7 +113,12 @@ func RunPush(skipHooks bool) error {
 			// self-contained, so wrapping them here would only stutter.
 			return err
 		}
-		return finishPublish(cwd, pkgJSON, files, database, false, db.DefaultTag)
+		// Nothing is in the store to read a channel off, so an unset --tag can
+		// only mean the default one.
+		if tag == "" {
+			tag = db.DefaultTag
+		}
+		return finishPublish(cwd, pkgJSON, files, database, false, tag)
 	}
 
 	// Always run prepare scripts before packing
@@ -84,7 +144,14 @@ func RunPush(skipHooks bool) error {
 	// Calculate content hash
 	newHash := pack.HashFiles(files)
 
-	fmt.Printf("Pushing %s@%s...\n", pkgJSON.Name, pkgJSON.Version)
+	if tag == "" {
+		tag, err = pushTag(database, pkgJSON.Name, newHash)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("Pushing %s@%s%s...\n", pkgJSON.Name, pkgJSON.Version, tagSuffix(tag))
 
 	// Get store
 	s, err := store.New()
@@ -134,7 +201,7 @@ func RunPush(skipHooks bool) error {
 			ModTime:      f.ModTime,
 		}
 	}
-	if err := database.InsertPackageWithFiles(pkg, fileEntries); err != nil {
+	if err := database.InsertPackageWithFilesTagged(pkg, fileEntries, tag); err != nil {
 		return fmt.Errorf("failed to update package: %w", err)
 	}
 

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -58,7 +58,7 @@ func RunPush(skipHooks bool) error {
 			// self-contained, so wrapping them here would only stutter.
 			return err
 		}
-		return finishPublish(cwd, pkgJSON, files, database, false)
+		return finishPublish(cwd, pkgJSON, files, database, false, db.DefaultTag)
 	}
 
 	// Always run prepare scripts before packing

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 
@@ -17,46 +18,109 @@ import (
 // said.
 //
 // Push has no channel of its own to go on. It re-publishes the working tree, and
-// nothing records which channel that tree was last published to. What is
-// recorded is which tags name the build already in the store, and for an
-// unchanged working tree that answers the question exactly: a push over the
-// build tagged beta is a push to beta. That is the case worth getting right -
-// without it a bare push in a package whose current build is a pre-release moves
-// the default tag onto it and releases something nobody asked to release.
+// nothing records which channel that tree was last published to. Two things in
+// the store answer the question anyway, and they are asked in that order.
 //
-// Content the store does not hold is named by no tag and falls back to the
-// default one, so editing a pre-release and pushing it does still move the
-// default tag. Nothing in the store can be read to infer otherwise, and
-// inferring it from the last publish would mean inferring it from state lnpm
-// does not keep; --tag is what says it instead.
+// The first is which tags name the packed content. For an unchanged working tree
+// that is exact: a push over the build tagged beta is a push to beta.
 //
-// Content several channels name is refused rather than resolved by picking one.
-// Which channel a build belongs to is not a thing to guess when the guess
-// releases software.
-func pushTag(database *db.DB, name, hash string) (string, error) {
+// The second is the version string, and it is what covers the loop push exists
+// for. An edit gives the tree content no tag has ever named, but a push loop
+// edits files without touching package.json, so the version is still the one the
+// stored pre-release carries - and the tags naming that record say which channel
+// the tree belongs to. Without this step an ordinary edit inside a pre-release
+// moved the default tag onto it, carried every latest-following consumer across
+// and wrote the pre-release into all of them, saying nothing.
+//
+// The default tag wins wherever it appears, at either step. It naming the
+// content means the push moves nothing; it naming the version means the mainline
+// is on this version, which is what an edit-without-bumping there looks like.
+//
+// Beyond that, resolution stops. A version bumped past everything in the store
+// is answered by neither step and falls back to the default tag, because the
+// store holds nothing that says otherwise - warnPushMovesTheDefaultTag says so
+// out loud rather than letting the fallback pass for a decision.
+func pushTag(database *db.DB, name, version, hash string) (string, error) {
 	tags, err := database.TagsForPackage(name)
 	if err != nil {
 		return "", fmt.Errorf("failed to read the tags of %s: %w", name, err)
 	}
 
-	var naming []string
-	for _, tag := range tagsNamingList(tags, hash) {
-		if tag == db.DefaultTag {
-			// Already what the default tag names, so this push moves nothing.
-			return db.DefaultTag, nil
-		}
-		naming = append(naming, tag)
+	// Tags naming the packed content. Several non-default ones are not
+	// ambiguous, because every choice has the same outcome: each already points
+	// at this hash, so setTagTx finds nothing to move and carries no link, and
+	// the name index is touched only for the default tag. The first is taken so
+	// that the channel the run reports is at least the same on every run.
+	if naming := tagsNamingList(tags, hash); len(naming) > 0 {
+		return pickDefaultFirst(naming), nil
 	}
 
-	switch len(naming) {
-	case 0:
-		return db.DefaultTag, nil
-	case 1:
-		return naming[0], nil
-	default:
-		return "", fmt.Errorf("the build of %s in your working tree is named by the tags %s, so which channel this push is for is ambiguous: re-run with --tag",
-			name, strings.Join(naming, ", "))
+	// Tags naming a stored record that carries this version.
+	var naming []string
+	for tag, tagged := range tags {
+		pkg, err := database.GetPackageByHash(name, tagged)
+		if err != nil {
+			return "", fmt.Errorf("failed to read the version the %s tag of %s names: %w", tag, name, err)
+		}
+		if pkg != nil && pkg.Version == version {
+			naming = append(naming, tag)
+		}
 	}
+	sort.Strings(naming)
+
+	switch {
+	case len(naming) == 0:
+		warnPushMovesTheDefaultTag(name, tags)
+		return db.DefaultTag, nil
+	case len(naming) == 1 || naming[0] == db.DefaultTag:
+		return pickDefaultFirst(naming), nil
+	default:
+		// Two channels carrying one version on builds this content is not. The
+		// push would move whichever was picked and drag its consumers with it,
+		// so the choice is not the caller's to guess.
+		return "", fmt.Errorf("%s@%s is named by the tags %s, so which channel this push is for is ambiguous: re-run with --tag",
+			name, version, strings.Join(naming, ", "))
+	}
+}
+
+// pickDefaultFirst returns the default tag when it is in the sorted list, and
+// otherwise the first entry.
+func pickDefaultFirst(naming []string) string {
+	for _, tag := range naming {
+		if tag == db.DefaultTag {
+			return db.DefaultTag
+		}
+	}
+	return naming[0]
+}
+
+// warnPushMovesTheDefaultTag says that this push is about to release, in the one
+// case where the store holds nothing that could say otherwise: content no tag
+// names, carrying a version no tagged record carries.
+//
+// It is said only for a package that has channels besides the default one. A
+// package with none has nothing to be moved onto the wrong one, and the line
+// would then be on every push lnpm has ever printed. Where there are channels
+// the fallback is a real decision made by default, and the line that follows it
+// - "Pushing my-lib@2.0.0-beta.2..." - names no tag at all, because tagSuffix
+// leaves the default one unsaid. So without this nothing in the run says which
+// channel is moving.
+func warnPushMovesTheDefaultTag(name string, tags map[string]string) {
+	others := make([]string, 0, len(tags))
+	for tag := range tags {
+		if tag != db.DefaultTag {
+			others = append(others, tag)
+		}
+	}
+	if len(others) == 0 {
+		return
+	}
+	sort.Strings(others)
+
+	fmt.Printf("  %s no tag names the build in your working tree, so this push moves the %s tag onto it\n",
+		iconWarn(), db.DefaultTag)
+	fmt.Printf("      %s also has the tags %s: re-run with --tag if this build belongs to one of them\n",
+		name, strings.Join(others, ", "))
 }
 
 // RunPush executes the push command, publishing to the channel the build
@@ -145,7 +209,7 @@ func RunPushTagged(skipHooks bool, tag string) error {
 	newHash := pack.HashFiles(files)
 
 	if tag == "" {
-		tag, err = pushTag(database, pkgJSON.Name, newHash)
+		tag, err = pushTag(database, pkgJSON.Name, pkgJSON.Version, newHash)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -58,6 +58,11 @@ func RunRemove(packageName string, all bool, yes bool) error {
 		return fmt.Errorf("failed to get project: %w", err)
 	}
 
+	held, err := linksOfProject(database, cwd)
+	if err != nil {
+		return err
+	}
+
 	linker := link.New(cwd)
 
 	// Remove each package
@@ -97,11 +102,13 @@ func RunRemove(packageName string, all bool, yes bool) error {
 		// Remove from lock file
 		lock.Remove(name)
 
-		// Remove link from database
+		// Remove link from database. The row this project holds, not the one a
+		// lookup by name would find: the name index mirrors the default tag, so
+		// for a project on a tagged version that lookup names a different record
+		// and the delete would silently match nothing.
 		if proj != nil {
-			pkg, _ := database.GetPackageByName(name)
-			if pkg != nil {
-				_ = database.DeleteLink(pkg.ID, proj.ID)
+			if l, ok := held[name]; ok {
+				_ = database.DeleteLink(l.PackageID, proj.ID)
 			}
 		}
 

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/pedrosousa13/lnpm/internal/config"
@@ -137,8 +138,12 @@ func RunRestore() error {
 		// in the store, and a consumer on the default channel would be put back
 		// on a release it never linked.
 		//
-		// A snapshot written before the lock file recorded hashes has none, and
-		// falls back to the name it always resolved through.
+		// An entry with no hash falls back to the name, which resolves through
+		// the default tag. No lnpm ever wrote one: lockfile.Package has carried
+		// Hash since the file's first commit and every writer sets it, so this
+		// is defence against a hand-edited lock file and nothing else. The
+		// fallback restores whatever the default tag names today, which for a
+		// hand-edited entry is the best the entry supports.
 		var pkg *db.Package
 		if entry.Hash != "" {
 			pkg, err = database.GetPackageByHash(name, entry.Hash)
@@ -307,6 +312,14 @@ func recordRestoredLink(database *db.DB, cwd string, pkg *db.Package, linkType l
 	// asked for months ago, and a wrong one is worse than none - it would have
 	// later publishes carry the project down a channel it never chose.
 	// warnIfOffTheDefaultChannel says so out loud instead.
+	//
+	// pushTag reads the same tags and does infer from them, which is not a
+	// contradiction: it is asking a different question. Push asks which channel
+	// the build in front of it belongs to, about a tree its user is editing now,
+	// and a wrong answer is a release the next command can re-tag. Here the
+	// question is what a user chose before a retreat that may be weeks old, and
+	// a wrong answer is written into a link row that quietly steers every
+	// publish after it.
 	dbLink := &db.Link{
 		PackageID: pkg.ID,
 		ProjectID: existingProj.ID,
@@ -318,26 +331,51 @@ func recordRestoredLink(database *db.DB, cwd string, pkg *db.Package, linkType l
 }
 
 // warnIfOffTheDefaultChannel reports that a restored package is on a build the
-// default tag does not name, which means the project was following some other
-// channel before the retreat and is not following it now.
+// default tag does not name. The restored link follows that tag - the third
+// thing restore cannot rebuild from the snapshot, alongside whether a package
+// was added with --link and which dependency field it was in - so the project is
+// on one build and following another. Left unsaid it would surface later and
+// elsewhere: the files are right, so nothing looks wrong until the next `lnpm
+// pull` moves the project onto whatever the default tag names.
 //
-// This is the third thing restore cannot rebuild from the snapshot, alongside
-// whether a package was added with --link and which dependency field it was in.
-// Left unsaid it would surface later and elsewhere: the files are right, so
-// nothing looks wrong until the next `lnpm pull` reads the restored link as a
-// default-channel one and moves the project onto the stable release.
+// Two quite different things put a project there, and they take opposite advice,
+// so which one happened is worked out rather than hedged over.
 //
-// A failure to read the tag is not reported. The warning is advice about a state
-// restore has already left the project in, and turning a failed read into a
-// second warning about the first would say less than nothing.
+// A tag naming the restored build means the project was following that channel:
+// the snapshot cannot say so, but a build that a channel still names is one a
+// consumer plausibly asked for, and re-adding under the tag says it again.
+//
+// No tag naming it means the channel is not the story. The build was the default
+// one and the package has been published since, which hash-based restore turned
+// from a failure into this: the recorded build comes back exactly, and it is
+// simply behind. Sending that user after a dist-tag would have them hunt for a
+// channel their package never had; what they want is `lnpm pull`.
+//
+// A failure to read is not reported. The warning is advice about a state restore
+// has already left the project in, and turning a failed read into a second
+// warning about the first would say less than nothing.
 func warnIfOffTheDefaultChannel(database *db.DB, name string, pkg *db.Package) {
 	current, err := database.ResolveTag(name, db.DefaultTag)
 	if err != nil || (current != nil && current.ContentHash == pkg.ContentHash) {
 		return
 	}
-	fmt.Printf("  %s %s was restored on a build the %s tag does not name, so it now follows %s\n",
-		iconWarn(), name, db.DefaultTag, db.DefaultTag)
-	fmt.Printf("      If it was added under a dist-tag, run 'lnpm add %s@<tag>' to follow that channel again\n", name)
+
+	tags, err := database.TagsForPackage(name)
+	if err != nil {
+		return
+	}
+
+	// The default tag is not among these: it names other content, or nothing.
+	if naming := tagsNamingList(tags, pkg.ContentHash); len(naming) > 0 {
+		fmt.Printf("  %s %s was restored on the build tagged %s, but the restored link follows %s\n",
+			iconWarn(), name, strings.Join(naming, ", "), db.DefaultTag)
+		fmt.Printf("      If it was added under a dist-tag, run 'lnpm add %s@<tag>' to follow that channel again\n", name)
+		return
+	}
+
+	fmt.Printf("  %s %s has been published since the retreat, so the build restored is no longer the one %s names\n",
+		iconWarn(), name, db.DefaultTag)
+	fmt.Printf("      Run 'lnpm pull' to move onto the current release\n")
 }
 
 // dependencyFieldKnown reports whether package.json still says which dependency

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -28,13 +28,19 @@ import (
 // the snapshot for the re-run it advises, and the re-run then sees only what is
 // genuinely left.
 //
-// Two parts of the pre-retreat state cannot be rebuilt from the snapshot,
-// because the lock file records neither. The first is whether a package was
-// added with --link: everything is restored as a store copy, which is what the
-// file:.lnpm/<pkg> specifier the command writes describes. The second is which
-// dependency field a package belonged in; that is recovered from package.json,
-// where retreat has just put the original specifier back, and reported when the
-// package has no entry there to recover it from.
+// Which build each package was on is rebuilt exactly: the snapshot records a
+// content hash, and that names one version of one package however many of them
+// the store holds.
+//
+// Three parts of the pre-retreat state cannot be rebuilt, because the lock file
+// records none of them. The first is whether a package was added with --link:
+// everything is restored as a store copy, which is what the file:.lnpm/<pkg>
+// specifier the command writes describes. The second is which dependency field
+// a package belonged in; that is recovered from package.json, where retreat has
+// just put the original specifier back, and reported when the package has no
+// entry there to recover it from. The third is the dist-tag a package was added
+// under: the restored link follows the default channel, and a package restored
+// on a build that channel does not name is reported.
 func RunRestore() error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -123,22 +129,36 @@ func RunRestore() error {
 		}
 		attempted++
 
-		// The store keeps the latest published version per package, so the
-		// version the snapshot recorded may since have been superseded. Report
-		// it the way add does and carry on with the rest.
-		pkg, err := database.GetPackageByName(name)
+		// Resolved through the content hash the snapshot recorded, which names
+		// one build of one package exactly. Resolving by name would answer with
+		// whatever the default tag points at, and the store can hold several
+		// versions of a name at once now: a consumer that was on another channel
+		// would have had the build it asked for reported as missing while it sat
+		// in the store, and a consumer on the default channel would be put back
+		// on a release it never linked.
+		//
+		// A snapshot written before the lock file recorded hashes has none, and
+		// falls back to the name it always resolved through.
+		var pkg *db.Package
+		if entry.Hash != "" {
+			pkg, err = database.GetPackageByHash(name, entry.Hash)
+		} else {
+			pkg, err = database.GetPackageByName(name)
+		}
 		if err != nil {
 			fmt.Printf("  %s %s: failed to look up package: %v\n", iconFail(), name, err)
 			failed++
 			continue
 		}
 		if pkg == nil {
-			fmt.Printf("  %s %s: not found in store. Did you run 'lnpm publish' in the package directory?\n", iconFail(), name)
-			failed++
-			continue
-		}
-		if entry.Version != "" && pkg.Version != entry.Version {
-			fmt.Printf("  %s %s: %v\n", iconFail(), name, versionNotInStoreError(entry.Version, name, pkg.Version))
+			// Reported per package and not fatal, so one collected build does not
+			// abort the rest of the restore.
+			if entry.Hash == "" {
+				fmt.Printf("  %s %s: not found in store. Did you run 'lnpm publish' in the package directory?\n", iconFail(), name)
+			} else {
+				fmt.Printf("  %s %s@%s (hash %s) is no longer in the store; re-publish it, then re-run 'lnpm restore'\n",
+					iconFail(), name, entry.Version, shortHash(entry.Hash))
+			}
 			failed++
 			continue
 		}
@@ -206,6 +226,7 @@ func RunRestore() error {
 		consumeSnapshotEntry(snapshot, cwd, name)
 
 		recordRestoredLink(database, cwd, pkg, linkRes.Type)
+		warnIfOffTheDefaultChannel(database, name, pkg)
 
 		fmt.Printf("%s Restored %s@%s\n", iconOK(), name, pkg.Version)
 		restored++
@@ -279,6 +300,13 @@ func recordRestoredLink(database *db.DB, cwd string, pkg *db.Package, linkType l
 		return
 	}
 
+	// The link follows the default tag, which is what an unset Tag means. Nothing
+	// records the channel a consumer was on: the lock file has never held one, so
+	// neither does the snapshot retreat writes from it. Guessing from the tags
+	// that happen to name this build today would be a guess about what someone
+	// asked for months ago, and a wrong one is worse than none - it would have
+	// later publishes carry the project down a channel it never chose.
+	// warnIfOffTheDefaultChannel says so out loud instead.
 	dbLink := &db.Link{
 		PackageID: pkg.ID,
 		ProjectID: existingProj.ID,
@@ -287,6 +315,29 @@ func recordRestoredLink(database *db.DB, cwd string, pkg *db.Package, linkType l
 	if err := database.InsertLink(dbLink); err != nil {
 		fmt.Printf("  %s Failed to record link for %s: %v\n", iconWarn(), pkg.Name, err)
 	}
+}
+
+// warnIfOffTheDefaultChannel reports that a restored package is on a build the
+// default tag does not name, which means the project was following some other
+// channel before the retreat and is not following it now.
+//
+// This is the third thing restore cannot rebuild from the snapshot, alongside
+// whether a package was added with --link and which dependency field it was in.
+// Left unsaid it would surface later and elsewhere: the files are right, so
+// nothing looks wrong until the next `lnpm pull` reads the restored link as a
+// default-channel one and moves the project onto the stable release.
+//
+// A failure to read the tag is not reported. The warning is advice about a state
+// restore has already left the project in, and turning a failed read into a
+// second warning about the first would say less than nothing.
+func warnIfOffTheDefaultChannel(database *db.DB, name string, pkg *db.Package) {
+	current, err := database.ResolveTag(name, db.DefaultTag)
+	if err != nil || (current != nil && current.ContentHash == pkg.ContentHash) {
+		return
+	}
+	fmt.Printf("  %s %s was restored on a build the %s tag does not name, so it now follows %s\n",
+		iconWarn(), name, db.DefaultTag, db.DefaultTag)
+	fmt.Printf("      If it was added under a dist-tag, run 'lnpm add %s@<tag>' to follow that channel again\n", name)
 }
 
 // dependencyFieldKnown reports whether package.json still says which dependency

--- a/internal/cli/retreat.go
+++ b/internal/cli/retreat.go
@@ -80,10 +80,12 @@ func RunRetreat(force bool, runInstall bool) error {
 	// Get database for cleanup
 	database, _ := db.GetDB()
 
-	// Get current project
+	// Get current project, and the links it actually holds
 	var proj *db.Project
+	var held projectLinks
 	if database != nil {
 		proj, _ = database.GetProjectByPath(cwd)
+		held, _ = linksOfProject(database, cwd)
 	}
 
 	// Remove each linked package
@@ -118,11 +120,13 @@ func RunRetreat(force bool, runInstall bool) error {
 			}
 		}
 
-		// Remove link from database
+		// Remove link from database. The row this project holds, not the one a
+		// lookup by name would find: the name index mirrors the default tag, so
+		// for a project on a tagged version that lookup names a different record
+		// and the delete would silently match nothing.
 		if database != nil && proj != nil {
-			dbPkg, _ := database.GetPackageByName(name)
-			if dbPkg != nil {
-				_ = database.DeleteLink(dbPkg.ID, proj.ID)
+			if l, ok := held[name]; ok {
+				_ = database.DeleteLink(l.PackageID, proj.ID)
 			}
 		}
 	}

--- a/internal/cli/retreat.go
+++ b/internal/cli/retreat.go
@@ -80,12 +80,25 @@ func RunRetreat(force bool, runInstall bool) error {
 	// Get database for cleanup
 	database, _ := db.GetDB()
 
-	// Get current project, and the links it actually holds
+	// Get current project, and the links it actually holds.
+	//
+	// A failed read is returned rather than read as "this project holds no
+	// links", which is what remove does with the same call for the same reason:
+	// the rows are how the link this project actually holds is found, and
+	// treating a failure as an empty set would leave every one of them behind
+	// while the retreat reported success. Nothing has been removed yet at this
+	// point, so returning here leaves the project untouched.
+	//
+	// A database that would not open at all is still tolerated, as it always was:
+	// then there are no rows to clean up and no read to fail.
 	var proj *db.Project
 	var held projectLinks
 	if database != nil {
 		proj, _ = database.GetProjectByPath(cwd)
-		held, _ = linksOfProject(database, cwd)
+		held, err = linksOfProject(database, cwd)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Remove each linked package

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -40,15 +40,19 @@ func RunStatus() error {
 		fmt.Println("  (none)")
 	} else {
 		// Print header
-		fmt.Printf("  %-25s %-14s %-10s %-16s %-20s\n", "NAME", "VERSION", "HASH", "TAGS", "PUBLISHED")
-		fmt.Printf("  %s\n", hrule(88))
+		// The rule is as wide as the columns and their separators: 25+14+10+20+20
+		// plus the four single spaces between them. The tag column is wide enough
+		// for three tags - "latest, beta, next" is 18 - because a version that
+		// several channels name is the one a reader most needs spelled out.
+		fmt.Printf("  %-25s %-14s %-10s %-20s %-20s\n", "NAME", "VERSION", "HASH", "TAGS", "PUBLISHED")
+		fmt.Printf("  %s\n", hrule(93))
 
 		for _, pkg := range packages {
-			fmt.Printf("  %-25s %-14s %-10s %-16s %-20s\n",
+			fmt.Printf("  %-25s %-14s %-10s %-20s %-20s\n",
 				truncate(pkg.Name, 25),
 				truncate(pkg.Version, 14),
 				shortHash(pkg.ContentHash),
-				truncate(strings.Join(tagsNamingList(tagsByName[pkg.Name], pkg.ContentHash), ", "), 16),
+				truncate(strings.Join(tagsNamingList(tagsByName[pkg.Name], pkg.ContentHash), ", "), 20),
 				formatTimeAgo(pkg.UpdatedAt),
 			)
 		}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -23,20 +24,31 @@ func RunStatus() error {
 		return fmt.Errorf("failed to list packages: %w", err)
 	}
 
+	// Tags of each name, read once per name however many of its versions the
+	// store holds. The table lists one row per retained version, so without the
+	// tags two rows of one name say nothing about which of them a plain add
+	// resolves to - and a name whose tags cannot be read would print rows that
+	// claim it has none.
+	tagsByName, err := tagsOfPackages(database, packages)
+	if err != nil {
+		return err
+	}
+
 	// Print packages section
 	fmt.Println(header("📦", "Published Packages"))
 	if len(packages) == 0 {
 		fmt.Println("  (none)")
 	} else {
 		// Print header
-		fmt.Printf("  %-25s %-12s %-10s %-20s\n", "NAME", "VERSION", "HASH", "PUBLISHED")
-		fmt.Printf("  %s\n", hrule(70))
+		fmt.Printf("  %-25s %-14s %-10s %-16s %-20s\n", "NAME", "VERSION", "HASH", "TAGS", "PUBLISHED")
+		fmt.Printf("  %s\n", hrule(88))
 
 		for _, pkg := range packages {
-			fmt.Printf("  %-25s %-12s %-10s %-20s\n",
+			fmt.Printf("  %-25s %-14s %-10s %-16s %-20s\n",
 				truncate(pkg.Name, 25),
-				truncate(pkg.Version, 12),
+				truncate(pkg.Version, 14),
 				shortHash(pkg.ContentHash),
+				truncate(strings.Join(tagsNamingList(tagsByName[pkg.Name], pkg.ContentHash), ", "), 16),
 				formatTimeAgo(pkg.UpdatedAt),
 			)
 		}
@@ -124,21 +136,9 @@ func RunList(showStore bool, packageName string, showProjects bool) error {
 			return nil
 		}
 
-		// Tags of each name, read once per name however many of its versions the
-		// store holds. With more than one version live at a time this listing is
-		// the only place a user can see which of them a channel points at, so a
-		// name whose tags cannot be read fails the command rather than being
-		// printed as if it had none.
-		tagsByName := make(map[string]map[string]string)
-		for _, pkg := range packages {
-			if _, ok := tagsByName[pkg.Name]; ok {
-				continue
-			}
-			tags, err := database.TagsForPackage(pkg.Name)
-			if err != nil {
-				return fmt.Errorf("failed to read the tags of %s: %w", pkg.Name, err)
-			}
-			tagsByName[pkg.Name] = tags
+		tagsByName, err := tagsOfPackages(database, packages)
+		if err != nil {
+			return err
 		}
 
 		fmt.Println("Packages in store:")
@@ -154,28 +154,56 @@ func RunList(showStore bool, packageName string, showProjects bool) error {
 	}
 
 	if packageName != "" && showProjects {
-		// List projects using a specific package
-		pkg, err := database.GetPackageByName(packageName)
+		// Every version of the name, not the one it resolves to. The name index
+		// mirrors the default tag, so resolving by name would answer with the
+		// stable release and leave every project that asked for a channel out of
+		// a listing whose whole job is naming who consumes this package.
+		packages, err := database.ListPackages()
 		if err != nil {
-			return fmt.Errorf("failed to look up package: %w", err)
+			return fmt.Errorf("failed to list packages: %w", err)
 		}
-		if pkg == nil {
+		var versions []*db.Package
+		for _, pkg := range packages {
+			if pkg.Name == packageName {
+				versions = append(versions, pkg)
+			}
+		}
+		if len(versions) == 0 {
 			return fmt.Errorf("package %s not found", packageName)
 		}
 
-		projects, err := database.GetProjectsForPackage(pkg.ID)
+		tags, err := database.TagsForPackage(packageName)
 		if err != nil {
-			return fmt.Errorf("failed to get projects: %w", err)
+			return fmt.Errorf("failed to read the tags of %s: %w", packageName, err)
 		}
 
-		if len(projects) == 0 {
+		// Each line says which build the project is on, because that is what
+		// differs between them now and what a maintainer looking at this list is
+		// deciding from.
+		var lines []string
+		for _, version := range versions {
+			projects, err := database.GetProjectsForPackage(version.ID)
+			if err != nil {
+				return fmt.Errorf("failed to get projects: %w", err)
+			}
+			for _, proj := range projects {
+				lines = append(lines, fmt.Sprintf("  %s (%s) -> %s@%s%s",
+					proj.Path, proj.PackageManager, packageName, version.Version,
+					tagsNaming(tags, version.ContentHash)))
+			}
+		}
+
+		if len(lines) == 0 {
 			fmt.Printf("No projects using %s\n", packageName)
 			return nil
 		}
 
+		// Sorted, so a store holding several versions lists the same way on
+		// every run rather than in whatever order the records were written.
+		sort.Strings(lines)
 		fmt.Printf("Projects using %s:\n", packageName)
-		for _, proj := range projects {
-			fmt.Printf("  %s (%s)\n", proj.Path, proj.PackageManager)
+		for _, line := range lines {
+			fmt.Println(line)
 		}
 		return nil
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -124,9 +124,27 @@ func RunList(showStore bool, packageName string, showProjects bool) error {
 			return nil
 		}
 
+		// Tags of each name, read once per name however many of its versions the
+		// store holds. With more than one version live at a time this listing is
+		// the only place a user can see which of them a channel points at, so a
+		// name whose tags cannot be read fails the command rather than being
+		// printed as if it had none.
+		tagsByName := make(map[string]map[string]string)
+		for _, pkg := range packages {
+			if _, ok := tagsByName[pkg.Name]; ok {
+				continue
+			}
+			tags, err := database.TagsForPackage(pkg.Name)
+			if err != nil {
+				return fmt.Errorf("failed to read the tags of %s: %w", pkg.Name, err)
+			}
+			tagsByName[pkg.Name] = tags
+		}
+
 		fmt.Println("Packages in store:")
 		for _, pkg := range packages {
-			fmt.Printf("  %s@%s (%s)\n", pkg.Name, pkg.Version, shortHash(pkg.ContentHash))
+			fmt.Printf("  %s@%s (%s)%s\n", pkg.Name, pkg.Version, shortHash(pkg.ContentHash),
+				tagsNaming(tagsByName[pkg.Name], pkg.ContentHash))
 		}
 		return nil
 	}

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -38,6 +38,29 @@ func tagsNamingList(tags map[string]string, hash string) []string {
 	return naming
 }
 
+// tagsOfPackages reads the tags of every name in packages, once per name however
+// many of its versions the store holds.
+//
+// A name whose tags cannot be read fails the caller rather than being reported
+// as untagged. Both callers are listings whose point is saying which channel
+// names which build, and a row that silently claimed a version has no channel
+// would be worse than no row: it is exactly what a version gc is about to
+// collect looks like.
+func tagsOfPackages(database *db.DB, packages []*db.Package) (map[string]map[string]string, error) {
+	tagsByName := make(map[string]map[string]string)
+	for _, pkg := range packages {
+		if _, ok := tagsByName[pkg.Name]; ok {
+			continue
+		}
+		tags, err := database.TagsForPackage(pkg.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read the tags of %s: %w", pkg.Name, err)
+		}
+		tagsByName[pkg.Name] = tags
+	}
+	return tagsByName, nil
+}
+
 // projectLinks maps each package name a project consumes to the link row that
 // records it. An absent name is a package this project has no link for.
 type projectLinks map[string]*db.Link

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -30,6 +30,51 @@ func tagsNaming(tags map[string]string, hash string) string {
 	return " [" + strings.Join(naming, ", ") + "]"
 }
 
+// tagsFollowedByProject reports which channel the project at path follows for
+// each package it has linked, as package name to tag. A name absent from the
+// result, or present with an empty tag, follows the default one.
+//
+// The link row is the authority here rather than the lock file, because the lock
+// records what was linked and not what was asked for: two versions of a name can
+// be in the store at once now, and only the link says which channel the project
+// chose.
+//
+// A project not in the database yet - a lock file written by an add whose
+// database write failed, say - is not an error. It has no links to read, so
+// every package it holds falls back to the default tag, which is what the
+// caller would have done anyway.
+func tagsFollowedByProject(database *db.DB, path string) (map[string]string, error) {
+	proj, err := database.GetProjectByPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up this project: %w", err)
+	}
+	if proj == nil {
+		return nil, nil
+	}
+
+	links, err := database.GetLinksForProject(proj.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read this project's links: %w", err)
+	}
+
+	packages, err := database.ListPackages()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list packages: %w", err)
+	}
+	nameByID := make(map[int64]string, len(packages))
+	for _, pkg := range packages {
+		nameByID[pkg.ID] = pkg.Name
+	}
+
+	followed := make(map[string]string, len(links))
+	for _, l := range links {
+		if name, ok := nameByID[l.PackageID]; ok {
+			followed[name] = l.Tag
+		}
+	}
+	return followed, nil
+}
+
 // RunTag manages a dist-tag on a package already in the store, without
 // republishing it.
 //

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -130,13 +130,20 @@ func RunTag(packageName, tag string, del bool) error {
 	return nil
 }
 
+// isDefaultTag reports whether tag is the one every lookup by name resolves
+// through. An empty tag counts: that is how a link written before tags existed
+// reads, and what an unset --tag carries.
+func isDefaultTag(tag string) bool {
+	return tag == "" || tag == db.DefaultTag
+}
+
 // tagNote names a tag for output, and says nothing at all for the default one.
 //
 // The default tag is left unsaid because every publish moves it: spelling it out
 // would add a clause to every line lnpm has ever printed while saying only what
 // was already true. A tag is worth naming exactly when someone chose it.
 func tagNote(tag string) string {
-	if tag == "" || tag == db.DefaultTag {
+	if isDefaultTag(tag) {
 		return ""
 	}
 	return "tag: " + tag

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"github.com/pedrosousa13/lnpm/internal/db"
+)
+
+// tagNote names a tag for output, and says nothing at all for the default one.
+//
+// The default tag is left unsaid because every publish moves it: spelling it out
+// would add a clause to every line lnpm has ever printed while saying only what
+// was already true. A tag is worth naming exactly when someone chose it.
+func tagNote(tag string) string {
+	if tag == "" || tag == db.DefaultTag {
+		return ""
+	}
+	return "tag: " + tag
+}
+
+// tagSuffix is tagNote as a trailing parenthetical, for a line that has none of
+// its own.
+func tagSuffix(tag string) string {
+	note := tagNote(tag)
+	if note == "" {
+		return ""
+	}
+	return " (" + note + ")"
+}
+
+// tagClause is tagNote folded into a parenthetical a line already carries, so a
+// tagged publish reads "(3 files, tag: beta)" rather than trailing a second pair
+// of brackets behind the first.
+func tagClause(tag string) string {
+	note := tagNote(tag)
+	if note == "" {
+		return ""
+	}
+	return ", " + note
+}

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -2,9 +2,33 @@ package cli
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/pedrosousa13/lnpm/internal/db"
 )
+
+// tagsNaming renders every tag in tags that points at hash, as a trailing
+// " [beta, latest]", and nothing when none does.
+//
+// Sorted, because bolt hands back a map and an unordered listing would reshuffle
+// itself between runs of the same command over an unchanged store. The default
+// tag is included here, unlike in the running commentary the other helpers
+// produce: this listing exists to say which version each channel names, and
+// latest is the channel most readers came to find.
+func tagsNaming(tags map[string]string, hash string) string {
+	var naming []string
+	for tag, tagged := range tags {
+		if tagged == hash {
+			naming = append(naming, tag)
+		}
+	}
+	if len(naming) == 0 {
+		return ""
+	}
+	sort.Strings(naming)
+	return " [" + strings.Join(naming, ", ") + "]"
+}
 
 // RunTag manages a dist-tag on a package already in the store, without
 // republishing it.

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -30,20 +30,34 @@ func tagsNaming(tags map[string]string, hash string) string {
 	return " [" + strings.Join(naming, ", ") + "]"
 }
 
-// tagsFollowedByProject reports which channel the project at path follows for
-// each package it has linked, as package name to tag. A name absent from the
-// result, or present with an empty tag, follows the default one.
+// projectLinks maps each package name a project consumes to the link row that
+// records it. An absent name is a package this project has no link for.
+type projectLinks map[string]*db.Link
+
+// tag returns the channel the project follows for name, reading an absent or
+// untagged link as the default one.
+func (p projectLinks) tag(name string) string {
+	if l, ok := p[name]; ok {
+		return l.Tag
+	}
+	return ""
+}
+
+// linksOfProject reads the links the project at path holds, keyed by package
+// name.
 //
-// The link row is the authority here rather than the lock file, because the lock
-// records what was linked and not what was asked for: two versions of a name can
-// be in the store at once now, and only the link says which channel the project
-// chose.
+// Looking a package up by name instead is what every command used to do, and it
+// stopped being enough once two versions of a name could be in the store at
+// once: the name index mirrors the default tag, so a name lookup answers with
+// the version tagged latest whatever version the project is actually on. The
+// link row is the only record of which one that is, and of which channel the
+// project asked for - the lock file says what was linked, not what was
+// requested.
 //
-// A project not in the database yet - a lock file written by an add whose
-// database write failed, say - is not an error. It has no links to read, so
-// every package it holds falls back to the default tag, which is what the
-// caller would have done anyway.
-func tagsFollowedByProject(database *db.DB, path string) (map[string]string, error) {
+// A project not in the database - a lock file written by an add whose database
+// write failed, say - is not an error. It holds no links, so every caller falls
+// back to what it would have done anyway.
+func linksOfProject(database *db.DB, path string) (projectLinks, error) {
 	proj, err := database.GetProjectByPath(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to look up this project: %w", err)
@@ -66,13 +80,13 @@ func tagsFollowedByProject(database *db.DB, path string) (map[string]string, err
 		nameByID[pkg.ID] = pkg.Name
 	}
 
-	followed := make(map[string]string, len(links))
+	held := make(projectLinks, len(links))
 	for _, l := range links {
 		if name, ok := nameByID[l.PackageID]; ok {
-			followed[name] = l.Tag
+			held[name] = l
 		}
 	}
-	return followed, nil
+	return held, nil
 }
 
 // RunTag manages a dist-tag on a package already in the store, without

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -1,8 +1,51 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/pedrosousa13/lnpm/internal/db"
 )
+
+// RunTag manages a dist-tag on a package already in the store, without
+// republishing it.
+//
+// Setting points the tag at the version the package resolves to by name - the
+// one tagged latest - because that is the version a publish just wrote and the
+// only one a user can name without knowing content hashes. Deleting takes the
+// tag off and leaves that version in the store, still reachable by name.
+//
+// The database refuses two things, and both refusals are passed through rather
+// than worked around: a tag on a version no record holds, and a delete of the
+// default tag, which the name index mirrors.
+func RunTag(packageName, tag string, del bool) error {
+	database, err := db.GetDB()
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+
+	if del {
+		if err := database.DeleteTag(packageName, tag); err != nil {
+			return err
+		}
+		fmt.Printf("%s Removed tag %s from %s\n", iconOK(), tag, packageName)
+		return nil
+	}
+
+	pkg, err := database.GetPackageByName(packageName)
+	if err != nil {
+		return fmt.Errorf("failed to look up package: %w", err)
+	}
+	if pkg == nil {
+		return fmt.Errorf("package %s not found in store. Did you run 'lnpm publish' in the package directory?", packageName)
+	}
+
+	if err := database.SetTag(packageName, tag, pkg.ContentHash); err != nil {
+		return err
+	}
+
+	fmt.Printf("%s Tagged %s@%s as %s\n", iconOK(), pkg.Name, pkg.Version, tag)
+	return nil
+}
 
 // tagNote names a tag for output, and says nothing at all for the default one.
 //

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -17,17 +17,25 @@ import (
 // produce: this listing exists to say which version each channel names, and
 // latest is the channel most readers came to find.
 func tagsNaming(tags map[string]string, hash string) string {
+	naming := tagsNamingList(tags, hash)
+	if len(naming) == 0 {
+		return ""
+	}
+	return " [" + strings.Join(naming, ", ") + "]"
+}
+
+// tagsNamingList returns, sorted, every tag in tags that points at hash. It is
+// tagsNaming without the rendering, for the callers that lay the tags out
+// themselves or count them.
+func tagsNamingList(tags map[string]string, hash string) []string {
 	var naming []string
 	for tag, tagged := range tags {
 		if tagged == hash {
 			naming = append(naming, tag)
 		}
 	}
-	if len(naming) == 0 {
-		return ""
-	}
 	sort.Strings(naming)
-	return " [" + strings.Join(naming, ", ") + "]"
+	return naming
 }
 
 // projectLinks maps each package name a project consumes to the link row that

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -224,13 +224,21 @@ func initDB() (*DB, error) {
 // which is what makes the pass safe to interrupt — bolt commits it whole or not
 // at all, and re-running it writes the same entries again.
 //
-// A database written by a newer build is left alone rather than rewritten
-// backwards. Guessing at a schema this build does not know would be guessing
-// about which files gc may delete.
+// A database written by a newer build is refused, not migrated backwards and not
+// merely left alone. Guessing at a schema this build does not know would be
+// guessing about which files gc may delete - and declining to migrate while
+// letting the session carry on is exactly that guess, made silently: the very
+// next command would read the store through this build's rules. Refusing at open
+// is the only place the guess can be avoided rather than deferred.
 func migrateTx(tx *bolt.Tx) error {
 	meta := tx.Bucket(bucketMeta)
-	if v := meta.Get(keySchemaVersion); len(v) == 8 && btoi(v) >= schemaVersion {
-		return nil
+	if v := meta.Get(keySchemaVersion); len(v) == 8 {
+		switch recorded := btoi(v); {
+		case recorded > schemaVersion:
+			return fmt.Errorf("the store was written by a newer lnpm (schema version %d; this build understands %d): upgrade lnpm to use it", recorded, schemaVersion)
+		case recorded == schemaVersion:
+			return nil
+		}
 	}
 
 	packages := tx.Bucket(bucketPackages)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -109,12 +109,28 @@ type Project struct {
 
 // Link represents a link between a package and a project
 type Link struct {
-	ID        int64     `json:"id"`
-	PackageID int64     `json:"package_id"`
-	ProjectID int64     `json:"project_id"`
-	LinkType  string    `json:"link_type"`
+	ID        int64  `json:"id"`
+	PackageID int64  `json:"package_id"`
+	ProjectID int64  `json:"project_id"`
+	LinkType  string `json:"link_type"`
+	// Tag is the channel the project follows. When that tag is moved to
+	// another version - by a publish, or by tagging a version already in the
+	// store - this link is carried across to it, so the project keeps
+	// consuming the package it asked for rather than the release it happened
+	// to be pinned to. Empty means DefaultTag, which is what every link
+	// written before tags existed meant.
+	Tag       string    `json:"tag,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// tag returns the channel a link follows, reading an unset tag as the default
+// one. Links written before tags existed carry none.
+func (l *Link) tag() string {
+	if l.Tag == "" {
+		return DefaultTag
+	}
+	return l.Tag
 }
 
 // FileEntry represents a file in a package
@@ -379,34 +395,31 @@ func (db *DB) InsertPackageWithFilesTagged(pkg *Package, files []*FileEntry, tag
 // caller so it can share one with insertFilesTx.
 func (db *DB) insertPackageTx(tx *bolt.Tx, pkg *Package, tag string) error {
 	packages := tx.Bucket(bucketPackages)
-	byName := tx.Bucket(bucketPackagesByName)
 
-	// Check if package with same name exists (update case)
-	if existingIDBytes := byName.Get([]byte(pkg.Name)); existingIDBytes != nil {
-		existingID := btoi(existingIDBytes)
-		if data := packages.Get(itob(existingID)); data != nil {
-			var existing Package
-			if err := json.Unmarshal(data, &existing); err == nil {
-				// Update existing package
-				existing.Version = pkg.Version
-				existing.ContentHash = pkg.ContentHash
-				existing.SourcePath = pkg.SourcePath
-				existing.StorePath = pkg.StorePath
-				existing.FilesCount = pkg.FilesCount
-				existing.TotalSize = pkg.TotalSize
-				existing.UpdatedAt = time.Now()
-				pkg.ID = existing.ID
+	// A record is addressed by name and content hash. Publishing the same
+	// content again describes the same version, and updates it in place;
+	// publishing different content adds a version beside the ones already
+	// there instead of displacing them, which is what lets two tags name
+	// genuinely different content. Which version a name resolves to is decided
+	// by the tag, below, and not by which record was written last.
+	if existing := findPackageByHashTx(tx, pkg.Name, pkg.ContentHash); existing != nil {
+		existing.Version = pkg.Version
+		existing.SourcePath = pkg.SourcePath
+		existing.StorePath = pkg.StorePath
+		existing.FilesCount = pkg.FilesCount
+		existing.TotalSize = pkg.TotalSize
+		existing.UpdatedAt = time.Now()
+		pkg.ID = existing.ID
+		pkg.CreatedAt = existing.CreatedAt
 
-				data, err := json.Marshal(&existing)
-				if err != nil {
-					return err
-				}
-				if err := packages.Put(itob(existing.ID), data); err != nil {
-					return err
-				}
-				return setTagTx(tx, pkg.Name, tag, pkg.ContentHash, pkg.ID)
-			}
+		data, err := json.Marshal(existing)
+		if err != nil {
+			return err
 		}
+		if err := packages.Put(itob(existing.ID), data); err != nil {
+			return err
+		}
+		return setTagTx(tx, pkg.Name, tag, pkg.ContentHash, pkg.ID)
 	}
 
 	// Insert new package
@@ -427,34 +440,157 @@ func (db *DB) insertPackageTx(tx *bolt.Tx, pkg *Package, tag string) error {
 		return err
 	}
 
-	// Index by name
-	if err := byName.Put([]byte(pkg.Name), itob(id)); err != nil {
-		return err
-	}
-
 	return setTagTx(tx, pkg.Name, tag, pkg.ContentHash, pkg.ID)
 }
 
 // --- Tag operations ---
 
 // setTagTx points name's tag at hash, which belongs to the record with the given
-// id.
+// id, and carries the projects that follow that tag across to it.
 //
 // Setting the default tag also moves the name index, because the two say the
 // same thing: bucketPackagesByName names the version tagged DefaultTag. Letting
 // them disagree would give GetPackageByName and ResolveTag different answers to
 // the same question.
+//
+// A package's first version is given the default tag as well as the one asked
+// for. Every command but a tag-aware add reaches a package through the name
+// index, so a package published only under some other tag would sit in the store
+// and on disk while push, remove, restore and status could not see it at all.
 func setTagTx(tx *bolt.Tx, name, tag, hash string, id int64) error {
 	if tag == "" {
 		tag = DefaultTag
 	}
-	if err := tx.Bucket(bucketTags).Put(tagKey(name, tag), []byte(hash)); err != nil {
+
+	tags := tx.Bucket(bucketTags)
+	byName := tx.Bucket(bucketPackagesByName)
+
+	// Whatever the tag named before this, so the projects following it can be
+	// carried across. Read before the Put that overwrites it.
+	var previous *Package
+	if prevHash := tags.Get(tagKey(name, tag)); prevHash != nil && string(prevHash) != hash {
+		previous = findPackageByHashTx(tx, name, string(prevHash))
+	}
+
+	if err := tags.Put(tagKey(name, tag), []byte(hash)); err != nil {
 		return err
 	}
+
 	if tag == DefaultTag {
-		return tx.Bucket(bucketPackagesByName).Put([]byte(name), itob(id))
+		if err := byName.Put([]byte(name), itob(id)); err != nil {
+			return err
+		}
+	} else if byName.Get([]byte(name)) == nil {
+		if err := setTagTx(tx, name, DefaultTag, hash, id); err != nil {
+			return err
+		}
 	}
-	return nil
+
+	if previous == nil || previous.ID == id {
+		return nil
+	}
+	return moveLinksTx(tx, previous.ID, id, tag)
+}
+
+// moveLinksTx repoints the links that follow tag from one version of a package
+// to another.
+//
+// A link says a project consumes a package, and every command that reads one -
+// push, publish --push, remove, retreat, status - finds it by looking the
+// package up by name. Leaving a link on the version a tag has moved off would
+// make those projects unreachable from the name they were linked under, so a
+// push would report no consumers and a remove would find nothing to unlink.
+//
+// Only the links following the tag that moved are carried across: a project that
+// asked for beta must not be dragged onto latest because the two tags happened
+// to name the same version. A project that already has a link on the
+// destination keeps that one and loses the duplicate, because everything that
+// reads links treats one row per project and package as given.
+func moveLinksTx(tx *bolt.Tx, fromID, toID int64, tag string) error {
+	links := tx.Bucket(bucketLinks)
+	byPackage := tx.Bucket(bucketLinksByPackage)
+	byProject := tx.Bucket(bucketLinksByProject)
+
+	fromIDs := indexIDs(byPackage, itob(fromID))
+	if len(fromIDs) == 0 {
+		return nil
+	}
+
+	toIDs := indexIDs(byPackage, itob(toID))
+	onDestination := make(map[int64]bool, len(toIDs))
+	for _, id := range toIDs {
+		if data := links.Get(itob(id)); data != nil {
+			var l Link
+			if json.Unmarshal(data, &l) == nil {
+				onDestination[l.ProjectID] = true
+			}
+		}
+	}
+
+	stay := make([]int64, 0, len(fromIDs))
+	for _, id := range fromIDs {
+		data := links.Get(itob(id))
+		if data == nil {
+			continue // Index entry naming no link row: drop it
+		}
+		var l Link
+		if err := json.Unmarshal(data, &l); err != nil || l.tag() != tag {
+			stay = append(stay, id)
+			continue
+		}
+
+		if onDestination[l.ProjectID] {
+			// The project already follows the destination version.
+			if err := links.Delete(itob(id)); err != nil {
+				return err
+			}
+			removeIDFromIndex(byProject, itob(l.ProjectID), id)
+			continue
+		}
+
+		l.PackageID = toID
+		l.UpdatedAt = time.Now()
+		moved, err := json.Marshal(&l)
+		if err != nil {
+			return err
+		}
+		if err := links.Put(itob(id), moved); err != nil {
+			return err
+		}
+		onDestination[l.ProjectID] = true
+		toIDs = append(toIDs, id)
+	}
+
+	if err := putIndexIDs(byPackage, itob(fromID), stay); err != nil {
+		return err
+	}
+	return putIndexIDs(byPackage, itob(toID), toIDs)
+}
+
+// indexIDs reads a link index entry, which holds a JSON array of link IDs.
+func indexIDs(b *bolt.Bucket, key []byte) []int64 {
+	data := b.Get(key)
+	if data == nil {
+		return nil
+	}
+	var ids []int64
+	if json.Unmarshal(data, &ids) != nil {
+		return nil
+	}
+	return ids
+}
+
+// putIndexIDs writes a link index entry, deleting the key when no IDs are left
+// so an empty index entry never outlives the links it named.
+func putIndexIDs(b *bolt.Bucket, key []byte, ids []int64) error {
+	if len(ids) == 0 {
+		return b.Delete(key)
+	}
+	data, err := json.Marshal(ids)
+	if err != nil {
+		return err
+	}
+	return b.Put(key, data)
 }
 
 // SetTag points a tag at a version already in the store, without republishing
@@ -636,12 +772,20 @@ func (db *DB) DeletePackage(id int64) error {
 		byPackage := tx.Bucket(bucketLinksByPackage)
 		byProject := tx.Bucket(bucketLinksByProject)
 
-		// Get package name for index cleanup
+		// Clean up the indexes that name this version.
+		//
+		// The name index is cleared only when it names this very record: a
+		// package can have several versions now, and dropping the entry while
+		// collecting a superseded one would unpublish a package whose current
+		// version is still in the store.
 		data := packages.Get(itob(id))
 		if data != nil {
 			var pkg Package
 			if json.Unmarshal(data, &pkg) == nil {
-				_ = byName.Delete([]byte(pkg.Name))
+				if current := byName.Get([]byte(pkg.Name)); current != nil && btoi(current) == id {
+					_ = byName.Delete([]byte(pkg.Name))
+				}
+				deleteTagsForHashTx(tx, pkg.Name, pkg.ContentHash)
 			}
 		}
 
@@ -669,6 +813,29 @@ func (db *DB) DeletePackage(id int64) error {
 		_ = files.Delete(itob(id))
 		return nil
 	})
+}
+
+// deleteTagsForHashTx removes every tag of name that points at hash. A tag left
+// naming a deleted version resolves to nothing and, since tags are what keeps a
+// version from being collected, would go on protecting nothing.
+//
+// The keys are collected before any is deleted rather than deleted through the
+// cursor, so the iteration does not depend on how bolt handles a cursor whose
+// current key has just been removed.
+func deleteTagsForHashTx(tx *bolt.Tx, name, hash string) {
+	tags := tx.Bucket(bucketTags)
+	prefix := tagPrefix(name)
+
+	var stale [][]byte
+	c := tags.Cursor()
+	for k, v := c.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, v = c.Next() {
+		if string(v) == hash {
+			stale = append(stale, append([]byte(nil), k...))
+		}
+	}
+	for _, k := range stale {
+		_ = tags.Delete(k)
+	}
 }
 
 // removeIDFromIndex removes id from the []int64 stored at key in bucket b,

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -405,11 +405,25 @@ func (db *DB) insertPackageTx(tx *bolt.Tx, pkg *Package, tag string) error {
 	packages := tx.Bucket(bucketPackages)
 
 	// A record is addressed by name and content hash. Publishing the same
-	// content again describes the same version, and updates it in place;
-	// publishing different content adds a version beside the ones already
-	// there instead of displacing them, which is what lets two tags name
-	// genuinely different content. Which version a name resolves to is decided
-	// by the tag, below, and not by which record was written last.
+	// content again updates that record in place; publishing different content
+	// adds a version beside the ones already there instead of displacing them,
+	// which is what lets two tags name genuinely different content. Which
+	// version a name resolves to is decided by the tag, below, and not by which
+	// record was written last.
+	//
+	// The update overwrites Version, which is what one record addressed by
+	// content forces: the same bytes cannot be two versions at once, so the
+	// newer publish's label is the one kept. Normally that is the only version
+	// there is, because package.json is inside the hash. It is not always:
+	// pack's walk tests the ignore rules before the default-include list, and
+	// the default-include list is consulted only under a "files" whitelist, so
+	// an .npmignore - or a .gitignore through the fallback - with a line reading
+	// package.json drops it from the pack, and two publishes differing only in
+	// version then hash the same. What that costs is a report: `lnpm status`
+	// shows the record under the newer version while the tag that named it has
+	// not moved. No consumer is affected, because the content really is
+	// identical. The fix belongs in pack, which unlike npm lets package.json be
+	// ignored at all.
 	if existing := findPackageByHashTx(tx, pkg.Name, pkg.ContentHash); existing != nil {
 		existing.Version = pkg.Version
 		existing.SourcePath = pkg.SourcePath

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -45,7 +46,36 @@ var (
 	bucketLinksByProject = []byte("links_by_project")
 	bucketFiles          = []byte("files")
 	bucketMeta           = []byte("meta")
+	bucketTags           = []byte("tags")
 )
+
+// DefaultTag is the tag a publish moves and the one every name-based lookup
+// resolves through: bucketPackagesByName always names the version it points at.
+const DefaultTag = "latest"
+
+// tagSeparator joins a package name and a tag into one bucket key. A package
+// name cannot contain a NUL byte, so the first one in a key always ends the
+// name — which is what lets the tags of one package be found by prefix.
+const tagSeparator = "\x00"
+
+func tagKey(name, tag string) []byte {
+	return []byte(name + tagSeparator + tag)
+}
+
+func tagPrefix(name string) []byte {
+	return []byte(name + tagSeparator)
+}
+
+// schemaVersion is the shape of the buckets this build writes. It is recorded in
+// bucketMeta so a database written by an older build can be brought forward on
+// open rather than silently read as if it were current.
+//
+//	1 — packages, one live record per name, no tags bucket.
+//	2 — a tags bucket, with the latest tag naming the record bucketPackagesByName
+//	    points at.
+const schemaVersion = 2
+
+var keySchemaVersion = []byte("schema_version")
 
 // DB wraps the bbolt database
 type DB struct {
@@ -151,13 +181,14 @@ func initDB() (*DB, error) {
 			bucketLinksByProject,
 			bucketFiles,
 			bucketMeta,
+			bucketTags,
 		}
 		for _, bucket := range buckets {
 			if _, err := tx.CreateBucketIfNotExists(bucket); err != nil {
 				return fmt.Errorf("failed to create bucket %s: %w", bucket, err)
 			}
 		}
-		return nil
+		return migrateTx(tx)
 	})
 	if err != nil {
 		_ = boltDB.Close()
@@ -165,6 +196,48 @@ func initDB() (*DB, error) {
 	}
 
 	return db, nil
+}
+
+// migrateTx brings a database written by an older build up to schemaVersion,
+// inside the transaction that created any buckets it was missing.
+//
+// Version 1 had no tags bucket: bucketPackagesByName was the only way to reach a
+// package, and the one record it named was by definition that package's latest.
+// So every name in that index gains a latest tag naming its record's content
+// hash, and nothing else changes. No record is rewritten and nothing is deleted,
+// which is what makes the pass safe to interrupt — bolt commits it whole or not
+// at all, and re-running it writes the same entries again.
+//
+// A database written by a newer build is left alone rather than rewritten
+// backwards. Guessing at a schema this build does not know would be guessing
+// about which files gc may delete.
+func migrateTx(tx *bolt.Tx) error {
+	meta := tx.Bucket(bucketMeta)
+	if v := meta.Get(keySchemaVersion); len(v) == 8 && btoi(v) >= schemaVersion {
+		return nil
+	}
+
+	packages := tx.Bucket(bucketPackages)
+	tags := tx.Bucket(bucketTags)
+
+	err := tx.Bucket(bucketPackagesByName).ForEach(func(name, idBytes []byte) error {
+		data := packages.Get(idBytes)
+		if data == nil {
+			// An index entry naming no record: there is no hash to tag, and
+			// inventing one would create a tag pointing at nothing.
+			return nil
+		}
+		var pkg Package
+		if err := json.Unmarshal(data, &pkg); err != nil {
+			return nil // Unreadable record, left exactly as it was found
+		}
+		return tags.Put(tagKey(string(name), DefaultTag), []byte(pkg.ContentHash))
+	})
+	if err != nil {
+		return fmt.Errorf("failed to record the %s tag of existing packages: %w", DefaultTag, err)
+	}
+
+	return meta.Put(keySchemaVersion, itob(schemaVersion))
 }
 
 // getStorePath returns the lnpm store path
@@ -258,12 +331,18 @@ func (db *DB) nextID(tx *bolt.Tx) (int64, error) {
 // of one package, and committing them separately lets a failure between them
 // leave a package row naming content its file rows do not describe.
 func (db *DB) InsertPackage(pkg *Package) error {
-	debug.Logf("db: insert package %s@%s", pkg.Name, pkg.Version)
+	return db.InsertPackageTagged(pkg, DefaultTag)
+}
+
+// InsertPackageTagged is InsertPackage, pointing tag at the package it records
+// instead of the default tag.
+func (db *DB) InsertPackageTagged(pkg *Package, tag string) error {
+	debug.Logf("db: insert package %s@%s (tag: %s)", pkg.Name, pkg.Version, tag)
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
 	return db.db.Update(func(tx *bolt.Tx) error {
-		return db.insertPackageTx(tx, pkg)
+		return db.insertPackageTx(tx, pkg, tag)
 	})
 }
 
@@ -278,12 +357,18 @@ func (db *DB) InsertPackage(pkg *Package) error {
 // transaction per write, and one transaction is what makes that state
 // unreachable.
 func (db *DB) InsertPackageWithFiles(pkg *Package, files []*FileEntry) error {
-	debug.Logf("db: insert package %s@%s with %d files", pkg.Name, pkg.Version, len(files))
+	return db.InsertPackageWithFilesTagged(pkg, files, DefaultTag)
+}
+
+// InsertPackageWithFilesTagged is InsertPackageWithFiles, pointing tag at the
+// package it records instead of the default tag.
+func (db *DB) InsertPackageWithFilesTagged(pkg *Package, files []*FileEntry, tag string) error {
+	debug.Logf("db: insert package %s@%s with %d files (tag: %s)", pkg.Name, pkg.Version, len(files), tag)
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
 	return db.db.Update(func(tx *bolt.Tx) error {
-		if err := db.insertPackageTx(tx, pkg); err != nil {
+		if err := db.insertPackageTx(tx, pkg, tag); err != nil {
 			return err
 		}
 		return db.insertFilesTx(tx, pkg.ID, files)
@@ -292,7 +377,7 @@ func (db *DB) InsertPackageWithFiles(pkg *Package, files []*FileEntry) error {
 
 // insertPackageTx is InsertPackage's body, taking the transaction from its
 // caller so it can share one with insertFilesTx.
-func (db *DB) insertPackageTx(tx *bolt.Tx, pkg *Package) error {
+func (db *DB) insertPackageTx(tx *bolt.Tx, pkg *Package, tag string) error {
 	packages := tx.Bucket(bucketPackages)
 	byName := tx.Bucket(bucketPackagesByName)
 
@@ -316,7 +401,10 @@ func (db *DB) insertPackageTx(tx *bolt.Tx, pkg *Package) error {
 				if err != nil {
 					return err
 				}
-				return packages.Put(itob(existing.ID), data)
+				if err := packages.Put(itob(existing.ID), data); err != nil {
+					return err
+				}
+				return setTagTx(tx, pkg.Name, tag, pkg.ContentHash, pkg.ID)
 			}
 		}
 	}
@@ -340,7 +428,135 @@ func (db *DB) insertPackageTx(tx *bolt.Tx, pkg *Package) error {
 	}
 
 	// Index by name
-	return byName.Put([]byte(pkg.Name), itob(id))
+	if err := byName.Put([]byte(pkg.Name), itob(id)); err != nil {
+		return err
+	}
+
+	return setTagTx(tx, pkg.Name, tag, pkg.ContentHash, pkg.ID)
+}
+
+// --- Tag operations ---
+
+// setTagTx points name's tag at hash, which belongs to the record with the given
+// id.
+//
+// Setting the default tag also moves the name index, because the two say the
+// same thing: bucketPackagesByName names the version tagged DefaultTag. Letting
+// them disagree would give GetPackageByName and ResolveTag different answers to
+// the same question.
+func setTagTx(tx *bolt.Tx, name, tag, hash string, id int64) error {
+	if tag == "" {
+		tag = DefaultTag
+	}
+	if err := tx.Bucket(bucketTags).Put(tagKey(name, tag), []byte(hash)); err != nil {
+		return err
+	}
+	if tag == DefaultTag {
+		return tx.Bucket(bucketPackagesByName).Put([]byte(name), itob(id))
+	}
+	return nil
+}
+
+// SetTag points a tag at a version already in the store, without republishing
+// it. The version is named by its content hash, and one that no record has is
+// refused: a tag pointing at nothing resolves to nothing, and once gc treats
+// tags as reachability roots it would also protect nothing.
+func (db *DB) SetTag(name, tag, hash string) error {
+	debug.Logf("db: set tag %s of %s to %s", tag, name, hash)
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	return db.db.Update(func(tx *bolt.Tx) error {
+		pkg := findPackageByHashTx(tx, name, hash)
+		if pkg == nil {
+			return fmt.Errorf("no version of %s with content hash %s is in the store", name, hash)
+		}
+		return setTagTx(tx, name, tag, hash, pkg.ID)
+	})
+}
+
+// DeleteTag removes a tag from a package, leaving the version it named in the
+// store.
+//
+// The default tag cannot be removed. It is what bucketPackagesByName mirrors, so
+// deleting it would leave the package published, its files on disk and its
+// record intact, while making it unreachable by name from every command lnpm
+// has.
+func (db *DB) DeleteTag(name, tag string) error {
+	if tag == "" {
+		tag = DefaultTag
+	}
+	if tag == DefaultTag {
+		return fmt.Errorf("cannot delete the %s tag of %s: it is the tag every lookup by name resolves through", DefaultTag, name)
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	return db.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(bucketTags).Delete(tagKey(name, tag))
+	})
+}
+
+// TagsForPackage returns every tag set on name, as tag to content hash.
+func (db *DB) TagsForPackage(name string) (map[string]string, error) {
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	tags := make(map[string]string)
+	err := db.db.View(func(tx *bolt.Tx) error {
+		prefix := tagPrefix(name)
+		c := tx.Bucket(bucketTags).Cursor()
+		for k, v := c.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, v = c.Next() {
+			tags[string(k[len(prefix):])] = string(v)
+		}
+		return nil
+	})
+
+	return tags, err
+}
+
+// ResolveTag returns the version a tag names, or nil when the tag is not set.
+// An empty tag means the default one.
+func (db *DB) ResolveTag(name, tag string) (*Package, error) {
+	if tag == "" {
+		tag = DefaultTag
+	}
+
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	var pkg *Package
+	err := db.db.View(func(tx *bolt.Tx) error {
+		hash := tx.Bucket(bucketTags).Get(tagKey(name, tag))
+		if hash == nil {
+			return nil
+		}
+		pkg = findPackageByHashTx(tx, name, string(hash))
+		return nil
+	})
+
+	return pkg, err
+}
+
+// findPackageByHashTx returns the record for one version of a package, or nil if
+// the store holds no such version.
+func findPackageByHashTx(tx *bolt.Tx, name, hash string) *Package {
+	var found *Package
+	_ = tx.Bucket(bucketPackages).ForEach(func(k, v []byte) error {
+		if found != nil {
+			return nil
+		}
+		var pkg Package
+		if err := json.Unmarshal(v, &pkg); err != nil {
+			return nil // Skip invalid entries
+		}
+		if pkg.Name == name && pkg.ContentHash == hash {
+			found = &pkg
+		}
+		return nil
+	})
+	return found
 }
 
 // GetPackageByName returns the latest package with the given name
@@ -378,18 +594,8 @@ func (db *DB) GetPackageByHash(name, hash string) (*Package, error) {
 
 	var result *Package
 	err := db.db.View(func(tx *bolt.Tx) error {
-		packages := tx.Bucket(bucketPackages)
-
-		return packages.ForEach(func(k, v []byte) error {
-			var pkg Package
-			if err := json.Unmarshal(v, &pkg); err != nil {
-				return nil // Skip invalid entries
-			}
-			if pkg.Name == name && pkg.ContentHash == hash {
-				result = &pkg
-			}
-			return nil
-		})
+		result = findPackageByHashTx(tx, name, hash)
+		return nil
 	})
 
 	return result, err

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -838,6 +838,31 @@ func deleteTagsForHashTx(tx *bolt.Tx, name, hash string) {
 	}
 }
 
+// packageNameTx returns the name of the package a record ID names, or "" when
+// no readable record has that ID.
+func packageNameTx(tx *bolt.Tx, id int64) string {
+	data := tx.Bucket(bucketPackages).Get(itob(id))
+	if data == nil {
+		return ""
+	}
+	var pkg Package
+	if json.Unmarshal(data, &pkg) != nil {
+		return ""
+	}
+	return pkg.Name
+}
+
+// deleteLinkRowTx removes one link row and scrubs it from both indexes, so no
+// index entry outlives the row it named.
+func deleteLinkRowTx(tx *bolt.Tx, linkID, packageID, projectID int64) error {
+	if err := tx.Bucket(bucketLinks).Delete(itob(linkID)); err != nil {
+		return err
+	}
+	removeIDFromIndex(tx.Bucket(bucketLinksByPackage), itob(packageID), linkID)
+	removeIDFromIndex(tx.Bucket(bucketLinksByProject), itob(projectID), linkID)
+	return nil
+}
+
 // removeIDFromIndex removes id from the []int64 stored at key in bucket b,
 // deleting the key entirely when the slice becomes empty.
 func removeIDFromIndex(b *bolt.Bucket, key []byte, id int64) {
@@ -969,9 +994,28 @@ func (db *DB) GetProjectByPath(path string) (*Project, error) {
 
 // --- Link operations ---
 
-// InsertLink creates a link between a package and project
+// InsertLink records that a project consumes a version of a package, replacing
+// whatever it consumed of that package before.
+//
+// A project holds one row per package name, and that is an invariant this
+// function is responsible for rather than one its callers happen to respect.
+// Everything downstream assumes it: moveLinksTx says so outright, linksOfProject
+// keys by name and would silently drop all but one of several rows, and remove
+// and retreat delete the one row that map hands them. A project has one
+// .lnpm/<name> and so consumes one version of one name; a second row is a second
+// answer to which.
+//
+// It is enforced here because the path that would break it is the one the whole
+// feature exists for. `lnpm add pkg@beta` in a project already on latest either
+// finds the row - when both tags name one version, which is what `lnpm tag`
+// produces - or does not, when they name two. Both have to end with one row
+// carrying the tag that was asked for: the first because a row updated without
+// its tag leaves the project recorded as a latest follower, which the next
+// publish drags forward; the second because the stale row goes on being carried
+// onto each new release, and `publish --push` then overwrites the channel
+// consumer's files with what latest names.
 func (db *DB) InsertLink(link *Link) error {
-	debug.Logf("db: insert link pkg=%d proj=%d", link.PackageID, link.ProjectID)
+	debug.Logf("db: insert link pkg=%d proj=%d tag=%q", link.PackageID, link.ProjectID, link.Tag)
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
@@ -980,39 +1024,53 @@ func (db *DB) InsertLink(link *Link) error {
 		byPackage := tx.Bucket(bucketLinksByPackage)
 		byProject := tx.Bucket(bucketLinksByProject)
 
-		// Check if link already exists
-		var existingLinkID int64
-		err := links.ForEach(func(k, v []byte) error {
-			var l Link
-			if err := json.Unmarshal(v, &l); err != nil {
-				return nil
-			}
-			if l.PackageID == link.PackageID && l.ProjectID == link.ProjectID {
-				existingLinkID = l.ID
-			}
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+		// The name the incoming link is for, so a row this project holds on
+		// another version of it can be recognised. An unreadable package record
+		// leaves this empty, which matches no row and so falls back to the
+		// same-record update alone rather than deleting on a guess.
+		name := packageNameTx(tx, link.PackageID)
 
-		if existingLinkID > 0 {
-			// Update existing link
-			data := links.Get(itob(existingLinkID))
-			if data != nil {
-				var existing Link
-				if json.Unmarshal(data, &existing) == nil {
-					existing.LinkType = link.LinkType
-					existing.UpdatedAt = time.Now()
-					link.ID = existing.ID
+		// indexIDs decodes into a slice of its own, so deleting rows below does
+		// not disturb this walk.
+		var updated bool
+		for _, id := range indexIDs(byProject, itob(link.ProjectID)) {
+			data := links.Get(itob(id))
+			if data == nil {
+				continue // Index entry naming no link row
+			}
+			var existing Link
+			if json.Unmarshal(data, &existing) != nil {
+				continue
+			}
 
-					data, err := json.Marshal(&existing)
-					if err != nil {
-						return err
-					}
-					return links.Put(itob(existing.ID), data)
+			switch {
+			case existing.PackageID == link.PackageID:
+				existing.LinkType = link.LinkType
+				// The tag too. Without it a project that switches channel onto
+				// the version it is already on keeps following the old one.
+				existing.Tag = link.Tag
+				existing.UpdatedAt = time.Now()
+				link.ID = existing.ID
+
+				encoded, err := json.Marshal(&existing)
+				if err != nil {
+					return err
+				}
+				if err := links.Put(itob(existing.ID), encoded); err != nil {
+					return err
+				}
+				updated = true
+
+			case name != "" && packageNameTx(tx, existing.PackageID) == name:
+				// Another version of the same package: the row this link
+				// replaces.
+				if err := deleteLinkRowTx(tx, existing.ID, existing.PackageID, existing.ProjectID); err != nil {
+					return err
 				}
 			}
+		}
+		if updated {
+			return nil
 		}
 
 		// Insert new link

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -457,6 +457,14 @@ func (db *DB) insertPackageTx(tx *bolt.Tx, pkg *Package, tag string) error {
 // for. Every command but a tag-aware add reaches a package through the name
 // index, so a package published only under some other tag would sit in the store
 // and on disk while push, remove, restore and status could not see it at all.
+//
+// That is a guarantee about what publishing does, not an invariant of the
+// database. gc can reach the state this avoids and does so deliberately: it
+// collects the version the default tag names when nothing links it, because that
+// tag is not a reachability root (ADR-0002), and DeletePackage then clears the
+// name index. What is left is a package reachable only by its other tags. The
+// next publish of that name restores the default tag, so the state is one gc can
+// produce and only a publish can clear.
 func setTagTx(tx *bolt.Tx, name, tag, hash string, id int64) error {
 	if tag == "" {
 		tag = DefaultTag
@@ -618,6 +626,14 @@ func (db *DB) SetTag(name, tag, hash string) error {
 // deleting it would leave the package published, its files on disk and its
 // record intact, while making it unreachable by name from every command lnpm
 // has.
+//
+// gc can leave a package in that state anyway, by collecting the version the
+// default tag names while another tag keeps an older one (ADR-0002). The refusal
+// here is not a claim that the state is unreachable, then. It is that reaching
+// it by deleting a tag would be a user asking for a package to stay published
+// and getting it hidden instead, where reaching it through gc is a version being
+// collected because nothing reached it - which is what gc is for, and which the
+// next publish of that name undoes.
 func (db *DB) DeleteTag(name, tag string) error {
 	if tag == "" {
 		tag = DefaultTag

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,6 +36,203 @@ func holdDatabaseLock(t *testing.T, storeDir string) *bolt.DB {
 	}
 	t.Cleanup(func() { _ = holder.Close() })
 	return holder
+}
+
+// writeSchemaV1Database writes a database in the shape the build before tags
+// wrote: no tags bucket, no schema version, and one record per package name in
+// bucketPackagesByName.
+//
+// The bucket names are spelled out rather than taken from the constants. What an
+// existing user's database holds is those literal names, so a rename that broke
+// every deployed store would have to fail here rather than travel silently into
+// both the fixture and the code under test.
+func writeSchemaV1Database(t *testing.T, storeDir string, packages ...*Package) {
+	t.Helper()
+
+	boltDB, err := bolt.Open(filepath.Join(storeDir, "lnpm.db"), 0600, &bolt.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Failed to create the old database: %v", err)
+	}
+	defer func() { _ = boltDB.Close() }()
+
+	err = boltDB.Update(func(tx *bolt.Tx) error {
+		for _, name := range []string{
+			"packages", "packages_by_name", "projects", "projects_by_path",
+			"links", "links_by_package", "links_by_project", "files", "meta",
+		} {
+			if _, err := tx.CreateBucketIfNotExists([]byte(name)); err != nil {
+				return err
+			}
+		}
+		nextID := int64(1)
+		for _, pkg := range packages {
+			pkg.ID = nextID
+			nextID++
+			data, err := json.Marshal(pkg)
+			if err != nil {
+				return err
+			}
+			if err := tx.Bucket([]byte("packages")).Put(itob(pkg.ID), data); err != nil {
+				return err
+			}
+			if err := tx.Bucket([]byte("packages_by_name")).Put([]byte(pkg.Name), itob(pkg.ID)); err != nil {
+				return err
+			}
+		}
+		return tx.Bucket([]byte("meta")).Put([]byte("next_id"), itob(nextID))
+	})
+	if err != nil {
+		t.Fatalf("Failed to seed the old database: %v", err)
+	}
+}
+
+// openStore points lnpm at storeDir and opens the database the way a command
+// would, so whatever initDB does on open is what the test exercises.
+func openStore(t *testing.T, storeDir string) *DB {
+	t.Helper()
+
+	ResetForTesting()
+	t.Setenv("LNPM_STORE", storeDir)
+	t.Cleanup(ResetForTesting)
+
+	database, err := GetDB()
+	if err != nil {
+		t.Fatalf("Failed to open the database: %v", err)
+	}
+	return database
+}
+
+// TestGetDB_UpgradesADatabaseWrittenWithoutTags pins the upgrade path for a
+// store an existing user already has. The record that name index pointed at was
+// that package's latest by definition, so opening the store has to say so —
+// otherwise the package is published, on disk and reachable by name, but no tag
+// reaches it, which is the state gc now collects.
+func TestGetDB_UpgradesADatabaseWrittenWithoutTags(t *testing.T) {
+	storeDir := t.TempDir()
+	writeSchemaV1Database(t, storeDir, &Package{
+		Name:        "legacy-pkg",
+		Version:     "1.2.3",
+		ContentHash: "legacyhash",
+		StorePath:   filepath.Join(storeDir, "store", "legacy-pkg", "legacyhash"),
+	})
+
+	database := openStore(t, storeDir)
+
+	pkg, err := database.GetPackageByName("legacy-pkg")
+	if err != nil || pkg == nil {
+		t.Fatalf("GetPackageByName after the upgrade = %v, %v; want the legacy package", pkg, err)
+	}
+	if pkg.ContentHash != "legacyhash" || pkg.Version != "1.2.3" {
+		t.Errorf("the upgrade rewrote the package record: %+v", pkg)
+	}
+
+	tags, err := database.TagsForPackage("legacy-pkg")
+	if err != nil {
+		t.Fatalf("TagsForPackage: %v", err)
+	}
+	if got := tags[DefaultTag]; got != "legacyhash" {
+		t.Errorf("the %s tag points at %q, want the hash the name index named", DefaultTag, got)
+	}
+	if len(tags) != 1 {
+		t.Errorf("the upgrade wrote %v, want only the %s tag", tags, DefaultTag)
+	}
+
+	resolved, err := database.ResolveTag("legacy-pkg", DefaultTag)
+	if err != nil || resolved == nil {
+		t.Fatalf("ResolveTag after the upgrade = %v, %v; want the legacy package", resolved, err)
+	}
+}
+
+// TestGetDB_UpgradeRecordsTheSchemaVersion pins the marker the upgrade leaves
+// behind, and that a second open leaves a tag that has moved since alone.
+//
+// The marker is what a later schema change will branch on, and it is what stops
+// the backfill re-reading every name on every command. It is asserted directly
+// because the backfill is idempotent on its own — bucketPackagesByName tracks
+// the latest tag, so re-running it writes what is already there — which means no
+// observable behaviour would betray a missing marker until the next migration
+// needed it, by which point it would be too late for the store that lost it.
+func TestGetDB_UpgradeRecordsTheSchemaVersion(t *testing.T) {
+	storeDir := t.TempDir()
+	writeSchemaV1Database(t, storeDir, &Package{
+		Name:        "legacy-pkg",
+		Version:     "1.0.0",
+		ContentHash: "hash-v1",
+	})
+
+	database := openStore(t, storeDir)
+	if err := database.InsertPackage(&Package{
+		Name:        "legacy-pkg",
+		Version:     "2.0.0",
+		ContentHash: "hash-v2",
+	}); err != nil {
+		t.Fatalf("publish a second version: %v", err)
+	}
+
+	// Re-open, as the next lnpm command would.
+	database = openStore(t, storeDir)
+
+	var recorded int64
+	if err := database.db.View(func(tx *bolt.Tx) error {
+		v := tx.Bucket(bucketMeta).Get(keySchemaVersion)
+		if len(v) == 8 {
+			recorded = btoi(v)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("read the schema version: %v", err)
+	}
+	if recorded != schemaVersion {
+		t.Errorf("the upgrade recorded schema version %d, want %d", recorded, schemaVersion)
+	}
+
+	tags, err := database.TagsForPackage("legacy-pkg")
+	if err != nil {
+		t.Fatalf("TagsForPackage: %v", err)
+	}
+	if tags[DefaultTag] != "hash-v2" {
+		t.Errorf("re-opening moved the %s tag to %q, want hash-v2", DefaultTag, tags[DefaultTag])
+	}
+}
+
+// TestGetDB_UpgradeToleratesADanglingNameIndex pins that a name index entry
+// naming a record that is not there does not stop the store opening. gc is the
+// command a user reaches for when the store is already damaged, and it cannot
+// run if opening the database fails.
+func TestGetDB_UpgradeToleratesADanglingNameIndex(t *testing.T) {
+	storeDir := t.TempDir()
+	writeSchemaV1Database(t, storeDir, &Package{
+		Name:        "good-pkg",
+		Version:     "1.0.0",
+		ContentHash: "goodhash",
+	})
+
+	boltDB, err := bolt.Open(filepath.Join(storeDir, "lnpm.db"), 0600, &bolt.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Failed to re-open the old database: %v", err)
+	}
+	err = boltDB.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte("packages_by_name")).Put([]byte("ghost-pkg"), itob(9999))
+	})
+	if err != nil {
+		t.Fatalf("Failed to seed the dangling index entry: %v", err)
+	}
+	if err := boltDB.Close(); err != nil {
+		t.Fatalf("Failed to close the old database: %v", err)
+	}
+
+	database := openStore(t, storeDir)
+
+	tags, err := database.TagsForPackage("ghost-pkg")
+	if err != nil {
+		t.Fatalf("TagsForPackage: %v", err)
+	}
+	if len(tags) != 0 {
+		t.Errorf("the upgrade tagged a name with no record: %v", tags)
+	}
+	if tags, _ := database.TagsForPackage("good-pkg"); tags[DefaultTag] != "goodhash" {
+		t.Errorf("the dangling entry stopped the rest of the upgrade: %v", tags)
+	}
 }
 
 // TestGetDB_LockHeldElsewhere_NamesTheOtherProcess checks that a database the

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -438,3 +438,132 @@ func TestGetDB_NonTimeoutFailure_DoesNotBlameAnotherProcess(t *testing.T) {
 		t.Errorf("Expected error not to blame another lnpm process, got: %v", err)
 	}
 }
+
+// writeLinkRow inserts a link row and its two index entries directly, bypassing
+// InsertLink.
+//
+// It exists because InsertLink now keeps one row per project and package name:
+// a second call for the same pair deletes the first row rather than adding
+// beside it, so the duplicate cannot be built through the public API any more.
+// A database written before that rule can still hold one, and moveLinksTx's
+// merge branch is the path that heals it, so the branch has to be reached with a
+// duplicate built the way such a database holds one.
+func writeLinkRow(t *testing.T, d *DB, link *Link) {
+	t.Helper()
+
+	err := d.db.Update(func(tx *bolt.Tx) error {
+		id, err := d.nextID(tx)
+		if err != nil {
+			return err
+		}
+		link.ID = id
+		link.CreatedAt = time.Now()
+		link.UpdatedAt = time.Now()
+
+		data, err := json.Marshal(link)
+		if err != nil {
+			return err
+		}
+		if err := tx.Bucket(bucketLinks).Put(itob(id), data); err != nil {
+			return err
+		}
+
+		for _, index := range []struct {
+			bucket *bolt.Bucket
+			key    []byte
+		}{
+			{tx.Bucket(bucketLinksByPackage), itob(link.PackageID)},
+			{tx.Bucket(bucketLinksByProject), itob(link.ProjectID)},
+		} {
+			if err := putIndexIDs(index.bucket, index.key, append(indexIDs(index.bucket, index.key), id)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to write a link row: %v", err)
+	}
+}
+
+// insertVersion records one version of a package under the default tag and
+// returns it with its assigned ID.
+func insertVersion(t *testing.T, d *DB, name, hash string) *Package {
+	t.Helper()
+
+	pkg := &Package{
+		Name:        name,
+		Version:     "1.0.0",
+		ContentHash: hash,
+		SourcePath:  "/src/" + name,
+		StorePath:   "/store/" + name + "/" + hash,
+		FilesCount:  1,
+		TotalSize:   1,
+	}
+	if err := d.InsertPackage(pkg); err != nil {
+		t.Fatalf("Failed to insert %s@%s: %v", name, hash, err)
+	}
+	return pkg
+}
+
+// TestSetTag_MergesADuplicateLinkAProjectHolds pins the healing path in
+// moveLinksTx: carrying links across a tag move must not leave a project holding
+// two rows for one package.
+//
+// Everything that reads links treats one row per project and package as given,
+// so a second row makes remove and gc report a link that nothing can clear. The
+// duplicate is written directly rather than through InsertLink, which now
+// prevents it - built through InsertLink the project would hold one row before
+// the tag ever moves, moveLinksTx would merely repoint it, and the branch this
+// test exists for would never be entered while every assertion still passed.
+func TestSetTag_MergesADuplicateLinkAProjectHolds(t *testing.T) {
+	database := openStore(t, t.TempDir())
+
+	v1 := insertVersion(t, database, "merge-pkg", "h1")
+	v2 := insertVersion(t, database, "merge-pkg", "h2")
+
+	projectPath := filepath.FromSlash("/projects/merger")
+	if err := database.InsertProject(&Project{Path: projectPath, Name: "merger"}); err != nil {
+		t.Fatalf("Failed to insert the project: %v", err)
+	}
+	proj, err := database.GetProjectByPath(projectPath)
+	if err != nil || proj == nil {
+		t.Fatalf("Failed to read the project back: %v", err)
+	}
+
+	writeLinkRow(t, database, &Link{PackageID: v1.ID, ProjectID: proj.ID, LinkType: "reflink"})
+	writeLinkRow(t, database, &Link{PackageID: v2.ID, ProjectID: proj.ID, LinkType: "reflink"})
+
+	before, err := database.GetLinksForProject(proj.ID)
+	if err != nil {
+		t.Fatalf("Failed to read the project's links: %v", err)
+	}
+	if len(before) != 2 {
+		t.Fatalf("The fixture holds %d link rows, want the duplicate this test exists for", len(before))
+	}
+
+	// Moving the default tag back onto the first version carries the second
+	// version's link across, into a project that already holds one there.
+	if err := database.SetTag("merge-pkg", DefaultTag, "h1"); err != nil {
+		t.Fatalf("Failed to move the default tag: %v", err)
+	}
+
+	links, err := database.GetLinksForProject(proj.ID)
+	if err != nil {
+		t.Fatalf("Failed to read the project's links: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("The project holds %d links to merge-pkg, want 1", len(links))
+	}
+	if links[0].PackageID != v1.ID {
+		t.Errorf("The surviving link names record %d, want the tagged version %d", links[0].PackageID, v1.ID)
+	}
+
+	projects, err := database.GetProjectsForPackage(v2.ID)
+	if err != nil {
+		t.Fatalf("Failed to read the consumers of the version moved off: %v", err)
+	}
+	if len(projects) != 0 {
+		t.Errorf("The version the tag moved off still has %d consumer(s)", len(projects))
+	}
+}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -235,6 +235,76 @@ func TestGetDB_UpgradeToleratesADanglingNameIndex(t *testing.T) {
 	}
 }
 
+// TestGetDB_RefusesADatabaseFromANewerBuild pins that a store written by a
+// build this one does not understand is refused at open rather than opened and
+// operated on.
+//
+// Declining to migrate it is not enough on its own. The session carries on, and
+// this build then applies its own rules to a database whose shape it is guessing
+// at - gc most of all, which decides what to delete from reachability roots that
+// a later schema may have moved.
+func TestGetDB_RefusesADatabaseFromANewerBuild(t *testing.T) {
+	storeDir := t.TempDir()
+	writeSchemaV1Database(t, storeDir, &Package{
+		Name:        "future-pkg",
+		Version:     "1.0.0",
+		ContentHash: "futurehash",
+	})
+	writeSchemaVersion(t, storeDir, schemaVersion+1)
+
+	ResetForTesting()
+	t.Setenv("LNPM_STORE", storeDir)
+	t.Cleanup(ResetForTesting)
+
+	database, err := GetDB()
+	if err == nil {
+		t.Fatal("GetDB opened a database written by a newer build, want a refusal")
+	}
+	if database != nil {
+		t.Errorf("GetDB returned a usable handle alongside the refusal: %v", database)
+	}
+	if !strings.Contains(err.Error(), "newer") {
+		t.Errorf("GetDB error = %v, want it to say the store is from a newer lnpm", err)
+	}
+}
+
+// TestGetDB_OpensADatabaseAtTheCurrentSchema is the other half: the refusal must
+// fire on a newer schema only, not on the one this build writes.
+func TestGetDB_OpensADatabaseAtTheCurrentSchema(t *testing.T) {
+	storeDir := t.TempDir()
+	writeSchemaV1Database(t, storeDir, &Package{
+		Name:        "current-pkg",
+		Version:     "1.0.0",
+		ContentHash: "currenthash",
+	})
+	writeSchemaVersion(t, storeDir, schemaVersion)
+
+	database := openStore(t, storeDir)
+	if pkg, err := database.GetPackageByName("current-pkg"); err != nil || pkg == nil {
+		t.Fatalf("GetPackageByName = %v, %v; want the package the store holds", pkg, err)
+	}
+}
+
+// writeSchemaVersion stamps a schema version onto an existing database, so a
+// test can present one this build did not write.
+func writeSchemaVersion(t *testing.T, storeDir string, version int64) {
+	t.Helper()
+
+	boltDB, err := bolt.Open(filepath.Join(storeDir, "lnpm.db"), 0600, &bolt.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("Failed to re-open the database: %v", err)
+	}
+	err = boltDB.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte("meta")).Put([]byte("schema_version"), itob(version))
+	})
+	if err != nil {
+		t.Fatalf("Failed to stamp schema version %d: %v", version, err)
+	}
+	if err := boltDB.Close(); err != nil {
+		t.Fatalf("Failed to close the database: %v", err)
+	}
+}
+
 // TestGetDB_LockHeldElsewhere_NamesTheOtherProcess checks that a database the
 // process cannot lock within the timeout is reported as a concurrency problem
 // rather than a bare "timeout".

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -840,42 +840,12 @@ func TestDatabaseLinksForAnotherTagStayWithTheirVersion(t *testing.T) {
 	}
 }
 
-// TestDatabaseMovingATagMergesADuplicateLink pins that carrying links across
-// does not leave a project holding two links to one package. Everything that
-// reads links treats one row per project as given, and a second row would make
-// remove and gc report a link that nothing can clear.
-func TestDatabaseMovingATagMergesADuplicateLink(t *testing.T) {
-	env := setupTest(t)
-
-	v1 := insertTagPkg(t, env.Database, "merge-pkg", "h1")
-	v2 := insertTagPkg(t, env.Database, "merge-pkg", "h2")
-	proj := insertProject(t, env.Database, filepath.FromSlash("/projects/merger"))
-
-	for _, id := range []int64{v1.ID, v2.ID} {
-		if err := env.Database.InsertLink(&db.Link{PackageID: id, ProjectID: proj.ID, LinkType: "reflink"}); err != nil {
-			t.Fatalf("insert link to record %d: %v", id, err)
-		}
-	}
-
-	// Move the default tag back to the first version, carrying its links.
-	if err := env.Database.SetTag("merge-pkg", db.DefaultTag, "h1"); err != nil {
-		t.Fatalf("move the default tag: %v", err)
-	}
-
-	links, err := env.Database.GetLinksForProject(proj.ID)
-	if err != nil {
-		t.Fatalf("links for the project: %v", err)
-	}
-	if len(links) != 1 {
-		t.Fatalf("the project holds %d links to merge-pkg, want 1", len(links))
-	}
-	if links[0].PackageID != v1.ID {
-		t.Errorf("the surviving link names record %d, want the tagged version %d", links[0].PackageID, v1.ID)
-	}
-	if got := linkedProjects(t, env.Database, v2.ID); len(got) != 0 {
-		t.Errorf("the untagged version still has %v linked", got)
-	}
-}
+// Moving a tag onto a version a project already holds a link to merges the two
+// rows, and that is pinned by TestSetTag_MergesADuplicateLinkAProjectHolds in
+// internal/db. It lives there rather than here because the duplicate it needs
+// cannot be built through InsertLink any more: a second call for one project and
+// one package name replaces the first row instead of adding beside it, so a
+// fixture built out here would leave moveLinksTx nothing to merge.
 
 // TestDatabaseInsertLinkKeepsOneRowPerProjectAndName pins the invariant
 // moveLinksTx states and linksOfProject, remove and retreat all rely on: a

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -274,8 +274,10 @@ func TestDatabasePackageUpdatePreservesLinks(t *testing.T) {
 		t.Fatalf("Failed to get links: %v", err)
 	}
 
+	// Fatal rather than an error: the assertion below indexes into links, and
+	// a failure that panics takes the rest of the package's tests with it.
 	if len(links) != 1 {
-		t.Errorf("Expected 1 link after update, got %d", len(links))
+		t.Fatalf("Expected 1 link after update, got %d", len(links))
 	}
 	if links[0].ProjectID != existingProj.ID {
 		t.Errorf("Expected the link to project %d, got %d", existingProj.ID, links[0].ProjectID)

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -204,7 +205,14 @@ func TestDatabaseConcurrentReadsWrites(t *testing.T) {
 	}
 }
 
-// TestDatabasePackageUpdatePreservesLinks tests that updating a package preserves links
+// TestDatabasePackageUpdatePreservesLinks tests that publishing a new version of
+// a package preserves the links to it.
+//
+// The link is asserted against whatever record the package name resolves to
+// rather than against the record it was created on. Those were the same thing
+// while a name had one record; now that a superseded version keeps its own
+// record, the link is carried across to the version the tag names, and the name
+// is how every command that reads links finds the package.
 func TestDatabasePackageUpdatePreservesLinks(t *testing.T) {
 	env := setupTest(t)
 
@@ -257,13 +265,20 @@ func TestDatabasePackageUpdatePreservesLinks(t *testing.T) {
 	}
 
 	// Verify link still exists
-	links, err := env.Database.GetLinksForPackage(pkg.ID)
+	current, err := env.Database.GetPackageByName("update-pkg")
+	if err != nil || current == nil {
+		t.Fatalf("Failed to look up update-pkg after the update: %v", err)
+	}
+	links, err := env.Database.GetLinksForPackage(current.ID)
 	if err != nil {
 		t.Fatalf("Failed to get links: %v", err)
 	}
 
 	if len(links) != 1 {
 		t.Errorf("Expected 1 link after update, got %d", len(links))
+	}
+	if links[0].ProjectID != existingProj.ID {
+		t.Errorf("Expected the link to project %d, got %d", existingProj.ID, links[0].ProjectID)
 	}
 }
 
@@ -614,6 +629,301 @@ func TestDatabaseGetProjectsForPackage(t *testing.T) {
 	if len(projects) != projectCount {
 		t.Errorf("Expected %d projects, got %d", projectCount, len(projects))
 	}
+}
+
+// --- Multiple versions of one package ----------------------------------------
+
+// insertProject inserts a project and returns it with its assigned ID.
+func insertProject(t *testing.T, d *db.DB, path string) *db.Project {
+	t.Helper()
+
+	if err := d.InsertProject(&db.Project{Path: path, Name: filepath.Base(path)}); err != nil {
+		t.Fatalf("insert project %s: %v", path, err)
+	}
+	proj, err := d.GetProjectByPath(path)
+	if err != nil || proj == nil {
+		t.Fatalf("project %s not found after insert: %v", path, err)
+	}
+	return proj
+}
+
+// linkedProjects returns the paths of the projects linked to a package version,
+// so a test can say which projects follow which version without unpacking link
+// rows itself.
+func linkedProjects(t *testing.T, d *db.DB, packageID int64) []string {
+	t.Helper()
+
+	projects, err := d.GetProjectsForPackage(packageID)
+	if err != nil {
+		t.Fatalf("projects for package %d: %v", packageID, err)
+	}
+	paths := make([]string, 0, len(projects))
+	for _, proj := range projects {
+		paths = append(paths, proj.Path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// TestDatabaseVersionsOfOneNameCoexist pins the schema change tags rest on:
+// publishing different content no longer displaces the record of what was
+// published before, so two versions of a package can be addressed at once.
+func TestDatabaseVersionsOfOneNameCoexist(t *testing.T) {
+	env := setupTest(t)
+
+	v1 := insertTagPkg(t, env.Database, "multi-pkg", "h1")
+	v2 := insertTagPkg(t, env.Database, "multi-pkg", "h2")
+
+	if v1.ID == v2.ID {
+		t.Fatalf("the second version reused record %d instead of taking its own", v1.ID)
+	}
+
+	for _, hash := range []string{"h1", "h2"} {
+		found, err := env.Database.GetPackageByHash("multi-pkg", hash)
+		if err != nil {
+			t.Fatalf("get multi-pkg by hash %s: %v", hash, err)
+		}
+		if found == nil {
+			t.Errorf("version %s is no longer in the store", hash)
+		}
+	}
+
+	current, err := env.Database.GetPackageByName("multi-pkg")
+	if err != nil || current == nil {
+		t.Fatalf("GetPackageByName = %v, %v", current, err)
+	}
+	if current.ContentHash != "h2" {
+		t.Errorf("GetPackageByName resolves to %s, want the version published last", current.ContentHash)
+	}
+	assertTags(t, env.Database, "multi-pkg", map[string]string{db.DefaultTag: "h2"})
+}
+
+// TestDatabaseRepublishingTheSameContentUpdatesInPlace pins that a version is
+// addressed by its content hash and not by the order it was published in.
+// Publishing the same content twice describes one version, so it must not leave
+// two records naming one store entry — gc removes an entry by path, and the
+// second record would then name a directory that is no longer there.
+func TestDatabaseRepublishingTheSameContentUpdatesInPlace(t *testing.T) {
+	env := setupTest(t)
+
+	first := insertTagPkg(t, env.Database, "same-pkg", "h1")
+	second := insertTagPkg(t, env.Database, "same-pkg", "h1")
+
+	if first.ID != second.ID {
+		t.Errorf("republishing the same content took a new record (%d, then %d)", first.ID, second.ID)
+	}
+
+	packages, err := env.Database.ListPackages()
+	if err != nil {
+		t.Fatalf("list packages: %v", err)
+	}
+	count := 0
+	for _, pkg := range packages {
+		if pkg.Name == "same-pkg" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("the store holds %d records for same-pkg, want 1", count)
+	}
+}
+
+// TestDatabaseInsertUnderAnotherTagKeepsTheDefaultVersion is the retention the
+// whole feature rests on: publishing a beta must leave the version consumers are
+// pinned to exactly where it was.
+func TestDatabaseInsertUnderAnotherTagKeepsTheDefaultVersion(t *testing.T) {
+	env := setupTest(t)
+
+	insertTagPkg(t, env.Database, "beta-pkg", "h1")
+
+	beta := &db.Package{
+		Name:        "beta-pkg",
+		Version:     "2.0.0-beta.1",
+		ContentHash: "h2",
+		StorePath:   "/store/beta-pkg/h2",
+	}
+	if err := env.Database.InsertPackageTagged(beta, "beta"); err != nil {
+		t.Fatalf("publish under the beta tag: %v", err)
+	}
+
+	current, err := env.Database.GetPackageByName("beta-pkg")
+	if err != nil || current == nil {
+		t.Fatalf("GetPackageByName = %v, %v", current, err)
+	}
+	if current.ContentHash != "h1" {
+		t.Errorf("publishing a beta moved the default version to %s", current.ContentHash)
+	}
+	assertTags(t, env.Database, "beta-pkg", map[string]string{db.DefaultTag: "h1", "beta": "h2"})
+
+	if found, _ := env.Database.GetPackageByHash("beta-pkg", "h2"); found == nil {
+		t.Error("the beta version was not recorded")
+	}
+}
+
+// TestDatabaseFirstVersionUnderAnotherTagIsAlsoTheDefault pins that a package's
+// first version is reachable by name whatever tag it was published under. Every
+// command but a tag-aware add resolves through the name index, so a package
+// published only as a beta would otherwise be in the store, on disk and
+// invisible to push, remove, restore and status alike.
+func TestDatabaseFirstVersionUnderAnotherTagIsAlsoTheDefault(t *testing.T) {
+	env := setupTest(t)
+
+	first := &db.Package{Name: "only-beta-pkg", Version: "0.1.0-beta.1", ContentHash: "h1"}
+	if err := env.Database.InsertPackageTagged(first, "beta"); err != nil {
+		t.Fatalf("publish under the beta tag: %v", err)
+	}
+
+	current, err := env.Database.GetPackageByName("only-beta-pkg")
+	if err != nil || current == nil {
+		t.Fatalf("GetPackageByName = %v, %v; want the only version there is", current, err)
+	}
+	assertTags(t, env.Database, "only-beta-pkg", map[string]string{db.DefaultTag: "h1", "beta": "h1"})
+}
+
+// TestDatabaseLinksFollowTheDefaultTag pins that a project keeps consuming the
+// package it linked when a new version is published. Links are how push,
+// publish --push, remove and status find a package's consumers, and all of them
+// reach a package by name — so a link left behind on a superseded record would
+// leave those projects unreachable.
+func TestDatabaseLinksFollowTheDefaultTag(t *testing.T) {
+	env := setupTest(t)
+
+	v1 := insertTagPkg(t, env.Database, "follow-pkg", "h1")
+	proj := insertProject(t, env.Database, filepath.FromSlash("/projects/follower"))
+	if err := env.Database.InsertLink(&db.Link{PackageID: v1.ID, ProjectID: proj.ID, LinkType: "reflink"}); err != nil {
+		t.Fatalf("insert link: %v", err)
+	}
+
+	v2 := insertTagPkg(t, env.Database, "follow-pkg", "h2")
+
+	if got := linkedProjects(t, env.Database, v1.ID); len(got) != 0 {
+		t.Errorf("the superseded version still has %v linked", got)
+	}
+	if got := linkedProjects(t, env.Database, v2.ID); len(got) != 1 || got[0] != proj.Path {
+		t.Errorf("the new version has %v linked, want just %s", got, proj.Path)
+	}
+	if links, _ := env.Database.GetLinksForProject(proj.ID); len(links) != 1 {
+		t.Errorf("the project holds %d links, want 1", len(links))
+	}
+}
+
+// TestDatabaseLinksForAnotherTagStayWithTheirVersion pins that only the projects
+// following the tag that moved are carried across. A project that asked for beta
+// must not be dragged onto latest because latest happened to point at the same
+// version at the time.
+func TestDatabaseLinksForAnotherTagStayWithTheirVersion(t *testing.T) {
+	env := setupTest(t)
+
+	v1 := insertTagPkg(t, env.Database, "channel-pkg", "h1")
+	if err := env.Database.SetTag("channel-pkg", "beta", "h1"); err != nil {
+		t.Fatalf("set tag beta: %v", err)
+	}
+
+	stable := insertProject(t, env.Database, filepath.FromSlash("/projects/stable"))
+	tester := insertProject(t, env.Database, filepath.FromSlash("/projects/tester"))
+	if err := env.Database.InsertLink(&db.Link{PackageID: v1.ID, ProjectID: stable.ID, LinkType: "reflink"}); err != nil {
+		t.Fatalf("insert the stable link: %v", err)
+	}
+	if err := env.Database.InsertLink(&db.Link{PackageID: v1.ID, ProjectID: tester.ID, LinkType: "reflink", Tag: "beta"}); err != nil {
+		t.Fatalf("insert the beta link: %v", err)
+	}
+
+	v2 := insertTagPkg(t, env.Database, "channel-pkg", "h2")
+
+	if got := linkedProjects(t, env.Database, v2.ID); len(got) != 1 || got[0] != stable.Path {
+		t.Errorf("the new version has %v linked, want just %s", got, stable.Path)
+	}
+	if got := linkedProjects(t, env.Database, v1.ID); len(got) != 1 || got[0] != tester.Path {
+		t.Errorf("the beta version has %v linked, want just %s", got, tester.Path)
+	}
+}
+
+// TestDatabaseMovingATagMergesADuplicateLink pins that carrying links across
+// does not leave a project holding two links to one package. Everything that
+// reads links treats one row per project as given, and a second row would make
+// remove and gc report a link that nothing can clear.
+func TestDatabaseMovingATagMergesADuplicateLink(t *testing.T) {
+	env := setupTest(t)
+
+	v1 := insertTagPkg(t, env.Database, "merge-pkg", "h1")
+	v2 := insertTagPkg(t, env.Database, "merge-pkg", "h2")
+	proj := insertProject(t, env.Database, filepath.FromSlash("/projects/merger"))
+
+	for _, id := range []int64{v1.ID, v2.ID} {
+		if err := env.Database.InsertLink(&db.Link{PackageID: id, ProjectID: proj.ID, LinkType: "reflink"}); err != nil {
+			t.Fatalf("insert link to record %d: %v", id, err)
+		}
+	}
+
+	// Move the default tag back to the first version, carrying its links.
+	if err := env.Database.SetTag("merge-pkg", db.DefaultTag, "h1"); err != nil {
+		t.Fatalf("move the default tag: %v", err)
+	}
+
+	links, err := env.Database.GetLinksForProject(proj.ID)
+	if err != nil {
+		t.Fatalf("links for the project: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("the project holds %d links to merge-pkg, want 1", len(links))
+	}
+	if links[0].PackageID != v1.ID {
+		t.Errorf("the surviving link names record %d, want the tagged version %d", links[0].PackageID, v1.ID)
+	}
+	if got := linkedProjects(t, env.Database, v2.ID); len(got) != 0 {
+		t.Errorf("the untagged version still has %v linked", got)
+	}
+}
+
+// TestDatabaseDeletingASupersededVersionKeepsTheNameLookup pins that collecting
+// an old version leaves the current one reachable. gc deletes versions one by
+// one, and a delete that cleared the name index would unpublish a package whose
+// files are still in the store.
+func TestDatabaseDeletingASupersededVersionKeepsTheNameLookup(t *testing.T) {
+	env := setupTest(t)
+
+	v1 := insertTagPkg(t, env.Database, "superseded-pkg", "h1")
+	insertTagPkg(t, env.Database, "superseded-pkg", "h2")
+
+	if err := env.Database.DeletePackage(v1.ID); err != nil {
+		t.Fatalf("delete the superseded version: %v", err)
+	}
+
+	current, err := env.Database.GetPackageByName("superseded-pkg")
+	if err != nil || current == nil {
+		t.Fatalf("GetPackageByName = %v, %v; want the current version", current, err)
+	}
+	if current.ContentHash != "h2" {
+		t.Errorf("GetPackageByName resolves to %s, want h2", current.ContentHash)
+	}
+	assertTags(t, env.Database, "superseded-pkg", map[string]string{db.DefaultTag: "h2"})
+}
+
+// TestDatabaseDeletingAVersionDropsOnlyItsOwnTags pins that removing a version
+// takes the tags naming it and no others. A tag left pointing at a deleted
+// version resolves to nothing, and would go on protecting nothing from gc.
+func TestDatabaseDeletingAVersionDropsOnlyItsOwnTags(t *testing.T) {
+	env := setupTest(t)
+
+	v1 := insertTagPkg(t, env.Database, "tagdel-pkg", "h1")
+	if err := env.Database.SetTag("tagdel-pkg", "beta", "h1"); err != nil {
+		t.Fatalf("set tag beta: %v", err)
+	}
+	v2 := insertTagPkg(t, env.Database, "tagdel-pkg", "h2")
+
+	if err := env.Database.DeletePackage(v2.ID); err != nil {
+		t.Fatalf("delete the current version: %v", err)
+	}
+
+	assertTags(t, env.Database, "tagdel-pkg", map[string]string{"beta": "h1"})
+	if pkg, _ := env.Database.GetPackageByName("tagdel-pkg"); pkg != nil {
+		t.Errorf("the name index still resolves to %s after its version was deleted", pkg.ContentHash)
+	}
+
+	if err := env.Database.DeletePackage(v1.ID); err != nil {
+		t.Fatalf("delete the beta version: %v", err)
+	}
+	assertTags(t, env.Database, "tagdel-pkg", map[string]string{})
 }
 
 // --- Tag operations ----------------------------------------------------------

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -877,6 +877,96 @@ func TestDatabaseMovingATagMergesADuplicateLink(t *testing.T) {
 	}
 }
 
+// TestDatabaseInsertLinkKeepsOneRowPerProjectAndName pins the invariant
+// moveLinksTx states and linksOfProject, remove and retreat all rely on: a
+// project holds one link row per package name, so linking it to another version
+// of a name replaces the row it had rather than adding beside it.
+func TestDatabaseInsertLinkKeepsOneRowPerProjectAndName(t *testing.T) {
+	env := setupTest(t)
+
+	v1 := insertTagPkg(t, env.Database, "onerow-pkg", "h1")
+	v2 := insertTagPkg(t, env.Database, "onerow-pkg", "h2")
+	other := insertTagPkg(t, env.Database, "other-pkg", "h3")
+	proj := insertProject(t, env.Database, filepath.FromSlash("/projects/onerow"))
+
+	for _, l := range []*db.Link{
+		{PackageID: v1.ID, ProjectID: proj.ID, LinkType: "reflink", Tag: "beta"},
+		{PackageID: other.ID, ProjectID: proj.ID, LinkType: "reflink"},
+		{PackageID: v2.ID, ProjectID: proj.ID, LinkType: "reflink"},
+	} {
+		if err := env.Database.InsertLink(l); err != nil {
+			t.Fatalf("insert link to record %d: %v", l.PackageID, err)
+		}
+	}
+
+	links, err := env.Database.GetLinksForProject(proj.ID)
+	if err != nil {
+		t.Fatalf("links for the project: %v", err)
+	}
+	if len(links) != 2 {
+		t.Fatalf("the project holds %d links, want one per package name: %+v", len(links), links)
+	}
+	byPackage := make(map[int64]*db.Link, len(links))
+	for _, l := range links {
+		byPackage[l.PackageID] = l
+	}
+	if byPackage[v2.ID] == nil {
+		t.Errorf("the project does not follow the version it was linked to last")
+	}
+	if byPackage[v1.ID] != nil {
+		t.Errorf("the project still holds a row on the version it moved off")
+	}
+	if byPackage[other.ID] == nil {
+		t.Errorf("linking one package removed the row for another")
+	}
+	if got := linkedProjects(t, env.Database, v1.ID); len(got) != 0 {
+		t.Errorf("the package index still names %v on the version moved off", got)
+	}
+}
+
+// TestDatabaseInsertLinkUpdatesTheTagOfAnExistingRow pins the other half of the
+// switch: when both channels name one version - which is what `lnpm tag`
+// produces, since it can only point a tag at what the name resolves to - there
+// is no second row to replace, and the existing one has to start following the
+// channel that was asked for. Left on the old tag the project stays a follower
+// of it, and the next publish carries it forward.
+func TestDatabaseInsertLinkUpdatesTheTagOfAnExistingRow(t *testing.T) {
+	env := setupTest(t)
+
+	v1 := insertTagPkg(t, env.Database, "retag-pkg", "h1")
+	if err := env.Database.SetTag("retag-pkg", "beta", "h1"); err != nil {
+		t.Fatalf("set tag beta: %v", err)
+	}
+	proj := insertProject(t, env.Database, filepath.FromSlash("/projects/retag"))
+
+	if err := env.Database.InsertLink(&db.Link{PackageID: v1.ID, ProjectID: proj.ID, LinkType: "reflink"}); err != nil {
+		t.Fatalf("insert the default-tag link: %v", err)
+	}
+	if err := env.Database.InsertLink(&db.Link{PackageID: v1.ID, ProjectID: proj.ID, LinkType: "reflink", Tag: "beta"}); err != nil {
+		t.Fatalf("switch the link onto beta: %v", err)
+	}
+
+	links, err := env.Database.GetLinksForProject(proj.ID)
+	if err != nil {
+		t.Fatalf("links for the project: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("the project holds %d links, want 1: %+v", len(links), links)
+	}
+	if links[0].Tag != "beta" {
+		t.Errorf("the link follows %q, want beta", links[0].Tag)
+	}
+
+	// Publishing to the default channel must now leave it alone.
+	v2 := insertTagPkg(t, env.Database, "retag-pkg", "h2")
+	if got := linkedProjects(t, env.Database, v2.ID); len(got) != 0 {
+		t.Errorf("publishing to the default channel carried %v onto it", got)
+	}
+	if got := linkedProjects(t, env.Database, v1.ID); len(got) != 1 {
+		t.Errorf("the beta version has %v linked, want the project that asked for beta", got)
+	}
+}
+
 // TestDatabaseDeletingASupersededVersionKeepsTheNameLookup pins that collecting
 // an old version leaves the current one reachable. gc deletes versions one by
 // one, and a delete that cleared the name index would unpublish a package whose

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -612,6 +613,168 @@ func TestDatabaseGetProjectsForPackage(t *testing.T) {
 
 	if len(projects) != projectCount {
 		t.Errorf("Expected %d projects, got %d", projectCount, len(projects))
+	}
+}
+
+// --- Tag operations ----------------------------------------------------------
+
+// insertTagPkg inserts a package with the given name and content hash under the
+// default tag and returns it, so the tag tests read as tag assertions rather
+// than as struct literals.
+func insertTagPkg(t *testing.T, d *db.DB, name, hash string) *db.Package {
+	t.Helper()
+
+	pkg := &db.Package{
+		Name:        name,
+		Version:     "1.0.0",
+		ContentHash: hash,
+		SourcePath:  "/src/" + name,
+		StorePath:   "/store/" + name + "/" + hash,
+		FilesCount:  1,
+		TotalSize:   1,
+	}
+	if err := d.InsertPackage(pkg); err != nil {
+		t.Fatalf("insert %s@%s: %v", name, hash, err)
+	}
+	return pkg
+}
+
+// assertTags checks the complete set of tags recorded for name. It compares the
+// whole map rather than one entry, because a tag write that also disturbs a tag
+// it was not asked about is exactly the failure worth catching.
+func assertTags(t *testing.T, d *db.DB, name string, want map[string]string) {
+	t.Helper()
+
+	got, err := d.TagsForPackage(name)
+	if err != nil {
+		t.Fatalf("tags for %s: %v", name, err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("tags for %s = %v, want %v", name, got, want)
+	}
+	for tag, hash := range want {
+		if got[tag] != hash {
+			t.Errorf("tag %s of %s points at %q, want %q", tag, name, got[tag], hash)
+		}
+	}
+}
+
+// TestDatabaseInsertPackageSetsTheLatestTag pins that publishing records the
+// default tag, which is what every existing name-based lookup resolves through.
+func TestDatabaseInsertPackageSetsTheLatestTag(t *testing.T) {
+	env := setupTest(t)
+
+	insertTagPkg(t, env.Database, "tagged-pkg", "h1")
+
+	assertTags(t, env.Database, "tagged-pkg", map[string]string{db.DefaultTag: "h1"})
+
+	resolved, err := env.Database.ResolveTag("tagged-pkg", db.DefaultTag)
+	if err != nil {
+		t.Fatalf("resolve latest: %v", err)
+	}
+	if resolved == nil || resolved.ContentHash != "h1" {
+		t.Fatalf("ResolveTag(latest) = %v, want the h1 version", resolved)
+	}
+}
+
+// TestDatabaseSetTagPointsAtAnExistingVersion covers setting a second tag on an
+// already published version without republishing it.
+func TestDatabaseSetTagPointsAtAnExistingVersion(t *testing.T) {
+	env := setupTest(t)
+
+	insertTagPkg(t, env.Database, "set-pkg", "h1")
+
+	if err := env.Database.SetTag("set-pkg", "beta", "h1"); err != nil {
+		t.Fatalf("set tag beta: %v", err)
+	}
+
+	assertTags(t, env.Database, "set-pkg", map[string]string{db.DefaultTag: "h1", "beta": "h1"})
+
+	resolved, err := env.Database.ResolveTag("set-pkg", "beta")
+	if err != nil {
+		t.Fatalf("resolve beta: %v", err)
+	}
+	if resolved == nil || resolved.ContentHash != "h1" {
+		t.Fatalf("ResolveTag(beta) = %v, want the h1 version", resolved)
+	}
+}
+
+// TestDatabaseSetTagRejectsAnUnknownHash pins that a tag cannot be pointed at a
+// version the store does not hold. A dangling tag would resolve to nothing and,
+// once gc treats tags as reachability roots, would protect nothing either.
+func TestDatabaseSetTagRejectsAnUnknownHash(t *testing.T) {
+	env := setupTest(t)
+
+	insertTagPkg(t, env.Database, "dangling-pkg", "h1")
+
+	if err := env.Database.SetTag("dangling-pkg", "beta", "nosuchhash"); err == nil {
+		t.Fatal("SetTag accepted a hash no version has")
+	}
+	assertTags(t, env.Database, "dangling-pkg", map[string]string{db.DefaultTag: "h1"})
+}
+
+// TestDatabaseDeleteTagRemovesOnlyThatTag pins that deleting one tag leaves the
+// others, and the version itself, alone.
+func TestDatabaseDeleteTagRemovesOnlyThatTag(t *testing.T) {
+	env := setupTest(t)
+
+	insertTagPkg(t, env.Database, "del-pkg", "h1")
+	if err := env.Database.SetTag("del-pkg", "beta", "h1"); err != nil {
+		t.Fatalf("set tag beta: %v", err)
+	}
+
+	if err := env.Database.DeleteTag("del-pkg", "beta"); err != nil {
+		t.Fatalf("delete tag beta: %v", err)
+	}
+
+	assertTags(t, env.Database, "del-pkg", map[string]string{db.DefaultTag: "h1"})
+	resolved, err := env.Database.ResolveTag("del-pkg", "beta")
+	if err != nil {
+		t.Fatalf("resolve beta: %v", err)
+	}
+	if resolved != nil {
+		t.Errorf("ResolveTag(beta) = %v after deleting it, want nil", resolved)
+	}
+	if pkg, _ := env.Database.GetPackageByName("del-pkg"); pkg == nil {
+		t.Error("deleting a tag removed the package from the name index")
+	}
+}
+
+// TestDatabaseDeleteTagRefusesTheDefaultTag pins that the tag every name-based
+// lookup resolves through cannot be deleted. Removing it would leave the package
+// in the store and its files on disk while making it unreachable by name from
+// every command lnpm has.
+func TestDatabaseDeleteTagRefusesTheDefaultTag(t *testing.T) {
+	env := setupTest(t)
+
+	insertTagPkg(t, env.Database, "keep-latest-pkg", "h1")
+
+	err := env.Database.DeleteTag("keep-latest-pkg", db.DefaultTag)
+	if err == nil {
+		t.Fatal("DeleteTag removed the default tag")
+	}
+	if !strings.Contains(err.Error(), db.DefaultTag) {
+		t.Errorf("DeleteTag error = %v, want it to name the %s tag", err, db.DefaultTag)
+	}
+	assertTags(t, env.Database, "keep-latest-pkg", map[string]string{db.DefaultTag: "h1"})
+	if pkg, _ := env.Database.GetPackageByName("keep-latest-pkg"); pkg == nil {
+		t.Error("the package is no longer reachable by name")
+	}
+}
+
+// TestDatabaseResolveUnknownTag pins that an unknown tag is not an error, so a
+// caller can tell "no such tag" from "the lookup failed".
+func TestDatabaseResolveUnknownTag(t *testing.T) {
+	env := setupTest(t)
+
+	insertTagPkg(t, env.Database, "unknown-tag-pkg", "h1")
+
+	resolved, err := env.Database.ResolveTag("unknown-tag-pkg", "next")
+	if err != nil {
+		t.Fatalf("resolve an unset tag: %v", err)
+	}
+	if resolved != nil {
+		t.Errorf("ResolveTag(next) = %v, want nil", resolved)
 	}
 }
 

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -1149,17 +1149,17 @@ func TestDatabaseDeleteTagRemovesOnlyThatTag(t *testing.T) {
 func TestDatabaseDeleteTagRefusesTheDefaultTag(t *testing.T) {
 	env := setupTest(t)
 
-	insertTagPkg(t, env.Database, "keep-latest-pkg", "h1")
+	insertTagPkg(t, env.Database, "refuse-delete-pkg", "h1")
 
-	err := env.Database.DeleteTag("keep-latest-pkg", db.DefaultTag)
+	err := env.Database.DeleteTag("refuse-delete-pkg", db.DefaultTag)
 	if err == nil {
 		t.Fatal("DeleteTag removed the default tag")
 	}
 	if !strings.Contains(err.Error(), db.DefaultTag) {
 		t.Errorf("DeleteTag error = %v, want it to name the %s tag", err, db.DefaultTag)
 	}
-	assertTags(t, env.Database, "keep-latest-pkg", map[string]string{db.DefaultTag: "h1"})
-	if pkg, _ := env.Database.GetPackageByName("keep-latest-pkg"); pkg == nil {
+	assertTags(t, env.Database, "refuse-delete-pkg", map[string]string{db.DefaultTag: "h1"})
+	if pkg, _ := env.Database.GetPackageByName("refuse-delete-pkg"); pkg == nil {
 		t.Error("the package is no longer reachable by name")
 	}
 }

--- a/tests/gc_test.go
+++ b/tests/gc_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/internal/db"
 )
 
 // TestGCRemovesOrphans table-drives garbage collection of orphaned (unlinked)
@@ -297,6 +298,34 @@ func TestGCKeepsAVersionATagPins(t *testing.T) {
 
 	// Nothing links the version latest names, and latest alone does not keep it.
 	env.AssertDirectoryExists(second.StorePath, false)
+
+	// So this run leaves the package reachable by its beta tag and by nothing
+	// else: collecting what latest named cleared the name index with it. ADR-0002
+	// discloses that a version can outlive its package's name, and this is the
+	// run that produces it - asserted here rather than left implied, because it
+	// is the one state db.go's two comments about the default tag say publishing
+	// never creates.
+	byName, err := env.Database.GetPackageByName("pinned-pkg")
+	if err != nil {
+		t.Fatalf("Failed to look pinned-pkg up by name: %v", err)
+	}
+	if byName != nil {
+		t.Errorf("pinned-pkg still resolves by name to %s, want nothing after its latest was collected", byName.ContentHash)
+	}
+	if tags[db.DefaultTag] != "" {
+		t.Errorf("the %s tag still names %q, want it gone with the version it named", db.DefaultTag, tags[db.DefaultTag])
+	}
+	resolved, err := env.Database.ResolveTag("pinned-pkg", "beta")
+	if err != nil || resolved == nil {
+		t.Fatalf("The beta tag no longer resolves: %v, %v", resolved, err)
+	}
+
+	// The next publish of the name puts the default tag back, which is the only
+	// thing that clears the state.
+	env.republish(pkgDir, "pinned-pkg", "3.0.0", "module.exports = 'v3';")
+	if pkg, _ := env.Database.GetPackageByName("pinned-pkg"); pkg == nil {
+		t.Error("republishing did not make pinned-pkg reachable by name again")
+	}
 }
 
 // TestGCNoPackages tests GC against an empty database is a safe no-op.

--- a/tests/gc_test.go
+++ b/tests/gc_test.go
@@ -208,6 +208,97 @@ func TestGCKeepsLinkedAndCollectsOrphans(t *testing.T) {
 	env.AssertDatabaseLink("linked-pkg", projectDir)
 }
 
+// TestGCCollectsASupersededVersion covers the version-level sweep the store
+// needs now that publishing keeps the version published before it. The old
+// version is reached by nothing — its link was carried across to the version
+// the tag names — so both its record and its files go, while the version the
+// project actually consumes stays exactly where it is.
+func TestGCCollectsASupersededVersion(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("superseded-pkg")
+	projectDir := env.newProject("consumer")
+	env.addPkg(projectDir, "superseded-pkg", false, false)
+
+	first, err := env.Database.GetPackageByName("superseded-pkg")
+	if err != nil || first == nil {
+		t.Fatalf("Failed to get the first version: %v", err)
+	}
+
+	env.republish(pkgDir, "superseded-pkg", "2.0.0", "module.exports = 'v2';")
+	second, err := env.Database.GetPackageByName("superseded-pkg")
+	if err != nil || second == nil {
+		t.Fatalf("Failed to get the second version: %v", err)
+	}
+	if second.ContentHash == first.ContentHash {
+		t.Fatal("the republish produced the same content, so there is no superseded version")
+	}
+
+	if err := cli.RunGC(false, "", false, true); err != nil {
+		t.Fatalf("Failed to run GC: %v", err)
+	}
+
+	if stale, _ := env.Database.GetPackageByHash("superseded-pkg", first.ContentHash); stale != nil {
+		t.Error("GC kept the record of a version nothing reaches")
+	}
+	env.AssertDirectoryExists(first.StorePath, false)
+
+	env.AssertPackageInDatabase("superseded-pkg", true)
+	env.AssertDirectoryExists(second.StorePath, true)
+	env.AssertDatabaseLink("superseded-pkg", projectDir)
+}
+
+// TestGCKeepsAVersionATagPins is the reachability rule's other half: a tag is a
+// root, so a version nothing links to survives for as long as a tag names it.
+//
+// The version tagged only latest is collected in the same run, and that
+// asymmetry is deliberate. Publish moves latest onto every package it writes, so
+// treating it as a root would leave gc nothing it could ever collect and quietly
+// retire the command. A tag a user set is a decision; latest is a side effect.
+func TestGCKeepsAVersionATagPins(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.simplePkg("pinned-pkg")
+	first, err := env.Database.GetPackageByName("pinned-pkg")
+	if err != nil || first == nil {
+		t.Fatalf("Failed to get the first version: %v", err)
+	}
+
+	env.republish(pkgDir, "pinned-pkg", "2.0.0", "module.exports = 'v2';")
+	second, err := env.Database.GetPackageByName("pinned-pkg")
+	if err != nil || second == nil {
+		t.Fatalf("Failed to get the second version: %v", err)
+	}
+
+	if err := env.Database.SetTag("pinned-pkg", "beta", first.ContentHash); err != nil {
+		t.Fatalf("Failed to tag the first version: %v", err)
+	}
+
+	if err := cli.RunGC(false, "", false, true); err != nil {
+		t.Fatalf("Failed to run GC: %v", err)
+	}
+
+	pinned, err := env.Database.GetPackageByHash("pinned-pkg", first.ContentHash)
+	if err != nil {
+		t.Fatalf("Failed to look up the tagged version: %v", err)
+	}
+	if pinned == nil {
+		t.Error("GC collected a version a tag names")
+	}
+	env.AssertDirectoryExists(first.StorePath, true)
+
+	tags, err := env.Database.TagsForPackage("pinned-pkg")
+	if err != nil {
+		t.Fatalf("Failed to read tags: %v", err)
+	}
+	if tags["beta"] != first.ContentHash {
+		t.Errorf("the beta tag points at %q, want the version it named before GC ran", tags["beta"])
+	}
+
+	// Nothing links the version latest names, and latest alone does not keep it.
+	env.AssertDirectoryExists(second.StorePath, false)
+}
+
 // TestGCNoPackages tests GC against an empty database is a safe no-op.
 func TestGCNoPackages(t *testing.T) {
 	_ = setupTest(t)

--- a/tests/publish_test.go
+++ b/tests/publish_test.go
@@ -268,6 +268,49 @@ func TestPublishVersionUpdate(t *testing.T) {
 	}
 }
 
+// TestPublishKeepsThePreviousVersionInTheStore pins that publishing does not
+// take the version published before it out of reach.
+//
+// The store has always written one directory per content hash and never removed
+// a sibling, but the database used to overwrite the one record it kept for a
+// name — so the previous version's files stayed on disk while nothing could
+// name them. Both halves are asserted here: the record and the tree.
+func TestPublishKeepsThePreviousVersionInTheStore(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("retained-pkg", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'v1';",
+	})
+	first, err := env.Database.GetPackageByName("retained-pkg")
+	if err != nil || first == nil {
+		t.Fatalf("Failed to get the first version: %v", err)
+	}
+
+	env.republish(pkgDir, "retained-pkg", "2.0.0", "module.exports = 'v2';")
+
+	second, err := env.Database.GetPackageByName("retained-pkg")
+	if err != nil || second == nil {
+		t.Fatalf("Failed to get the second version: %v", err)
+	}
+	if second.ContentHash == first.ContentHash {
+		t.Fatal("the republish produced the same content hash, so there is no second version to keep")
+	}
+
+	retained, err := env.Database.GetPackageByHash("retained-pkg", first.ContentHash)
+	if err != nil {
+		t.Fatalf("Failed to look up the first version by hash: %v", err)
+	}
+	if retained == nil {
+		t.Error("publishing a new version discarded the record of the one before it")
+	}
+	env.AssertDirectoryExists(first.StorePath, true)
+	env.AssertDirectoryExists(second.StorePath, true)
+
+	if first.StorePath == second.StorePath {
+		t.Error("both versions were stored at the same path")
+	}
+}
+
 // TestPublishSymlinks tests publishing a package containing symlinks succeeds.
 func TestPublishSymlinks(t *testing.T) {
 	env := setupTest(t)

--- a/tests/restore_test.go
+++ b/tests/restore_test.go
@@ -106,14 +106,20 @@ func TestRestoreWithoutSnapshotReportsNothingToRestore(t *testing.T) {
 	env.AssertDirectoryExists(filepath.Join(projectDir, ".lnpm"), false)
 }
 
-// TestRestoreReportsStaleVersionAndContinues covers the criterion that a package
-// whose recorded version is no longer the one in the store is reported per
-// package and does not abort the rest of the restore. The store is latest-wins,
-// so republishing at a new version is what strands the snapshot's entry.
-func TestRestoreReportsStaleVersionAndContinues(t *testing.T) {
+// TestRestoreReportsACollectedBuildAndContinues covers the criterion that a
+// package restore cannot put back is reported per package and does not abort the
+// rest of the restore.
+//
+// Restore resolves through the content hash the snapshot recorded, so a
+// republish no longer strands the entry - the build it names is still in the
+// store beside the newer one. What does strand it is gc collecting that build,
+// which after a retreat is exactly what happens: nothing links it and no tag
+// names it. The healthy package is tagged to keep gc off it, since nothing links
+// that either.
+func TestRestoreReportsACollectedBuildAndContinues(t *testing.T) {
 	env := setupTest(t)
 
-	stalePkgDir := env.simplePkg("stale-restore-pkg")
+	env.simplePkg("stale-restore-pkg")
 	env.simplePkg("fresh-restore-pkg")
 	projectDir := env.newProject("stale-restore-project")
 	env.addPkg(projectDir, "stale-restore-pkg", false, false)
@@ -123,7 +129,14 @@ func TestRestoreReportsStaleVersionAndContinues(t *testing.T) {
 		t.Fatalf("Failed to retreat: %v", err)
 	}
 
-	env.republish(stalePkgDir, "stale-restore-pkg", "2.0.0", "module.exports = 'v2';")
+	if err := cli.RunTag("fresh-restore-pkg", "keep", false); err != nil {
+		t.Fatalf("Failed to tag the healthy package: %v", err)
+	}
+	captureStdout(t, func() {
+		if err := cli.RunGC(false, "", false, true); err != nil {
+			t.Fatalf("Failed to collect the unreferenced build: %v", err)
+		}
+	})
 	env.chdir(projectDir)
 
 	var err error
@@ -132,9 +145,9 @@ func TestRestoreReportsStaleVersionAndContinues(t *testing.T) {
 		t.Error("Expected restore to exit non-zero when a package could not be restored")
 	}
 
-	want := "version 1.0.0 of stale-restore-pkg not found in store (latest published is 2.0.0"
-	if !strings.Contains(out, want) {
-		t.Errorf("Expected the report to contain %q, got:\n%s", want, out)
+	want := "stale-restore-pkg@1.0.0 (hash "
+	if !strings.Contains(out, want) || !strings.Contains(out, "is no longer in the store") {
+		t.Errorf("Expected the report to name the collected build (%q), got:\n%s", want, out)
 	}
 
 	// The healthy package is restored regardless.
@@ -290,6 +303,29 @@ func TestRestoreReportsAnUnknownDependencyField(t *testing.T) {
 	}
 }
 
+// collectUnreferencedBuilds takes every build no link and no tag reaches out of
+// the isolated store, which after a retreat is every build the project had. The
+// packages a caller needs to survive are named in keep and tagged first, since
+// gc keeps any version a non-default tag names.
+//
+// It is how a restore is made to fail on purpose. Republishing no longer does
+// it: restore resolves the snapshot's content hash, and the build that hash
+// names stays in the store beside whatever was published after it.
+func collectUnreferencedBuilds(t *testing.T, keep ...string) {
+	t.Helper()
+
+	for _, name := range keep {
+		if err := cli.RunTag(name, "keep", false); err != nil {
+			t.Fatalf("Failed to tag %s to keep gc off it: %v", name, err)
+		}
+	}
+	captureStdout(t, func() {
+		if err := cli.RunGC(false, "", false, true); err != nil {
+			t.Fatalf("Failed to collect unreferenced builds: %v", err)
+		}
+	})
+}
+
 // TestRestoreCountsOnlyThePackagesItAttempted pins the denominator of the
 // failure summary. Packages restore skipped because the user re-added them were
 // never attempted, so counting them makes the failure look like a smaller
@@ -298,7 +334,7 @@ func TestRestoreCountsOnlyThePackagesItAttempted(t *testing.T) {
 	env := setupTest(t)
 
 	readdedDir := env.simplePkg("count-readded-pkg")
-	staleDir := env.simplePkg("count-stale-pkg")
+	env.simplePkg("count-stale-pkg")
 	env.simplePkg("count-ok-pkg")
 	projectDir := env.newProject("count-restore-project")
 	env.addPkg(projectDir, "count-readded-pkg", false, false)
@@ -310,11 +346,11 @@ func TestRestoreCountsOnlyThePackagesItAttempted(t *testing.T) {
 	}
 
 	// One package is re-added since the retreat, so restore skips it untouched;
-	// another is republished, so the version the snapshot recorded is gone and
-	// restore cannot put it back. Only two of the three are ever attempted.
+	// another has had its build collected, so restore cannot put it back. Only
+	// two of the three are ever attempted.
 	env.republish(readdedDir, "count-readded-pkg", "2.0.0", "module.exports = 'v2';")
 	env.addPkg(projectDir, "count-readded-pkg", false, false)
-	env.republish(staleDir, "count-stale-pkg", "2.0.0", "module.exports = 'v2';")
+	collectUnreferencedBuilds(t, "count-ok-pkg")
 	env.chdir(projectDir)
 
 	var err error
@@ -380,16 +416,17 @@ func TestRestoreNamesTheSnapshotInAReadError(t *testing.T) {
 func TestRestoreMarkersComeFromTheIconHelpers(t *testing.T) {
 	cases := []struct {
 		name string
-		// stale republishes the package after the retreat, so its recorded
-		// version is gone from the store and restore reports a failure.
-		stale bool
+		// collected runs gc after the retreat, which takes the recorded build
+		// out of the store - nothing links it and no tag names it - so restore
+		// reports a failure.
+		collected bool
 		// dev adds the package with --dev and no package.json entry, so restore
 		// cannot tell which field it belonged in and reports a warning.
 		dev  bool
 		want string
 	}{
 		{name: "package restored", want: "Restored glyph-restore-pkg@1.0.0"},
-		{name: "version no longer in the store", stale: true, want: "not found in store"},
+		{name: "build no longer in the store", collected: true, want: "is no longer in the store"},
 		{name: "dependency field unknown", dev: true, want: "so its field is unknown"},
 	}
 
@@ -398,15 +435,19 @@ func TestRestoreMarkersComeFromTheIconHelpers(t *testing.T) {
 			t.Setenv("NO_COLOR", "1")
 			env := setupTest(t)
 
-			pkgDir := env.simplePkg("glyph-restore-pkg")
+			env.simplePkg("glyph-restore-pkg")
 			projectDir := env.newProject("glyph-restore-project")
 			env.addPkg(projectDir, "glyph-restore-pkg", tc.dev, false)
 
 			if err := cli.RunRetreat(true, false); err != nil {
 				t.Fatalf("Failed to retreat: %v", err)
 			}
-			if tc.stale {
-				env.republish(pkgDir, "glyph-restore-pkg", "2.0.0", "module.exports = 'v2';")
+			if tc.collected {
+				captureStdout(t, func() {
+					if err := cli.RunGC(false, "", false, true); err != nil {
+						t.Fatalf("Failed to collect the unreferenced build: %v", err)
+					}
+				})
 			}
 			env.chdir(projectDir)
 
@@ -453,7 +494,7 @@ func TestRestoreRerunDoesNotReportItsOwnWorkAsAReAdd(t *testing.T) {
 	env := setupTest(t)
 
 	env.simplePkg("prune-ok-pkg")
-	staleDir := env.simplePkg("prune-stale-pkg")
+	env.simplePkg("prune-stale-pkg")
 	projectDir := env.newProject("prune-restore-project")
 	env.addPkg(projectDir, "prune-ok-pkg", false, false)
 	env.addPkg(projectDir, "prune-stale-pkg", false, false)
@@ -462,9 +503,9 @@ func TestRestoreRerunDoesNotReportItsOwnWorkAsAReAdd(t *testing.T) {
 		t.Fatalf("Failed to retreat: %v", err)
 	}
 
-	// Republishing strands the version the snapshot recorded, so the first run
-	// restores one package and fails on the other.
-	env.republish(staleDir, "prune-stale-pkg", "2.0.0", "module.exports = 'v2';")
+	// Collecting the build the snapshot recorded strands its entry, so the first
+	// run restores one package and fails on the other.
+	collectUnreferencedBuilds(t, "prune-ok-pkg")
 	env.chdir(projectDir)
 
 	var err error
@@ -506,7 +547,7 @@ func TestRestoreDropsAReAddedPackageFromTheSnapshot(t *testing.T) {
 	env := setupTest(t)
 
 	readdedDir := env.simplePkg("skip-readded-pkg")
-	staleDir := env.simplePkg("skip-stale-pkg")
+	env.simplePkg("skip-stale-pkg")
 	projectDir := env.newProject("skip-restore-project")
 	env.addPkg(projectDir, "skip-readded-pkg", false, false)
 	env.addPkg(projectDir, "skip-stale-pkg", false, false)
@@ -515,11 +556,11 @@ func TestRestoreDropsAReAddedPackageFromTheSnapshot(t *testing.T) {
 		t.Fatalf("Failed to retreat: %v", err)
 	}
 
-	// One package is added again by the user, so restore skips it; another is
-	// stranded, so the run fails and the snapshot is kept.
+	// One package is added again by the user, so restore skips it; the other has
+	// had its build collected, so the run fails and the snapshot is kept.
 	env.republish(readdedDir, "skip-readded-pkg", "2.0.0", "module.exports = 'v2';")
 	env.addPkg(projectDir, "skip-readded-pkg", false, false)
-	env.republish(staleDir, "skip-stale-pkg", "2.0.0", "module.exports = 'v2';")
+	collectUnreferencedBuilds(t)
 	env.chdir(projectDir)
 
 	captureStdout(t, func() { _ = cli.RunRestore() })

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -371,16 +371,16 @@ func TestTagDeleteRemovesTheTag(t *testing.T) {
 func TestTagDeleteRefusesTheDefaultTag(t *testing.T) {
 	env := setupTest(t)
 
-	env.simplePkg("keep-latest-lib")
+	env.simplePkg("refuse-delete-lib")
 
-	err := cli.RunTag("keep-latest-lib", db.DefaultTag, true)
+	err := cli.RunTag("refuse-delete-lib", db.DefaultTag, true)
 	if err == nil {
 		t.Fatal("Deleting the default tag succeeded, want a refusal")
 	}
 	if !strings.Contains(err.Error(), db.DefaultTag) {
 		t.Errorf("The refusal is %v, want it to name the %s tag", err, db.DefaultTag)
 	}
-	env.AssertPackageInDatabase("keep-latest-lib", true)
+	env.AssertPackageInDatabase("refuse-delete-lib", true)
 }
 
 // TestTagOnAnUnknownPackageFails pins that tagging something the store does not
@@ -458,17 +458,21 @@ func TestListStoreShowsWhichTagsNameEachVersion(t *testing.T) {
 		}
 	})
 
+	// Asserted against the rendered marker rather than the bare tag name. The
+	// beta build's version string is "2.0.0-beta.1", so a test that looked for
+	// "beta" anywhere on that line would pass whether the tag column printed
+	// anything or not - which is the whole of what this test is for.
 	for _, line := range strings.Split(out, "\n") {
 		switch {
 		case strings.Contains(line, "listed-lib@1.0.0"):
-			if !strings.Contains(line, db.DefaultTag) {
+			if !strings.Contains(line, "["+db.DefaultTag+"]") {
 				t.Errorf("The 1.0.0 line does not name the %s tag: %q", db.DefaultTag, line)
 			}
 			if strings.Contains(line, "beta") {
 				t.Errorf("The 1.0.0 line claims the beta tag: %q", line)
 			}
 		case strings.Contains(line, "listed-lib@2.0.0-beta.1"):
-			if !strings.Contains(line, "beta") {
+			if !strings.Contains(line, "[beta]") {
 				t.Errorf("The 2.0.0-beta.1 line does not name the beta tag: %q", line)
 			}
 			if strings.Contains(line, db.DefaultTag) {
@@ -500,8 +504,13 @@ func TestListStoreLeavesAnUntaggedVersionUnmarked(t *testing.T) {
 		}
 	})
 
+	// The listing has to hold the superseded version at all, or the loop below
+	// asserts nothing: a negative check over lines that are not there passes.
+	if !strings.Contains(out, "superseded-lib@1.0.0") {
+		t.Fatalf("The store listing is missing the superseded version, output was:\n%s", out)
+	}
 	for _, line := range strings.Split(out, "\n") {
-		if strings.Contains(line, "superseded-lib@1.0.0") && strings.Contains(line, db.DefaultTag) {
+		if strings.Contains(line, "superseded-lib@1.0.0") && strings.Contains(line, "[") {
 			t.Errorf("The superseded version is shown as tagged: %q", line)
 		}
 	}

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -1059,6 +1059,53 @@ func TestPushUnderATagMovesOnlyThatChannel(t *testing.T) {
 	}
 }
 
+// TestRestoreAfterARepublishSaysToPull covers what hash-based restore turned a
+// failure into. A package republished while the project was retreated used to
+// have the consumer reported as missing from the store; now the recorded build
+// is still there and comes back exactly.
+//
+// The project never followed a dist-tag, so telling it to go find one sends the
+// user after a channel that does not exist. What actually happened is that the
+// package moved on, and the answer to that is `lnpm pull`.
+func TestRestoreAfterARepublishSaysToPull(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("restore-republish-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'one';",
+	})
+
+	projectDir := env.newProject("restore-republish-project")
+	env.addPkg(projectDir, "restore-republish-lib", false, false)
+
+	env.chdir(projectDir)
+	captureStdout(t, func() {
+		if err := cli.RunRetreat(true, false); err != nil {
+			t.Fatalf("Failed to retreat: %v", err)
+		}
+	})
+
+	// The package moves on while the project is retreated.
+	env.republish(pkgDir, "restore-republish-lib", "1.1.0", "module.exports = 'two';")
+
+	env.chdir(projectDir)
+	var out string
+	var err error
+	out = captureStdout(t, func() { err = cli.RunRestore() })
+	if err != nil {
+		t.Fatalf("Failed to restore after a republish: %v\n%s", err, out)
+	}
+
+	env.AssertLinkedFileContent(projectDir, "restore-republish-lib", "index.js", "module.exports = 'one';")
+
+	if !strings.Contains(out, "lnpm pull") {
+		t.Errorf("restore did not advise a pull, output was:\n%s", out)
+	}
+	if strings.Contains(out, "@<tag>") {
+		t.Errorf("restore sent the user after a dist-tag the package never had, output was:\n%s", out)
+	}
+	assertNoRawGlyphs(t, out)
+}
+
 // TestRestorePutsBackTheBuildTheSnapshotRecorded pins that a retreat and a
 // restore leave a consumer on the channel it was on.
 //
@@ -1104,9 +1151,13 @@ func TestRestorePutsBackTheBuildTheSnapshotRecorded(t *testing.T) {
 	})
 
 	// The snapshot cannot say which channel the project followed, so the
-	// restored link follows the default one and restore has to say so.
-	if !strings.Contains(out, db.DefaultTag+" tag does not name") {
+	// restored link follows the default one and restore has to say so - naming
+	// the channel that still holds the build, which is the one to re-add under.
+	if !strings.Contains(out, "restored on the build tagged beta") {
 		t.Errorf("restore did not warn that the channel could not be restored, output was:\n%s", out)
+	}
+	if !strings.Contains(out, "restore-tagged-lib@<tag>") {
+		t.Errorf("restore did not say how to follow the channel again, output was:\n%s", out)
 	}
 	assertNoRawGlyphs(t, out)
 }

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -817,6 +817,79 @@ func TestSwitchingAProjectBackOntoLatest(t *testing.T) {
 	}
 }
 
+// TestPushKeepsABetaBuildOffTheDefaultChannel pins that pushing does not
+// release. `lnpm push` re-publishes the working tree and relinks consumers, and
+// it used to record whatever it wrote under the default tag - so a bare push in
+// a package whose current build is a pre-release promoted that pre-release to
+// the channel every plain `lnpm add` resolves through.
+func TestPushKeepsABetaBuildOffTheDefaultChannel(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("push-tag-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	stable, err := env.Database.GetPackageByName("push-tag-lib")
+	if err != nil || stable == nil {
+		t.Fatalf("Failed to read the published package: %v", err)
+	}
+	publishTagged(t, env, pkgDir, "push-tag-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+	beta, err := env.Database.ResolveTag("push-tag-lib", "beta")
+	if err != nil || beta == nil {
+		t.Fatalf("Failed to resolve the beta tag: %v", err)
+	}
+
+	// The working tree is still the beta one publishTagged left behind.
+	env.chdir(pkgDir)
+	captureStdout(t, func() {
+		if err := cli.RunPush(false); err != nil {
+			t.Fatalf("Failed to push: %v", err)
+		}
+	})
+
+	assertTagged(t, env, "push-tag-lib", db.DefaultTag, stable.ContentHash)
+	assertTagged(t, env, "push-tag-lib", "beta", beta.ContentHash)
+}
+
+// TestPushUnderATagMovesOnlyThatChannel is the other half: a push of content the
+// store does not hold names no channel of its own, so --tag is how a maintainer
+// says which one it belongs to. Without it the edited pre-release would land on
+// the default tag, which is the promotion the test above pins against.
+func TestPushUnderATagMovesOnlyThatChannel(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("push-edit-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	stable, err := env.Database.GetPackageByName("push-edit-lib")
+	if err != nil || stable == nil {
+		t.Fatalf("Failed to read the published package: %v", err)
+	}
+	publishTagged(t, env, pkgDir, "push-edit-lib", "2.0.0-beta.1", "module.exports = 'beta one';", "beta")
+
+	projectDir := env.newProject("push-edit-project")
+	env.addPkg(projectDir, "push-edit-lib@beta", false, false)
+
+	// Edit the pre-release, so the content the push carries is in no channel yet.
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'beta two';")
+	captureStdout(t, func() {
+		if err := cli.RunPushTagged(false, "beta"); err != nil {
+			t.Fatalf("Failed to push under a tag: %v", err)
+		}
+	})
+
+	assertTagged(t, env, "push-edit-lib", db.DefaultTag, stable.ContentHash)
+	env.AssertLinkedFileContent(projectDir, "push-edit-lib", "index.js", "module.exports = 'beta two';")
+
+	moved, err := env.Database.ResolveTag("push-edit-lib", "beta")
+	if err != nil || moved == nil {
+		t.Fatalf("Failed to re-resolve the beta tag: %v", err)
+	}
+	if moved.Version != "2.0.0-beta.1" {
+		t.Errorf("The beta tag names %s, want the build just pushed", moved.Version)
+	}
+}
+
 // TestRestorePutsBackTheBuildTheSnapshotRecorded pins that a retreat and a
 // restore leave a consumer on the channel it was on.
 //

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -441,3 +441,123 @@ func TestTagCarriesConsumersOfThatChannelOnly(t *testing.T) {
 		t.Errorf("The links follow %v, want one on beta and one on the default tag", tagsSeen)
 	}
 }
+
+// TestListStoreShowsWhichTagsNameEachVersion covers the fifth acceptance
+// criterion. With more than one version of a name live at once, the store
+// listing is the only place a user can see which of them a channel points at.
+func TestListStoreShowsWhichTagsNameEachVersion(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("listed-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "listed-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+
+	out := captureStdout(t, func() {
+		if err := cli.RunList(true, "", false); err != nil {
+			t.Errorf("RunList(--store) error = %v", err)
+		}
+	})
+
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.Contains(line, "listed-lib@1.0.0"):
+			if !strings.Contains(line, db.DefaultTag) {
+				t.Errorf("The 1.0.0 line does not name the %s tag: %q", db.DefaultTag, line)
+			}
+			if strings.Contains(line, "beta") {
+				t.Errorf("The 1.0.0 line claims the beta tag: %q", line)
+			}
+		case strings.Contains(line, "listed-lib@2.0.0-beta.1"):
+			if !strings.Contains(line, "beta") {
+				t.Errorf("The 2.0.0-beta.1 line does not name the beta tag: %q", line)
+			}
+			if strings.Contains(line, db.DefaultTag) {
+				t.Errorf("The 2.0.0-beta.1 line claims the %s tag: %q", db.DefaultTag, line)
+			}
+		}
+	}
+
+	if !strings.Contains(out, "listed-lib@1.0.0") || !strings.Contains(out, "listed-lib@2.0.0-beta.1") {
+		t.Errorf("The store listing is missing one of the two live versions, output was:\n%s", out)
+	}
+}
+
+// TestListStoreLeavesAnUntaggedVersionUnmarked pins that the tag column says
+// nothing when there is nothing to say. A superseded version no tag names is
+// exactly what gc will collect, and marking it would be a claim about a channel
+// that does not exist.
+func TestListStoreLeavesAnUntaggedVersionUnmarked(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("superseded-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'old';",
+	})
+	env.republish(pkgDir, "superseded-lib", "2.0.0", "module.exports = 'new';")
+
+	out := captureStdout(t, func() {
+		if err := cli.RunList(true, "", false); err != nil {
+			t.Errorf("RunList(--store) error = %v", err)
+		}
+	})
+
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "superseded-lib@1.0.0") && strings.Contains(line, db.DefaultTag) {
+			t.Errorf("The superseded version is shown as tagged: %q", line)
+		}
+	}
+	assertNoRawGlyphs(t, out)
+}
+
+// TestDoctorDoesNotCallATagPinnedBuildOrphaned pins a report that only became
+// reachable once `publish --tag` existed. doctor counts a package with no links
+// as an orphan and advises running gc - but gc keeps anything a non-default tag
+// names, so on a tagged build the advice describes a run that would find
+// nothing. Warning about a build lnpm is deliberately keeping is worse than
+// saying nothing: it sends a user to a command that cannot act on it.
+func TestDoctorDoesNotCallATagPinnedBuildOrphaned(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("doctor-tagged-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "doctor-tagged-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+
+	// Link the stable build so the only unlinked version left is the tagged one.
+	projectDir := env.newProject("doctor-tagged-project")
+	env.addPkg(projectDir, "doctor-tagged-lib", false, false)
+
+	out := captureStdout(t, func() {
+		if err := cli.RunDoctor(); err != nil {
+			t.Errorf("RunDoctor() error = %v", err)
+		}
+	})
+
+	if strings.Contains(out, "orphaned package(s)") {
+		t.Errorf("doctor called the tag-pinned build an orphan, output was:\n%s", out)
+	}
+	if !strings.Contains(out, "All checks passed!") {
+		t.Errorf("doctor did not pass on a store whose only unlinked build is tagged, output was:\n%s", out)
+	}
+}
+
+// TestDoctorStillReportsAnUntaggedOrphan is the other half: dropping tag-pinned
+// builds from the count must not drop the ones gc really would collect.
+func TestDoctorStillReportsAnUntaggedOrphan(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("doctor-super-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'old';",
+	})
+	env.republish(pkgDir, "doctor-super-lib", "2.0.0", "module.exports = 'new';")
+
+	out := captureStdout(t, func() {
+		if err := cli.RunDoctor(); err != nil {
+			t.Errorf("RunDoctor() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "orphaned package(s)") {
+		t.Errorf("doctor did not report the untagged, unlinked versions, output was:\n%s", out)
+	}
+}

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -1059,6 +1059,129 @@ func TestPushUnderATagMovesOnlyThatChannel(t *testing.T) {
 	}
 }
 
+// TestPushEditingATaggedBuildStaysOnItsChannel covers push's dominant workflow.
+// Push exists to propagate a *changed* working tree - an unchanged one is what
+// publish already handles - so the edit-and-push loop is the case that decides
+// whether push can release something nobody asked to release.
+//
+// Resolving the channel from the tags that name the packed content answers
+// nothing here: the edit gives the tree a hash no tag has ever named. What still
+// answers is the version string, which a push loop does not touch, so the tags
+// naming the stored record that carries it say which channel the tree belongs
+// to. Without that, an edit inside a pre-release moved the default tag onto the
+// pre-release and carried every latest-following consumer onto it, silently.
+func TestPushEditingATaggedBuildStaysOnItsChannel(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("push-loop-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	stable, err := env.Database.GetPackageByName("push-loop-lib")
+	if err != nil || stable == nil {
+		t.Fatalf("Failed to read the published package: %v", err)
+	}
+	publishTagged(t, env, pkgDir, "push-loop-lib", "2.0.0-beta.1", "module.exports = 'beta one';", "beta")
+
+	// A consumer of the stable channel, which the push must not disturb, and one
+	// of the pre-release channel, which is the one it is for.
+	consumerDir := env.newProject("push-loop-consumer")
+	env.addPkg(consumerDir, "push-loop-lib", false, false)
+	testerDir := env.newProject("push-loop-tester")
+	env.addPkg(testerDir, "push-loop-lib@beta", false, false)
+
+	// The loop: edit the pre-release's tree, bump nothing, push.
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'beta two';")
+	captureStdout(t, func() {
+		if err := cli.RunPush(false); err != nil {
+			t.Fatalf("Failed to push an edited pre-release: %v", err)
+		}
+	})
+
+	assertTagged(t, env, "push-loop-lib", db.DefaultTag, stable.ContentHash)
+	moved, err := env.Database.ResolveTag("push-loop-lib", "beta")
+	if err != nil || moved == nil {
+		t.Fatalf("Failed to re-resolve the beta tag: %v", err)
+	}
+	if moved.Version != "2.0.0-beta.1" {
+		t.Errorf("The beta tag names %s, want the pre-release just pushed", moved.Version)
+	}
+	env.AssertLinkedFileContent(consumerDir, "push-loop-lib", "index.js", "module.exports = 'stable';")
+	env.AssertLinkedFileContent(testerDir, "push-loop-lib", "index.js", "module.exports = 'beta two';")
+}
+
+// TestPushWarnsWhenItMovesTheDefaultTagOntoAnUnnamedBuild is the other side of
+// the rule above. Bumping the pre-release number is as ordinary as editing
+// without bumping, and it puts a version in the working tree that no stored
+// record carries, so nothing in the store can say which channel the build is
+// for and push falls back to the default tag. Falling back is defensible; doing
+// it silently, in a package that plainly has other channels, is not.
+func TestPushWarnsWhenItMovesTheDefaultTagOntoAnUnnamedBuild(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("push-warn-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "push-warn-lib", "2.0.0-beta.1", "module.exports = 'beta one';", "beta")
+
+	// Bump the pre-release, so the version names no stored record either.
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "package.json"), `{"name":"push-warn-lib","version":"2.0.0-beta.2"}`)
+	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'beta two';")
+
+	out := captureStdout(t, func() {
+		if err := cli.RunPush(false); err != nil {
+			t.Fatalf("Failed to push: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, db.DefaultTag+" tag onto it") {
+		t.Errorf("push did not say it was moving the default tag, output was:\n%s", out)
+	}
+	if !strings.Contains(out, "--tag") {
+		t.Errorf("push did not say how to publish to another channel, output was:\n%s", out)
+	}
+	assertNoRawGlyphs(t, out)
+}
+
+// TestPushOnABuildTwoChannelsNameProceeds pins that push does not refuse an
+// operation whose outcome is the same whichever way it is resolved.
+//
+// When two non-default tags name the packed content, every choice is a no-op on
+// the tags: each already points at that hash, so nothing moves and no link is
+// carried. Refusing it blocked a harmless push, and the state is reached
+// ordinarily by pointing a second channel at a build that already has one.
+func TestPushOnABuildTwoChannelsNameProceeds(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("push-two-tags-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	stable, err := env.Database.GetPackageByName("push-two-tags-lib")
+	if err != nil || stable == nil {
+		t.Fatalf("Failed to read the published package: %v", err)
+	}
+	publishTagged(t, env, pkgDir, "push-two-tags-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+	beta, err := env.Database.ResolveTag("push-two-tags-lib", "beta")
+	if err != nil || beta == nil {
+		t.Fatalf("Failed to resolve the beta tag: %v", err)
+	}
+	// The same build, pointed at by a second channel.
+	publishTagged(t, env, pkgDir, "push-two-tags-lib", "2.0.0-beta.1", "module.exports = 'beta';", "next")
+	assertTagged(t, env, "push-two-tags-lib", "next", beta.ContentHash)
+
+	env.chdir(pkgDir)
+	captureStdout(t, func() {
+		if err := cli.RunPush(false); err != nil {
+			t.Fatalf("Pushing a build two channels name was refused: %v", err)
+		}
+	})
+
+	assertTagged(t, env, "push-two-tags-lib", db.DefaultTag, stable.ContentHash)
+	assertTagged(t, env, "push-two-tags-lib", "beta", beta.ContentHash)
+	assertTagged(t, env, "push-two-tags-lib", "next", beta.ContentHash)
+}
+
 // TestRestoreAfterARepublishSaysToPull covers what hash-based restore turned a
 // failure into. A package republished while the project was retreated used to
 // have the consumer reported as missing from the store; now the recorded build

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -817,6 +817,83 @@ func TestSwitchingAProjectBackOntoLatest(t *testing.T) {
 	}
 }
 
+// TestStatusShowsWhichTagsNameEachVersion pins that the published table says
+// which channel each retained version belongs to. It lists one row per version
+// now, so without it my-lib 1.0.0 and my-lib 2.0.0-beta.1 sit side by side with
+// nothing to say which of them a plain `lnpm add` would give you.
+func TestStatusShowsWhichTagsNameEachVersion(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("status-tag-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "status-tag-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+
+	out := captureStdout(t, func() {
+		if err := cli.RunStatus(); err != nil {
+			t.Errorf("RunStatus() error = %v", err)
+		}
+	})
+
+	var stable, beta string
+	for _, line := range strings.Split(out, "\n") {
+		switch {
+		case strings.Contains(line, "1.0.0") && strings.Contains(line, "status-tag-lib"):
+			stable = line
+		case strings.Contains(line, "2.0.0-beta.1") && strings.Contains(line, "status-tag-lib"):
+			beta = line
+		}
+	}
+	if stable == "" || beta == "" {
+		t.Fatalf("The published table is missing one of the two live versions, output was:\n%s", out)
+	}
+	// Checked against the tag column's own text: the beta build's version string
+	// already holds "beta", so looking for the bare word would pass whether the
+	// column printed anything or not.
+	if !strings.Contains(stable, db.DefaultTag) {
+		t.Errorf("The 1.0.0 row does not name the %s tag: %q", db.DefaultTag, stable)
+	}
+	if strings.Count(beta, "beta") < 2 {
+		t.Errorf("The 2.0.0-beta.1 row does not name the beta tag beside its version: %q", beta)
+	}
+	assertNoRawGlyphs(t, out)
+}
+
+// TestListProjectsFindsConsumersOfATaggedBuild pins that `lnpm list <pkg>
+// --projects` sees every project consuming the package, whichever version each
+// is on. It resolved the name to one record, and the name index mirrors the
+// default tag, so a project that asked for a channel was simply invisible - in
+// the one command whose whole job is saying who consumes this package.
+func TestListProjectsFindsConsumersOfATaggedBuild(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("consumers-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "consumers-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+
+	stableProject := env.newProject("consumers-stable")
+	env.addPkg(stableProject, "consumers-lib", false, false)
+	betaProject := env.newProject("consumers-beta")
+	env.addPkg(betaProject, "consumers-lib@beta", false, false)
+
+	out := captureStdout(t, func() {
+		if err := cli.RunList(false, "consumers-lib", true); err != nil {
+			t.Errorf("RunList(--projects) error = %v", err)
+		}
+	})
+
+	for _, want := range []string{stableProject, betaProject} {
+		if !strings.Contains(out, want) {
+			t.Errorf("The listing does not name %s, output was:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "[beta]") || !strings.Contains(out, "["+db.DefaultTag+"]") {
+		t.Errorf("The listing does not say which version each consumer is on, output was:\n%s", out)
+	}
+	assertNoRawGlyphs(t, out)
+}
+
 // TestPushKeepsABetaBuildOffTheDefaultChannel pins that pushing does not
 // release. `lnpm push` re-publishes the working tree and relinks consumers, and
 // it used to record whatever it wrote under the default tag - so a bare push in

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -968,9 +968,16 @@ func TestListProjectsFindsConsumersOfATaggedBuild(t *testing.T) {
 		}
 	})
 
+	// The database normalises a project path through its symlinks on the way in,
+	// so the listing prints the resolved one. Resolved here too, or this fails
+	// under a TMPDIR that is itself a symlink and says nothing about the listing.
 	for _, want := range []string{stableProject, betaProject} {
-		if !strings.Contains(out, want) {
-			t.Errorf("The listing does not name %s, output was:\n%s", want, out)
+		resolved, err := filepath.EvalSymlinks(want)
+		if err != nil {
+			t.Fatalf("Failed to resolve %s: %v", want, err)
+		}
+		if !strings.Contains(out, resolved) {
+			t.Errorf("The listing does not name %s, output was:\n%s", resolved, out)
 		}
 	}
 	if !strings.Contains(out, "[beta]") || !strings.Contains(out, "["+db.DefaultTag+"]") {

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -627,6 +627,187 @@ func TestPullFollowsItsChannelForward(t *testing.T) {
 	})
 }
 
+// linkRowsFor returns every link row the project at projectDir holds for a
+// package name, whichever version each of them names.
+//
+// Deliberately not linksOfProject: that keys by name, so a project holding two
+// rows for one package collapses to one and the very defect these tests pin
+// becomes invisible.
+func linkRowsFor(t *testing.T, env *TestEnvironment, projectDir, name string) []*db.Link {
+	t.Helper()
+
+	proj, err := env.Database.GetProjectByPath(projectDir)
+	if err != nil || proj == nil {
+		t.Fatalf("Project %s is not in the database: %v", projectDir, err)
+	}
+	links, err := env.Database.GetLinksForProject(proj.ID)
+	if err != nil {
+		t.Fatalf("Failed to read the links of %s: %v", projectDir, err)
+	}
+	packages, err := env.Database.ListPackages()
+	if err != nil {
+		t.Fatalf("Failed to list packages: %v", err)
+	}
+	nameByID := make(map[int64]string, len(packages))
+	for _, pkg := range packages {
+		nameByID[pkg.ID] = pkg.Name
+	}
+
+	var held []*db.Link
+	for _, l := range links {
+		if nameByID[l.PackageID] == name {
+			held = append(held, l)
+		}
+	}
+	return held
+}
+
+// assertOnlyLink fails unless the project holds exactly one link row for name,
+// on the given version and following the given channel, and returns it.
+func assertOnlyLink(t *testing.T, env *TestEnvironment, projectDir, name string, wantPkg *db.Package, wantTag string) {
+	t.Helper()
+
+	held := linkRowsFor(t, env, projectDir, name)
+	if len(held) != 1 {
+		t.Fatalf("The project holds %d link row(s) for %s, want exactly 1: %+v", len(held), name, held)
+	}
+	if held[0].PackageID != wantPkg.ID {
+		t.Errorf("The link names record %d (%s), want %d (%s)",
+			held[0].PackageID, name, wantPkg.ID, wantPkg.Version)
+	}
+	if held[0].Tag != wantTag {
+		t.Errorf("The link follows tag %q, want %q", held[0].Tag, wantTag)
+	}
+}
+
+// republishPushed republishes a package and pushes it to every project linked
+// to the version the default tag lands on, which is what a maintainer's
+// ordinary `lnpm publish --push` does.
+func republishPushed(t *testing.T, env *TestEnvironment, pkgDir, name, version, indexJS string) {
+	t.Helper()
+
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "package.json"), `{"name":"`+name+`","version":"`+version+`"}`)
+	env.writeFile(filepath.Join(pkgDir, "index.js"), indexJS)
+	captureStdout(t, func() {
+		if err := cli.RunPublish(true, false, false, false); err != nil {
+			t.Fatalf("Failed to publish %s@%s with --push: %v", name, version, err)
+		}
+	})
+}
+
+// TestSwitchingAProjectOntoAChannel covers the flow the whole feature exists
+// for: a project already consuming a package opts into another channel of it.
+//
+// Nothing reconciles the link row the project already holds, so both shapes of
+// the switch used to corrupt it. When the two tags name different versions the
+// add wrote a second row, leaving the project recorded as consuming one package
+// twice - which moveLinksTx, linksOfProject and remove all treat as impossible -
+// and the stale row went on carrying the project onto every later release. When
+// the two tags name the same version, which is what `lnpm tag` produces, the add
+// found the existing row and updated it without recording the tag, so the
+// project stayed a latest follower and the next publish dragged it forward.
+//
+// The subtests differ only in whether the channels start out on one version or
+// two, which is exactly the distinction that decided which corruption happened.
+func TestSwitchingAProjectOntoAChannel(t *testing.T) {
+	cases := []struct {
+		name string
+		// separate publishes a distinct build under beta; otherwise beta is
+		// pointed at the version latest already names, as `lnpm tag` does.
+		separate bool
+		wantBeta string
+	}{
+		{name: "the channels name different versions", separate: true, wantBeta: "module.exports = 'beta';"},
+		{name: "the channels name one version", wantBeta: "module.exports = 'stable';"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupTest(t)
+
+			pkgDir := env.publishPkg("switch-lib", "1.0.0", map[string]string{
+				"index.js": "module.exports = 'stable';",
+			})
+			if tc.separate {
+				publishTagged(t, env, pkgDir, "switch-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+			} else if err := cli.RunTag("switch-lib", "beta", false); err != nil {
+				t.Fatalf("Failed to tag the stored version as beta: %v", err)
+			}
+
+			projectDir := env.newProject("switch-project")
+			env.addPkg(projectDir, "switch-lib", false, false)
+			env.addPkg(projectDir, "switch-lib@beta", false, false)
+
+			beta, err := env.Database.ResolveTag("switch-lib", "beta")
+			if err != nil || beta == nil {
+				t.Fatalf("Failed to resolve the beta tag: %v", err)
+			}
+			assertOnlyLink(t, env, projectDir, "switch-lib", beta, "beta")
+			env.AssertLinkedFileContent(projectDir, "switch-lib", "index.js", tc.wantBeta)
+
+			// A later release of the stable channel must reach neither the link
+			// row nor the files, whether or not it pushes.
+			env.republish(pkgDir, "switch-lib", "3.0.0", "module.exports = 'newer stable';")
+			assertOnlyLink(t, env, projectDir, "switch-lib", beta, "beta")
+
+			republishPushed(t, env, pkgDir, "switch-lib", "4.0.0", "module.exports = 'newest stable';")
+			assertOnlyLink(t, env, projectDir, "switch-lib", beta, "beta")
+			env.AssertLinkedFileContent(projectDir, "switch-lib", "index.js", tc.wantBeta)
+		})
+	}
+}
+
+// TestSwitchingAProjectBackOntoLatest is the other direction: a project that
+// tried a channel goes back to the stable release, and has to start following
+// it again - files, link row and all later publishes included.
+func TestSwitchingAProjectBackOntoLatest(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("unswitch-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "unswitch-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+
+	projectDir := env.newProject("unswitch-project")
+	env.addPkg(projectDir, "unswitch-lib@beta", false, false)
+	env.addPkg(projectDir, "unswitch-lib", false, false)
+
+	stable, err := env.Database.GetPackageByName("unswitch-lib")
+	if err != nil || stable == nil {
+		t.Fatalf("Failed to look up unswitch-lib by name: %v", err)
+	}
+	assertOnlyLink(t, env, projectDir, "unswitch-lib", stable, "")
+	env.AssertLinkedFileContent(projectDir, "unswitch-lib", "index.js", "module.exports = 'stable';")
+
+	// The project follows latest again, so a plain publish carries its link
+	// across and a pushing one refreshes its files.
+	env.republish(pkgDir, "unswitch-lib", "3.0.0", "module.exports = 'newer stable';")
+	newer, err := env.Database.GetPackageByName("unswitch-lib")
+	if err != nil || newer == nil {
+		t.Fatalf("Failed to look up unswitch-lib after the republish: %v", err)
+	}
+	assertOnlyLink(t, env, projectDir, "unswitch-lib", newer, "")
+
+	republishPushed(t, env, pkgDir, "unswitch-lib", "4.0.0", "module.exports = 'newest stable';")
+	newest, err := env.Database.GetPackageByName("unswitch-lib")
+	if err != nil || newest == nil {
+		t.Fatalf("Failed to look up unswitch-lib after the pushing republish: %v", err)
+	}
+	assertOnlyLink(t, env, projectDir, "unswitch-lib", newest, "")
+	env.AssertLinkedFileContent(projectDir, "unswitch-lib", "index.js", "module.exports = 'newest stable';")
+
+	// The beta build keeps no link of its own, so gc is free to collect it once
+	// the tag is dropped.
+	beta, err := env.Database.ResolveTag("unswitch-lib", "beta")
+	if err != nil || beta == nil {
+		t.Fatalf("Failed to resolve the beta tag: %v", err)
+	}
+	if links, _ := env.Database.GetLinksForPackage(beta.ID); len(links) != 0 {
+		t.Errorf("The beta build kept %d link row(s) after the project moved off it", len(links))
+	}
+}
+
 // TestUnlinkingATaggedConsumerDeletesItsLinkRow pins that the commands which
 // tear a project down delete the link the project actually holds.
 //

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -1,0 +1,153 @@
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/internal/db"
+)
+
+// publishTagged rewrites an already published package's source with a new
+// version and index.js, then publishes it under tag. It is republish with a tag,
+// and exists here rather than in helpers_test.go because only the dist-tag tests
+// need a publish that does not move latest.
+func publishTagged(t *testing.T, env *TestEnvironment, pkgDir, name, version, indexJS, tag string) {
+	t.Helper()
+
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "package.json"), `{"name":"`+name+`","version":"`+version+`"}`)
+	env.writeFile(filepath.Join(pkgDir, "index.js"), indexJS)
+	if err := cli.RunPublishTagged(false, false, false, false, tag); err != nil {
+		t.Fatalf("Failed to publish %s@%s under tag %s: %v", name, version, tag, err)
+	}
+}
+
+// assertTagged fails unless the named tag of pkg points at wantHash.
+func assertTagged(t *testing.T, env *TestEnvironment, name, tag, wantHash string) {
+	t.Helper()
+
+	tags, err := env.Database.TagsForPackage(name)
+	if err != nil {
+		t.Fatalf("Failed to read the tags of %s: %v", name, err)
+	}
+	if got := tags[tag]; got != wantHash {
+		t.Errorf("Tag %s of %s points at %q, want %q", tag, name, got, wantHash)
+	}
+}
+
+// TestPublishWithTagDoesNotMoveLatest covers the first acceptance criterion:
+// publishing under a tag stores the build and leaves latest where it was, so
+// consumers who never asked for the channel keep the release they had.
+func TestPublishWithTagDoesNotMoveLatest(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("tagged-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	stable, err := env.Database.GetPackageByName("tagged-lib")
+	if err != nil || stable == nil {
+		t.Fatalf("Failed to read the published package: %v", err)
+	}
+
+	publishTagged(t, env, pkgDir, "tagged-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+
+	assertTagged(t, env, "tagged-lib", db.DefaultTag, stable.ContentHash)
+
+	beta, err := env.Database.ResolveTag("tagged-lib", "beta")
+	if err != nil {
+		t.Fatalf("Failed to resolve the beta tag: %v", err)
+	}
+	if beta == nil {
+		t.Fatal("The beta tag names no version, want the build just published")
+	}
+	if beta.Version != "2.0.0-beta.1" {
+		t.Errorf("The beta tag names version %s, want 2.0.0-beta.1", beta.Version)
+	}
+
+	// The name index mirrors latest, so the stable release must still be what a
+	// lookup by name answers with.
+	byName, err := env.Database.GetPackageByName("tagged-lib")
+	if err != nil || byName == nil {
+		t.Fatalf("Failed to look up tagged-lib by name: %v", err)
+	}
+	if byName.Version != "1.0.0" {
+		t.Errorf("Looking tagged-lib up by name gives %s, want the untouched 1.0.0", byName.Version)
+	}
+}
+
+// TestPublishWithTagMovesTheTagOnUnchangedContent pins the case a happy-path
+// test cannot reach: publish returns early when the content it packed is already
+// in the store, and that early return has to be tag-aware. Without it a
+// `publish --tag beta` of an unchanged working tree reports success and sets no
+// tag at all.
+func TestPublishWithTagMovesTheTagOnUnchangedContent(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("unchanged-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'same';",
+	})
+	published, err := env.Database.GetPackageByName("unchanged-lib")
+	if err != nil || published == nil {
+		t.Fatalf("Failed to read the published package: %v", err)
+	}
+
+	env.chdir(pkgDir)
+	if err := cli.RunPublishTagged(false, false, false, false, "beta"); err != nil {
+		t.Fatalf("Failed to publish unchanged content under a tag: %v", err)
+	}
+
+	assertTagged(t, env, "unchanged-lib", "beta", published.ContentHash)
+	assertTagged(t, env, "unchanged-lib", db.DefaultTag, published.ContentHash)
+}
+
+// TestPublishWithoutTagStillSkipsUnchangedContent is the other half of the
+// condition above: making the early return tag-aware must not stop it firing for
+// an ordinary republish of unchanged content, which is what tells a user their
+// working tree holds nothing new.
+func TestPublishWithoutTagStillSkipsUnchangedContent(t *testing.T) {
+	env := setupTest(t)
+
+	env.publishPkg("noop-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'same';",
+	})
+
+	out := captureStdout(t, func() {
+		if err := cli.RunPublish(false, false, false, false); err != nil {
+			t.Errorf("Failed to re-publish unchanged content: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "already published with same content") {
+		t.Errorf("Re-publishing unchanged content did not report it, output was:\n%s", out)
+	}
+}
+
+// TestPublishFirstVersionUnderATagIsReachableByName pins that a package whose
+// first publish names some other channel is still addressable by name. Every
+// command but a tag-aware add - push, remove, restore, status - resolves through
+// the name index, so a beta-only package that never got the default tag would
+// sit in the store invisible to all of them.
+func TestPublishFirstVersionUnderATagIsReachableByName(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.CreateTestPackage("beta-only-lib", "0.1.0-beta.1", map[string]string{
+		"index.js": "module.exports = 'beta';",
+	})
+	env.chdir(pkgDir)
+	if err := cli.RunPublishTagged(false, false, false, false, "beta"); err != nil {
+		t.Fatalf("Failed to publish under a tag: %v", err)
+	}
+
+	pkg, err := env.Database.GetPackageByName("beta-only-lib")
+	if err != nil {
+		t.Fatalf("Failed to look up beta-only-lib by name: %v", err)
+	}
+	if pkg == nil {
+		t.Fatal("A package published only under beta is not reachable by name")
+	}
+
+	assertTagged(t, env, "beta-only-lib", "beta", pkg.ContentHash)
+	assertTagged(t, env, "beta-only-lib", db.DefaultTag, pkg.ContentHash)
+}

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -301,3 +301,143 @@ func TestAddMultipleResolvesTagsToo(t *testing.T) {
 		t.Errorf("The parallel add recorded links %+v, want exactly one following beta", links)
 	}
 }
+
+// TestTagPointsATagAtTheStoredVersion covers the fourth acceptance criterion's
+// first half: `lnpm tag mylib beta` names the version already in the store,
+// without a republish. Nothing is packed, hashed or copied - the store entry the
+// package resolves to is the one the tag ends up on.
+func TestTagPointsATagAtTheStoredVersion(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("taggable-lib")
+	stored, err := env.Database.GetPackageByName("taggable-lib")
+	if err != nil || stored == nil {
+		t.Fatalf("Failed to read the published package: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := cli.RunTag("taggable-lib", "beta", false); err != nil {
+			t.Errorf("RunTag() error = %v", err)
+		}
+	})
+
+	assertTagged(t, env, "taggable-lib", "beta", stored.ContentHash)
+	if !strings.Contains(out, "beta") || !strings.Contains(out, "taggable-lib") {
+		t.Errorf("RunTag did not report what it tagged, output was:\n%s", out)
+	}
+	assertNoRawGlyphs(t, out)
+
+	// A tag is only worth having if an add resolves through it.
+	projectDir := env.newProject("taggable-project")
+	env.addPkg(projectDir, "taggable-lib@beta", false, false)
+	env.AssertFilesLinked(projectDir, "taggable-lib")
+}
+
+// TestTagDeleteRemovesTheTag covers the criterion's second half: `--delete`
+// takes the tag off without touching the version it named, which stays in the
+// store and stays reachable by name.
+func TestTagDeleteRemovesTheTag(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("untaggable-lib")
+	if err := cli.RunTag("untaggable-lib", "beta", false); err != nil {
+		t.Fatalf("Failed to set the tag: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := cli.RunTag("untaggable-lib", "beta", true); err != nil {
+			t.Errorf("RunTag(delete) error = %v", err)
+		}
+	})
+
+	tags, err := env.Database.TagsForPackage("untaggable-lib")
+	if err != nil {
+		t.Fatalf("Failed to read the tags: %v", err)
+	}
+	if _, ok := tags["beta"]; ok {
+		t.Errorf("The beta tag survived --delete: %v", tags)
+	}
+	if _, ok := tags[db.DefaultTag]; !ok {
+		t.Errorf("Deleting beta also removed %s: %v", db.DefaultTag, tags)
+	}
+	env.AssertPackageInDatabase("untaggable-lib", true)
+	assertNoRawGlyphs(t, out)
+}
+
+// TestTagDeleteRefusesTheDefaultTag pins that the database's refusal reaches the
+// user rather than being worked around. The name index mirrors the default tag,
+// so removing it would leave the package published, its files on disk, and every
+// command that resolves by name unable to see it.
+func TestTagDeleteRefusesTheDefaultTag(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("keep-latest-lib")
+
+	err := cli.RunTag("keep-latest-lib", db.DefaultTag, true)
+	if err == nil {
+		t.Fatal("Deleting the default tag succeeded, want a refusal")
+	}
+	if !strings.Contains(err.Error(), db.DefaultTag) {
+		t.Errorf("The refusal is %v, want it to name the %s tag", err, db.DefaultTag)
+	}
+	env.AssertPackageInDatabase("keep-latest-lib", true)
+}
+
+// TestTagOnAnUnknownPackageFails pins that tagging something the store does not
+// hold is an error rather than a tag pointing at nothing. A dangling tag
+// resolves to nothing and, since tags are gc reachability roots, would protect
+// nothing either.
+func TestTagOnAnUnknownPackageFails(t *testing.T) {
+	env := setupTest(t)
+	_ = env
+
+	err := cli.RunTag("no-such-lib", "beta", false)
+	if err == nil {
+		t.Fatal("Tagging a package that is not in the store succeeded, want an error")
+	}
+	if !strings.Contains(err.Error(), "no-such-lib") {
+		t.Errorf("The error is %v, want it to name the package", err)
+	}
+}
+
+// TestTagCarriesConsumersOfThatChannelOnly pins what moving a tag on an existing
+// package does to the projects following it: the beta consumer is carried onto
+// the version beta now names, and the latest consumer is left where it is.
+func TestTagCarriesConsumersOfThatChannelOnly(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("carry-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'one';",
+	})
+	publishTagged(t, env, pkgDir, "carry-lib", "2.0.0-beta.1", "module.exports = 'two';", "beta")
+
+	betaProject := env.newProject("beta-consumer")
+	env.addPkg(betaProject, "carry-lib@beta", false, false)
+	stableProject := env.newProject("stable-consumer")
+	env.addPkg(stableProject, "carry-lib", false, false)
+
+	// Point beta back at the version latest names.
+	if err := cli.RunTag("carry-lib", "beta", false); err != nil {
+		t.Fatalf("Failed to move the beta tag: %v", err)
+	}
+
+	stable, err := env.Database.GetPackageByName("carry-lib")
+	if err != nil || stable == nil {
+		t.Fatalf("Failed to read carry-lib: %v", err)
+	}
+	links, err := env.Database.GetLinksForPackage(stable.ID)
+	if err != nil {
+		t.Fatalf("Failed to read the links of the stable build: %v", err)
+	}
+	if len(links) != 2 {
+		t.Fatalf("The stable build has %d link(s), want both consumers after beta was moved onto it", len(links))
+	}
+
+	tagsSeen := map[string]int{}
+	for _, l := range links {
+		tagsSeen[l.Tag]++
+	}
+	if tagsSeen["beta"] != 1 || tagsSeen[""] != 1 {
+		t.Errorf("The links follow %v, want one on beta and one on the default tag", tagsSeen)
+	}
+}

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -817,6 +817,91 @@ func TestSwitchingAProjectBackOntoLatest(t *testing.T) {
 	}
 }
 
+// TestAddWithLinkRefusesADistTag pins that the two ways of saying what to
+// resolve to cannot be combined. --link points .lnpm/<pkg> at the source
+// directory, which holds the working tree; a tag names a build in the store. The
+// add used to honour --link and print "tag: beta" anyway, telling the user they
+// were on a channel while they were on uncommitted files.
+func TestAddWithLinkRefusesADistTag(t *testing.T) {
+	cases := []struct {
+		name  string
+		specs []string
+	}{
+		{name: "single", specs: []string{"live-tag-lib@beta"}},
+		{name: "parallel", specs: []string{"live-tag-lib@beta", "live-plain-lib"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupTest(t)
+
+			pkgDir := env.publishPkg("live-tag-lib", "1.0.0", map[string]string{
+				"index.js": "module.exports = 'stable';",
+			})
+			publishTagged(t, env, pkgDir, "live-tag-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+			env.simplePkg("live-plain-lib")
+
+			projectDir := env.newProject("live-tag-project")
+			env.chdir(projectDir)
+
+			var err error
+			captureStdout(t, func() {
+				err = cli.RunAddMultiple(tc.specs, false, false, false, true)
+			})
+			if err == nil {
+				t.Fatal("Adding a tagged spec with --link succeeded, want a refusal")
+			}
+
+			// Nothing about the tagged package is linked, whichever path ran.
+			env.AssertDirectoryExists(filepath.Join(projectDir, ".lnpm", "live-tag-lib"), false)
+			env.AssertPackageJSONMissing(projectDir, "live-tag-lib")
+		})
+	}
+}
+
+// TestPullRepointsALinkRowLeftOnAnotherVersion pins that a refresh leaves the
+// database describing what it just linked.
+//
+// pull writes no link row because a publish that moves a tag carries the links
+// following it across, so the row add wrote already names the version pull
+// resolves. That does not hold once a tag has been deleted and set again by a
+// publish: there is no previous version to carry links from, so the row stays on
+// the build the project no longer has - which is the one remove deletes, the one
+// gc counts as a reason to keep a version, and the one `publish --tag --push`
+// pushes to.
+func TestPullRepointsALinkRowLeftOnAnotherVersion(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("repoint-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "repoint-lib", "2.0.0-beta.1", "module.exports = 'beta one';", "beta")
+
+	projectDir := env.newProject("repoint-project")
+	env.addPkg(projectDir, "repoint-lib@beta", false, false)
+
+	// Drop the channel and publish it afresh: nothing carries the link across.
+	if err := cli.RunTag("repoint-lib", "beta", true); err != nil {
+		t.Fatalf("Failed to delete the beta tag: %v", err)
+	}
+	publishTagged(t, env, pkgDir, "repoint-lib", "2.0.0-beta.2", "module.exports = 'beta two';", "beta")
+
+	env.chdir(projectDir)
+	captureStdout(t, func() {
+		if err := cli.RunPull(nil); err != nil {
+			t.Fatalf("Failed to pull: %v", err)
+		}
+	})
+
+	env.AssertLinkedFileContent(projectDir, "repoint-lib", "index.js", "module.exports = 'beta two';")
+
+	beta, err := env.Database.ResolveTag("repoint-lib", "beta")
+	if err != nil || beta == nil {
+		t.Fatalf("Failed to resolve the beta tag: %v", err)
+	}
+	assertOnlyLink(t, env, projectDir, "repoint-lib", beta, "beta")
+}
+
 // TestStatusShowsWhichTagsNameEachVersion pins that the published table says
 // which channel each retained version belongs to. It lists one row per version
 // now, so without it my-lib 1.0.0 and my-lib 2.0.0-beta.1 sit side by side with

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -561,3 +561,69 @@ func TestDoctorStillReportsAnUntaggedOrphan(t *testing.T) {
 		t.Errorf("doctor did not report the untagged, unlinked versions, output was:\n%s", out)
 	}
 }
+
+// TestPullKeepsAProjectOnItsChannel pins that refreshing does not switch
+// channels. pull resolves by name, and the name index mirrors latest, so a beta
+// consumer running `lnpm pull` would have its files replaced with the stable
+// release and its lock rewritten to match - the very carry-over onto latest that
+// asking for a channel exists to prevent, reached through a different command.
+//
+// Unreachable before add learned tags: no link could follow anything but the
+// default one.
+func TestPullKeepsAProjectOnItsChannel(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("pull-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "pull-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+
+	projectDir := env.newProject("pull-project")
+	env.addPkg(projectDir, "pull-lib@beta", false, false)
+
+	// Move latest well past the beta build.
+	env.republish(pkgDir, "pull-lib", "3.0.0", "module.exports = 'newer stable';")
+
+	env.chdir(projectDir)
+	if err := cli.RunPull(nil); err != nil {
+		t.Fatalf("Failed to pull: %v", err)
+	}
+
+	env.AssertLinkedFileContent(projectDir, "pull-lib", "index.js", "module.exports = 'beta';")
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		entry, _ := lock.Get("pull-lib")
+		if entry.Version != "2.0.0-beta.1" {
+			t.Errorf("pull rewrote the lock to %s, want the beta build 2.0.0-beta.1", entry.Version)
+		}
+	})
+}
+
+// TestPullFollowsItsChannelForward is the other half: staying on a channel must
+// still mean picking up what that channel now names, or pull would have stopped
+// doing its job for tagged consumers.
+func TestPullFollowsItsChannelForward(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("pull-forward-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "pull-forward-lib", "2.0.0-beta.1", "module.exports = 'beta one';", "beta")
+
+	projectDir := env.newProject("pull-forward-project")
+	env.addPkg(projectDir, "pull-forward-lib@beta", false, false)
+
+	publishTagged(t, env, pkgDir, "pull-forward-lib", "2.0.0-beta.2", "module.exports = 'beta two';", "beta")
+
+	env.chdir(projectDir)
+	if err := cli.RunPull(nil); err != nil {
+		t.Fatalf("Failed to pull: %v", err)
+	}
+
+	env.AssertLinkedFileContent(projectDir, "pull-forward-lib", "index.js", "module.exports = 'beta two';")
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		entry, _ := lock.Get("pull-forward-lib")
+		if entry.Version != "2.0.0-beta.2" {
+			t.Errorf("pull recorded %s, want the newer beta build 2.0.0-beta.2", entry.Version)
+		}
+	})
+}

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
 	"github.com/pedrosousa13/lnpm/internal/db"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
 
 // publishTagged rewrites an already published package's source with a new
@@ -150,4 +151,153 @@ func TestPublishFirstVersionUnderATagIsReachableByName(t *testing.T) {
 
 	assertTagged(t, env, "beta-only-lib", "beta", pkg.ContentHash)
 	assertTagged(t, env, "beta-only-lib", db.DefaultTag, pkg.ContentHash)
+}
+
+// TestAddByTagLinksTheTaggedBuild covers the second acceptance criterion:
+// `lnpm add mylib@beta` materialises the build the beta tag names, not the one
+// latest names.
+func TestAddByTagLinksTheTaggedBuild(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("channel-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "channel-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+
+	projectDir := env.newProject("channel-project")
+	env.addPkg(projectDir, "channel-lib@beta", false, false)
+
+	env.AssertLinkedFileContent(projectDir, "channel-lib", "index.js", "module.exports = 'beta';")
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		entry, ok := lock.Get("channel-lib")
+		if !ok {
+			t.Fatal("channel-lib is missing from the lock file")
+		}
+		if entry.Version != "2.0.0-beta.1" {
+			t.Errorf("The lock file records version %s, want the tagged 2.0.0-beta.1", entry.Version)
+		}
+	})
+}
+
+// TestAddByTagRecordsTheTagOnTheLink pins that a project which asked for a
+// channel is recorded as following it. Without the tag on the link row, the next
+// time latest moves the link is carried onto it and the beta consumer is
+// silently switched to the stable release it deliberately did not ask for.
+func TestAddByTagRecordsTheTagOnTheLink(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("pinned-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "pinned-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+
+	projectDir := env.newProject("pinned-project")
+	env.addPkg(projectDir, "pinned-lib@beta", false, false)
+
+	beta, err := env.Database.ResolveTag("pinned-lib", "beta")
+	if err != nil || beta == nil {
+		t.Fatalf("Failed to resolve the beta tag: %v", err)
+	}
+	links, err := env.Database.GetLinksForPackage(beta.ID)
+	if err != nil {
+		t.Fatalf("Failed to read the links of the beta build: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("The beta build has %d link(s), want exactly 1", len(links))
+	}
+	if links[0].Tag != "beta" {
+		t.Errorf("The link follows tag %q, want beta", links[0].Tag)
+	}
+
+	// Moving latest must leave the beta consumer where it is.
+	env.republish(pkgDir, "pinned-lib", "3.0.0", "module.exports = 'newer stable';")
+
+	stillBeta, err := env.Database.ResolveTag("pinned-lib", "beta")
+	if err != nil || stillBeta == nil {
+		t.Fatalf("Failed to re-resolve the beta tag: %v", err)
+	}
+	links, err = env.Database.GetLinksForPackage(stillBeta.ID)
+	if err != nil {
+		t.Fatalf("Failed to re-read the links of the beta build: %v", err)
+	}
+	if len(links) != 1 {
+		t.Errorf("Publishing to latest left the beta build with %d link(s), want 1", len(links))
+	}
+}
+
+// TestAddWithoutATagStillResolvesLatest covers the third acceptance criterion:
+// the default resolution is untouched, so a plain add gets the build latest
+// names even when another channel holds something newer.
+func TestAddWithoutATagStillResolvesLatest(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("default-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "default-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+
+	projectDir := env.newProject("default-project")
+	env.addPkg(projectDir, "default-lib", false, false)
+
+	env.AssertLinkedFileContent(projectDir, "default-lib", "index.js", "module.exports = 'stable';")
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		entry, _ := lock.Get("default-lib")
+		if entry.Version != "1.0.0" {
+			t.Errorf("A plain add recorded version %s, want the latest-tagged 1.0.0", entry.Version)
+		}
+	})
+}
+
+// TestAddByAnUnsetTagStillReportsTheVersion pins that resolving a tag first does
+// not swallow the message an exact-version add gives. A spec that names no tag
+// falls through to the version check, which is what still tells a user their
+// version is not the one in the store.
+func TestAddByAnUnsetTagStillReportsTheVersion(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("exact-lib")
+	projectDir := env.newProject("exact-project")
+	env.chdir(projectDir)
+
+	err := cli.RunAdd("exact-lib@9.9.9", false, false, false)
+	if err == nil {
+		t.Fatal("Adding a version that is neither a tag nor the stored version succeeded, want an error")
+	}
+	if !strings.Contains(err.Error(), "9.9.9") || !strings.Contains(err.Error(), "1.0.0") {
+		t.Errorf("The error is %v, want it to name both the requested and the stored version", err)
+	}
+}
+
+// TestAddMultipleResolvesTagsToo pins that the parallel add path resolves a tag
+// the same way the single-package one does. The two duplicate their resolution,
+// and a fix applied to only one of them is exactly the kind of drift that makes
+// `lnpm add a@beta b` behave differently from `lnpm add a@beta`.
+func TestAddMultipleResolvesTagsToo(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("multi-tagged-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "multi-tagged-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+	env.simplePkg("multi-plain-lib")
+
+	projectDir := env.newProject("multi-project")
+	env.chdir(projectDir)
+	if err := cli.RunAddMultiple([]string{"multi-tagged-lib@beta", "multi-plain-lib"}, false, false, false, false); err != nil {
+		t.Fatalf("Failed to add a tagged and a plain package together: %v", err)
+	}
+
+	env.AssertLinkedFileContent(projectDir, "multi-tagged-lib", "index.js", "module.exports = 'beta';")
+
+	beta, err := env.Database.ResolveTag("multi-tagged-lib", "beta")
+	if err != nil || beta == nil {
+		t.Fatalf("Failed to resolve the beta tag: %v", err)
+	}
+	links, err := env.Database.GetLinksForPackage(beta.ID)
+	if err != nil {
+		t.Fatalf("Failed to read the links of the beta build: %v", err)
+	}
+	if len(links) != 1 || links[0].Tag != "beta" {
+		t.Errorf("The parallel add recorded links %+v, want exactly one following beta", links)
+	}
 }

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -626,3 +626,63 @@ func TestPullFollowsItsChannelForward(t *testing.T) {
 		}
 	})
 }
+
+// TestUnlinkingATaggedConsumerDeletesItsLinkRow pins that the commands which
+// tear a project down delete the link the project actually holds.
+//
+// Both find it by name, and the name index mirrors latest, so a project linked
+// to a tagged version had its files unlinked and its lock cleared while the link
+// row survived. What is left is not cosmetic: status and `list --projects` keep
+// naming a project that no longer consumes the package, `publish --tag --push`
+// tries to push into it, and gc counts the link as valid and so never collects
+// the version - the one build a tag was deliberately keeping is joined by one
+// nothing is keeping on purpose.
+//
+// Unreachable before add learned tags: every link was on the version latest
+// named, so looking it up by name always found it.
+func TestUnlinkingATaggedConsumerDeletesItsLinkRow(t *testing.T) {
+	cases := []struct {
+		name   string
+		unlink func(t *testing.T) error
+	}{
+		{"remove", func(t *testing.T) error { return cli.RunRemove("unlink-lib", false, true) }},
+		{"retreat", func(t *testing.T) error { return cli.RunRetreat(true, false) }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupTest(t)
+
+			pkgDir := env.publishPkg("unlink-lib", "1.0.0", map[string]string{
+				"index.js": "module.exports = 'stable';",
+			})
+			publishTagged(t, env, pkgDir, "unlink-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+
+			projectDir := env.newProject("unlink-project")
+			env.addPkg(projectDir, "unlink-lib@beta", false, false)
+
+			beta, err := env.Database.ResolveTag("unlink-lib", "beta")
+			if err != nil || beta == nil {
+				t.Fatalf("Failed to resolve the beta tag: %v", err)
+			}
+			if links, _ := env.Database.GetLinksForPackage(beta.ID); len(links) != 1 {
+				t.Fatalf("The beta build starts with %d link(s), want 1", len(links))
+			}
+
+			env.chdir(projectDir)
+			captureStdout(t, func() {
+				if err := tc.unlink(t); err != nil {
+					t.Errorf("Failed to unlink: %v", err)
+				}
+			})
+
+			links, err := env.Database.GetLinksForPackage(beta.ID)
+			if err != nil {
+				t.Fatalf("Failed to read the links of the beta build: %v", err)
+			}
+			if len(links) != 0 {
+				t.Errorf("The beta build kept %d link row(s) after %s", len(links), tc.name)
+			}
+		})
+	}
+}

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -388,8 +388,7 @@ func TestTagDeleteRefusesTheDefaultTag(t *testing.T) {
 // resolves to nothing and, since tags are gc reachability roots, would protect
 // nothing either.
 func TestTagOnAnUnknownPackageFails(t *testing.T) {
-	env := setupTest(t)
-	_ = env
+	setupTest(t)
 
 	err := cli.RunTag("no-such-lib", "beta", false)
 	if err == nil {

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -817,6 +817,58 @@ func TestSwitchingAProjectBackOntoLatest(t *testing.T) {
 	}
 }
 
+// TestRestorePutsBackTheBuildTheSnapshotRecorded pins that a retreat and a
+// restore leave a consumer on the channel it was on.
+//
+// restore used to resolve by name and compare the snapshot's version against
+// what the default tag names, so every consumer of a tagged build was reported
+// as missing from the store and skipped - while the build it asked for sat in
+// the store the whole time. The snapshot records the content hash, which names
+// that build exactly.
+func TestRestorePutsBackTheBuildTheSnapshotRecorded(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("restore-tagged-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'stable';",
+	})
+	publishTagged(t, env, pkgDir, "restore-tagged-lib", "2.0.0-beta.1", "module.exports = 'beta';", "beta")
+
+	projectDir := env.newProject("restore-tagged-project")
+	env.addPkg(projectDir, "restore-tagged-lib@beta", false, false)
+
+	env.chdir(projectDir)
+	captureStdout(t, func() {
+		if err := cli.RunRetreat(true, false); err != nil {
+			t.Fatalf("Failed to retreat: %v", err)
+		}
+	})
+
+	var out string
+	var err error
+	out = captureStdout(t, func() { err = cli.RunRestore() })
+	if err != nil {
+		t.Fatalf("Failed to restore a consumer of a tagged build: %v\n%s", err, out)
+	}
+
+	env.AssertLinkedFileContent(projectDir, "restore-tagged-lib", "index.js", "module.exports = 'beta';")
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		entry, ok := lock.Get("restore-tagged-lib")
+		if !ok {
+			t.Fatal("restore-tagged-lib is missing from the lock file")
+		}
+		if entry.Version != "2.0.0-beta.1" {
+			t.Errorf("restore recorded version %s, want the beta build 2.0.0-beta.1", entry.Version)
+		}
+	})
+
+	// The snapshot cannot say which channel the project followed, so the
+	// restored link follows the default one and restore has to say so.
+	if !strings.Contains(out, db.DefaultTag+" tag does not name") {
+		t.Errorf("restore did not warn that the channel could not be restored, output was:\n%s", out)
+	}
+	assertNoRawGlyphs(t, out)
+}
+
 // TestUnlinkingATaggedConsumerDeletesItsLinkRow pins that the commands which
 // tear a project down delete the link the project actually holds.
 //


### PR DESCRIPTION
Closes #196.

Adds npm-style dist-tags: `lnpm publish --tag beta` stores a build without moving
`latest`, `lnpm add mylib@beta` opts a consumer into that channel, `lnpm tag`
manages tags without republishing, and `lnpm list --store` shows which tags name
each version. `lnpm add mylib` is unchanged and still resolves to `latest`.

## The store already retained versions; the database did not

The issue framed this as deciding whether the store must keep multiple versions'
file trees. It already did — `store.Store` writes `store/<name>/<hash>` and never
removes a sibling. Only the **database** discarded the old version, by overwriting
the record for a name. Package records are now addressed by `(name, hash)`, with a
`tags` bucket mapping `(name, tag)` → hash and `packages_by_name` continuing to
mirror whatever `latest` names, written in the same transaction so the two cannot
disagree.

An existing database is migrated on open, inside the same transaction that creates
the buckets: every entry gets `latest → its hash`. Nothing is rewritten or deleted,
so it commits whole or not at all and re-runs safely after an interrupted upgrade.
A database written by a *newer* build is now refused at open rather than operated
on with this build's assumptions.

## `latest` is not a garbage-collection root

`gc` now keeps a version any link **or** any non-default tag reaches.

`latest` is deliberately excluded, and that is a maintainer decision recorded in
`docs/adr/0002`. Publish moves `latest` onto everything it writes, so treating it
as a root would mean no current version could ever be collected — in a store where
nothing was published twice, `gc` would run, report nothing and free nothing.

A consequence, disclosed in the ADR: a version can outlive its package's name.
`db.go`'s comments used to assert that state was impossible; they now say what is
true — publish never creates it, `gc` may, and the next publish of that name clears
it.

## Links were the largest piece, and were not in the issue

Links reference package IDs and are looked up by name, so they must be carried
across when a tag moves or `publish --push`, `push`, `remove`, `retreat` and
`status` all break for existing consumers. `InsertLink` is now the chokepoint that
enforces one row per `(project, name)`: it updates the row naming the same record —
carrying `Tag` — and deletes any row the project holds on another version of that
name.

Without that, the issue's own motivating flow was broken: a consumer already on
`latest` running `add mylib@beta` either stayed recorded as a `latest` follower
(and got dragged forward on the next publish) or gained a second link row, after
which `publish --push` **overwrote the beta consumer's files with `latest`
content**. Both are reproduced and pinned by tests.

## Four commands were holed by the same mechanism

Each resolved a package by name, which now names the wrong record for a tagged
consumer. All four became reachable only because `add` learned tags here.

- **`pull`** relinked a beta consumer onto `latest`'s content and rewrote its lock.
- **`remove` / `retreat`** deleted the link found by name, which matched nothing —
  files unlinked, lock cleared, link row orphaned. `retreat` reported success while
  doing it.
- **`restore`** reported every tagged consumer as "not in the store" and skipped it.
  It now resolves through the hash the snapshot already records.
- **`doctor`** counted tag-pinned builds as orphans and advised running `gc`, which
  would keep them.

## `lnpm push` no longer silently promotes a pre-release

Bare `lnpm push` hardcoded `latest`, so pushing an edited beta tree moved `latest`
onto a pre-release and dragged every latest-following consumer onto it, silently.

Push now works its channel out in two steps — tags naming the packed content, then
tags naming a stored record carrying the working tree's version, which is what an
edit-and-push loop looks like — falling back to the default tag with a **loud
warning** when the package has channels and neither question answers. `--tag`
overrides. The version-bump case (`beta.1` → `beta.2`) reaches the fallback, which
is why the warning exists rather than inference alone.

## Error paths that deleted or tore down on a read failure

Three reads swallowed their error and treated failure as "nothing there":
`gc` deleted a linked package's store entry, `retreat` tore the project down and
reported success, and `doctor` over-counted orphans. All three now surface the
failure; `gc` and `retreat` abort before mutating anything.

## Verification

`go test ./... -count=1`, `go vet`, `golangci-lint`, `gofmt -l`, plus build and vet
for windows/amd64, darwin/arm64 and linux/arm64 — all clean, and the full suite
re-run under a symlinked `TMPDIR`, which caught a real path-normalisation bug in a
new test.

Three review passes ran over this: both axes, then a verification pass over the
fix round. The verification pass found that a **pre-existing** test had gone
vacuous under the new `InsertLink` — its setup built the duplicate link it existed
to test by calling `InsertLink` twice, which now de-duplicates. It was rebuilt to
write the rows directly, and the merge branch was confirmed live by making it panic
and watching the new test fail where the old one had passed.

Every new test was revert-checked. No pre-existing test was weakened; the one that
changed name (`TestRestoreReportsStaleVersionAndContinues` →
`TestRestoreReportsACollectedBuildAndContinues`) did so because republishing no
longer strands a build — collecting it does — and it kept its assertions.

**`-race` could not run locally (no gcc) and Windows/macOS rest on CI**; local
gates cross-compile but never execute.

## Known limits, deliberate

- `lnpm tag <pkg> <tag>` can only point a tag at what `latest` names — there is no
  version argument, so no promoting a beta build to `next`. Naming a superseded
  version needs a content hash, which is #197's territory.
- A restored consumer follows the default channel. Neither the lock file nor the
  retreat snapshot records a tag, and guessing from today's tags would be guessing
  about a decision made before the retreat. Restore now says so and points at
  `lnpm pull` or `lnpm add <pkg>@<tag>` as appropriate.
- `add --link` with a tag is rejected: a live link resolves to the working tree, so
  the two requests contradict each other.
