### PR TITLE
feat(list): add version history and roll back with add <pkg>@<hash>

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -299,8 +299,11 @@ Add a package from the store to current project.
 # Add latest published version
 lnpm add my-package
 
-# Add a specific version (must match the version latest names)
+# Add a specific version, from anywhere in the retained history
 lnpm add my-package@1.0.0
+
+# Roll back to a specific published build, by content-hash prefix
+lnpm add my-package@a1b2c3d4
 
 # Add whatever the beta channel currently names
 lnpm add my-package@beta
@@ -316,12 +319,20 @@ lnpm add my-package --link
 ```
 
 **Process:**
-1. Find the version in the store. What follows the `@` is read as a dist-tag
-   first and as an exact version only when no tag by that name is set; a spec
-   with no `@` resolves through `latest`. The tag is recorded on the link row,
-   so a later move of `latest` does not carry this project onto it
-   (`--link` is refused with a tag: it resolves to the source directory, which
-   is not the build any tag names)
+1. Find the version in the store. What follows the `@` is matched in three
+   steps, most specific first: as a dist-tag; then as an exact version, against
+   every version the store has retained and not only the one `latest` names;
+   then as a content-hash prefix of at least four characters, git's minimum for
+   an abbreviated object name. A spec with no `@` resolves through `latest`. A
+   spec that matches two retained versions is refused with their full hashes
+   rather than resolved to one of them. A tag is recorded on the link row, so a
+   later move of `latest` does not carry this project onto it; a version and a
+   hash name a build rather than a channel, so the link they write follows
+   `latest` and the next `lnpm pull` moves the project off that build
+
+   None of the three can be combined with `--link`: that resolves to the source
+   directory, which holds the working tree and is not the build any of them
+   names
 2. Create a temporary directory alongside `.lnpm/{package}/`
 3. Hard link all files from store into it, write the `.lnpm-linked` manifest,
    then rename it to `.lnpm/{package}/`
@@ -565,6 +576,9 @@ lnpm list --store
 
 # List all projects using a package
 lnpm list my-package --projects
+
+# List every retained version of a package, newest first
+lnpm list my-package --versions
 ```
 
 `--store` marks each version with the tags naming it, as a trailing
@@ -576,6 +590,16 @@ is left unmarked, and is what `lnpm gc` will collect once nothing links it.
 one record, and says which build each consumer is on. Resolving by name would
 answer with the version `latest` points at, leaving every project that asked for
 a channel out of the one listing whose job is naming who consumes this package.
+
+`--versions` is one package's history: every version the store still holds,
+newest first, with its content hash, its version, when it was published, the
+dist-tags naming it and the projects linked to it. That set is exactly what
+`lnpm gc` has not collected, because a version's record and its store entry go
+together — there is no separate "ever published" history, and nothing here
+retains anything gc would otherwise take. It is what `lnpm add <pkg>@<hash>` can
+roll a project back to. It cannot be combined with `--projects`: the two answer
+different questions about the same package, so serving one silently would answer
+a question the user did not ask.
 
 ### `lnpm tag <package> <tag>`
 

--- a/README.md
+++ b/README.md
@@ -147,13 +147,14 @@ lnpm add my-package@beta
 lnpm add my-package        # still the latest release
 ```
 
-What follows the `@` is read as a tag first and as an exact version only if no
-tag by that name is set. A project that added a package under a tag keeps
-following it: `lnpm pull` refreshes it to whatever that tag now names, never to
-`latest`. Switching channels is just another `lnpm add` — `lnpm add
-my-package@beta` in a project already on `latest` moves it over, and dropping the
-tag moves it back. A tag cannot be combined with `--link`, which resolves to the
-source directory rather than to any published build.
+What follows the `@` is read as a tag first, then as an exact version, then as a
+content-hash prefix — the last two are what [roll a project back](#version-history-and-rollback).
+A project that added a package under a tag keeps following it: `lnpm pull`
+refreshes it to whatever that tag now names, never to `latest`. Switching
+channels is just another `lnpm add` — `lnpm add my-package@beta` in a project
+already on `latest` moves it over, and dropping the tag moves it back. None of
+the three can be combined with `--link`, which resolves to the source directory
+rather than to any published build.
 
 `lnpm push` goes to the channel the build in the store already carries, so
 pushing a pre-release keeps it a pre-release. An edit gives the tree content no
@@ -185,8 +186,10 @@ tree from a git checkout:
 ```bash
 lnpm list mylib --versions
 # mylib versions:
-#   a1b2c3d4   1.3.0   published 2 hours ago   [latest]
-#   9f8e7d6c   1.2.0   published 3 days ago    (currently linked in myapp)
+#   HASH       VERSION        PUBLISHED            TAGS                 LINKED IN
+#   -----------------------------------------------------------------------------
+#   a1b2c3d4   1.3.0          2 hours ago          latest
+#   9f8e7d6c   1.2.0          3 days ago                                ~/apps/myapp
 
 cd ~/apps/myapp
 lnpm add mylib@9f8e7d6c   # Roll this project back to the build that worked
@@ -194,14 +197,22 @@ lnpm add mylib@9f8e7d6c   # Roll this project back to the build that worked
 
 Either identifier the listing prints works. What follows the `@` is matched as a
 dist-tag first, then as an exact version against every retained version, then as
-a content-hash prefix — the eight characters the listing shows are enough, and
-more if that ever names two builds. A spec that names two builds is refused with
-their full hashes rather than resolved to one of them.
+a content-hash prefix of at least four characters. The eight characters the
+listing shows are enough; type more of them if that ever names two builds. A spec
+that names two builds is refused with their full hashes rather than resolved to
+one of them.
 
 The history is the set `lnpm gc` has not collected: a version stays for as long
 as a link or a tag you set reaches it. A version a project has rolled back to is
 linked, so `gc` keeps it — while the versions in between, which nothing reaches
 any more, are reclaimed.
+
+A rollback holds until that project runs `lnpm pull`. A rolled-back link follows
+no channel, so a pull resolves it through `latest`, moves the project onto the
+current release and repoints the link — after which `gc` is free to collect the
+build the project was on. Bare `lnpm pull` refreshes every package in the lock,
+so pulling one package can undo another package's rollback with no signal. There
+is no pinned link yet: re-run `lnpm add mylib@<hash>` to go back.
 
 ### Monorepo Support
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ lnpm push
 | `lnpm pull [pkg...]` | Sync linked packages with the store (all of them when no name is given) |
 | `lnpm push` | Push changes to all linked projects (`--tag` picks the channel) |
 | `lnpm status` | Show all published packages and active links across every project |
-| `lnpm list` | List this project's linked packages (`--store` lists the store, `--projects` lists consumers) |
+| `lnpm list` | List this project's linked packages (`--store` lists the store, `--projects` lists consumers, `--versions` lists one package's history) |
 | `lnpm tag <pkg> <tag>` | Point a dist-tag at a published package (`--delete` removes one) |
 | `lnpm check` | Fail if lnpm has left anything an `npm publish` would ship (pre-publish guard) |
 | `lnpm doctor` | Diagnose issues |
@@ -175,6 +175,33 @@ lnpm list --store                   # Shows which tags name each stored version
 It is also not a garbage-collection root: only a tag you set keeps a version
 alive, because `latest` moves onto everything a publish writes and treating it
 as a root would leave `lnpm gc` unable to reclaim anything.
+
+### Version History and Rollback
+
+Publishing keeps the version published before it, so a release that breaks one
+consumer can be undone for that consumer alone — no republishing an old source
+tree from a git checkout:
+
+```bash
+lnpm list mylib --versions
+# mylib versions:
+#   a1b2c3d4   1.3.0   published 2 hours ago   [latest]
+#   9f8e7d6c   1.2.0   published 3 days ago    (currently linked in myapp)
+
+cd ~/apps/myapp
+lnpm add mylib@9f8e7d6c   # Roll this project back to the build that worked
+```
+
+Either identifier the listing prints works. What follows the `@` is matched as a
+dist-tag first, then as an exact version against every retained version, then as
+a content-hash prefix — the eight characters the listing shows are enough, and
+more if that ever names two builds. A spec that names two builds is refused with
+their full hashes rather than resolved to one of them.
+
+The history is the set `lnpm gc` has not collected: a version stays for as long
+as a link or a tag you set reaches it. A version a project has rolled back to is
+linked, so `gc` keeps it — while the versions in between, which nothing reaches
+any more, are reclaimed.
 
 ### Monorepo Support
 

--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ lnpm list mylib --versions
 # mylib versions:
 #   HASH       VERSION        PUBLISHED            TAGS                 LINKED IN
 #   -----------------------------------------------------------------------------
-#   a1b2c3d4   1.3.0          2 hours ago          latest
-#   9f8e7d6c   1.2.0          3 days ago                                ~/apps/myapp
+#   a1b2c3d4   1.3.0          2 hours ago          latest               ~/apps/myapp
+#   9f8e7d6c   1.2.0          3 days ago
 
 cd ~/apps/myapp
 lnpm add mylib@9f8e7d6c   # Roll this project back to the build that worked

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -98,8 +98,8 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 			name, version := parsePackageSpec(pkgSpec)
 
 			// Resolved exactly as the single-package path resolves it: a tag
-			// first, then the version latest names.
-			pkg, tag, lookupErr := resolveAddSpec(database, name, version)
+			// first, then an exact version, then a content-hash prefix.
+			pkg, tag, kind, lookupErr := resolveAddSpec(database, name, version)
 			if lookupErr != nil {
 				result.err = lookupErr
 				results <- result
@@ -114,8 +114,8 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 			result.pkg = pkg
 			result.tag = tag
 
-			if useLink && !isDefaultTag(tag) {
-				result.err = liveLinkTagError(name, tag)
+			if useLink && kind != specDefault {
+				result.err = liveLinkSpecError(name, version, kind)
 				results <- result
 				return
 			}
@@ -491,9 +491,9 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useL
 		return fmt.Errorf("failed to open database: %w", err)
 	}
 
-	// Find the version in the store: a tag if the spec names one, otherwise the
-	// version latest points at, which a requested version must match.
-	pkg, tag, err := resolveAddSpec(database, name, version)
+	// Find the version in the store: a tag if the spec names one, then an exact
+	// version against the whole retained history, then a content-hash prefix.
+	pkg, tag, kind, err := resolveAddSpec(database, name, version)
 	if err != nil {
 		return err
 	}
@@ -501,8 +501,8 @@ func runAddSingle(packageSpec string, dev bool, pure bool, runInstall bool, useL
 		return fmt.Errorf("package %s not found in store. Did you run 'lnpm publish' in the package directory?", name)
 	}
 
-	if useLink && !isDefaultTag(tag) {
-		return liveLinkTagError(name, tag)
+	if useLink && kind != specDefault {
+		return liveLinkSpecError(name, version, kind)
 	}
 
 	if useLink {
@@ -654,8 +654,28 @@ func parsePackageSpec(spec string) (name, version string) {
 	return spec, ""
 }
 
-// resolveAddSpec works out which version of name an add should link, and which
-// channel the resulting link follows.
+// specKind says how a spec's @suffix resolved.
+//
+// The returned tag cannot carry this. A tag comes back as itself, but a version
+// and a hash both come back with an empty tag, because they name a build rather
+// than a channel - and so does a bare name. Anything reading the tag string to
+// decide what the user asked for therefore cannot tell "nothing" from "this
+// exact build", which is the distinction --link turns on.
+//
+// The kinds are strings rather than iota constants so that the zero value is
+// none of them: a path that forgot to report a kind then reads as "not a bare
+// name", which is the refusing side of every guard below.
+type specKind string
+
+const (
+	specDefault specKind = "default" // no @suffix: the default channel
+	specTag     specKind = "tag"
+	specVersion specKind = "version"
+	specHash    specKind = "hash"
+)
+
+// resolveAddSpec works out which version of name an add should link, which
+// channel the resulting link follows, and how the spec resolved.
 //
 // requested is whatever followed the @ in the spec, and it is matched in three
 // steps, most specific first:
@@ -686,48 +706,50 @@ func parsePackageSpec(spec string) (name, version string) {
 //
 // A returned tag of "" means the link follows the default one, which is how
 // every link written before tags existed reads. A hash or a version resolves to
-// a build rather than to a channel, so it returns "" too.
+// a build rather than to a channel, so it returns "" too - which is why the
+// returned specKind, and not the tag, is what a caller reads to find out what
+// the user asked for.
 //
 // An unknown name is reported as a nil package rather than an error, because the
 // two add paths word that one differently and both wordings predate tags.
-func resolveAddSpec(database *db.DB, name, requested string) (*db.Package, string, error) {
+func resolveAddSpec(database *db.DB, name, requested string) (*db.Package, string, specKind, error) {
 	if requested == "" {
 		pkg, err := database.GetPackageByName(name)
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to look up package: %w", err)
+			return nil, "", specDefault, fmt.Errorf("failed to look up package: %w", err)
 		}
-		return pkg, "", nil
+		return pkg, "", specDefault, nil
 	}
 
 	tagged, err := database.ResolveTag(name, requested)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to resolve tag %s of %s: %w", requested, name, err)
+		return nil, "", specTag, fmt.Errorf("failed to resolve tag %s of %s: %w", requested, name, err)
 	}
 	if tagged != nil {
-		return tagged, requested, nil
+		return tagged, requested, specTag, nil
 	}
 
 	versions, err := database.GetPackageVersions(name)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to read the versions of %s: %w", name, err)
+		return nil, "", specVersion, fmt.Errorf("failed to read the versions of %s: %w", name, err)
 	}
 	if len(versions) == 0 {
-		return nil, "", nil
+		return nil, "", specVersion, nil
 	}
 
 	current, err := database.GetPackageByName(name)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to look up package: %w", err)
+		return nil, "", specVersion, fmt.Errorf("failed to look up package: %w", err)
 	}
 
 	if pkg, err := matchVersion(versions, current, name, requested); pkg != nil || err != nil {
-		return pkg, "", err
+		return pkg, "", specVersion, err
 	}
 	if pkg, err := matchHashPrefix(versions, name, requested); pkg != nil || err != nil {
-		return pkg, "", err
+		return pkg, "", specHash, err
 	}
 
-	return nil, "", versionNotInStoreError(requested, name, versions)
+	return nil, "", specVersion, versionNotInStoreError(requested, name, versions)
 }
 
 // matchVersion finds the retained version whose version string is exactly
@@ -790,21 +812,26 @@ func describeHashes(candidates []*db.Package) string {
 	return strings.Join(hashes, ", ")
 }
 
-// liveLinkTagError refuses a spec that names a dist-tag alongside --link.
+// liveLinkSpecError refuses a spec that names a build alongside --link.
 //
 // The two say different things about what to resolve to, and only one of them
-// can be honoured. A tag names a build in the store; --link points
-// .lnpm/<package> at the source directory the package was published from, which
-// holds whatever is in the working tree - unpublished, possibly uncommitted, and
-// not what any tag names. Doing both is impossible, and doing --link while
-// reporting the tag, which is what the summary line did, tells the user they are
-// on a channel when they are not.
+// can be honoured. A tag, a version and a hash each name a build in the store;
+// --link points .lnpm/<package> at the source directory the package was
+// published from, which holds whatever is in the working tree - unpublished,
+// possibly uncommitted, and not what any of the three names. Doing both is
+// impossible, and doing --link while reporting the spec, which is what the
+// summary line did, tells the user they are on a build they are not on. A hash
+// names a build more specifically than a tag does, so it is refused for the same
+// reason and more sharply.
 //
 // Refused rather than warned about because the two are a contradiction in the
 // request, not a risk in it: there is no version of this add that does what the
 // spec asks for, so the user has to decide which half to drop.
-func liveLinkTagError(name, tag string) error {
-	return fmt.Errorf("cannot add %s@%s with --link: --link resolves to the package's source directory, which is not the build any tag names (drop --link to get the %s build, or drop the tag to link the source)", name, tag, tag)
+func liveLinkSpecError(name, requested string, kind specKind) error {
+	if kind == specTag {
+		return fmt.Errorf("cannot add %s@%s with --link: --link resolves to the package's source directory, which is not the build any tag names (drop --link to get the %s build, or drop the tag to link the source)", name, requested, requested)
+	}
+	return fmt.Errorf("cannot add %s@%s with --link: --link resolves to the package's source directory, which holds the working tree and not the build %s names (drop --link to get that build, or drop the @%s to link the source)", name, requested, requested, requested)
 }
 
 // versionNotInStoreError reports that nothing the store retains for name

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -657,36 +657,137 @@ func parsePackageSpec(spec string) (name, version string) {
 // resolveAddSpec works out which version of name an add should link, and which
 // channel the resulting link follows.
 //
-// requested is whatever followed the @ in the spec, and a tag is tried before a
-// version: `pkg@beta` has to mean the build beta names, and only a spec that
-// matches no tag falls through to the exact-version check that has always been
-// there. A returned tag of "" means the link follows the default one, which is
-// how every link written before tags existed reads.
+// requested is whatever followed the @ in the spec, and it is matched in three
+// steps, most specific first:
+//
+//  1. a dist-tag, so `pkg@beta` links the build beta names. A tag is a name a
+//     person chose for this package, so it wins even when it is spelled like a
+//     version or a hash;
+//  2. an exact version string, against every version the store has retained -
+//     not only the one the default tag names, which is all this could see while
+//     the store held one record per name;
+//  3. a content-hash prefix, against the same set.
+//
+// Steps 2 and 3 are what makes a rollback possible: `lnpm list <pkg> --versions`
+// prints a version and an eight-character short hash per row, and both have to
+// be typeable back. Resolving only the hash would mean showing a user two
+// identifiers and accepting one of them.
+//
+// Widening step 2 past the default tag cannot change an answer that already
+// existed. A version spec used to resolve only when it matched what the default
+// tag names, and that record is still preferred when several carry the version -
+// which two publishes can produce, since package.json can be kept out of a pack.
+// Beyond that preference an ambiguous spec is refused, never guessed: this is
+// the command reached for when a release broke something, so choosing between
+// two builds on the user's behalf is the last thing it should do. A hash prefix
+// has no such preference, because a prefix is not a claim about which version
+// was meant - any prefix that names one version resolves, and one that names
+// several is sent back with the full hashes, as git does.
+//
+// A returned tag of "" means the link follows the default one, which is how
+// every link written before tags existed reads. A hash or a version resolves to
+// a build rather than to a channel, so it returns "" too.
 //
 // An unknown name is reported as a nil package rather than an error, because the
 // two add paths word that one differently and both wordings predate tags.
 func resolveAddSpec(database *db.DB, name, requested string) (*db.Package, string, error) {
-	if requested != "" {
-		tagged, err := database.ResolveTag(name, requested)
+	if requested == "" {
+		pkg, err := database.GetPackageByName(name)
 		if err != nil {
-			return nil, "", fmt.Errorf("failed to resolve tag %s of %s: %w", requested, name, err)
+			return nil, "", fmt.Errorf("failed to look up package: %w", err)
 		}
-		if tagged != nil {
-			return tagged, requested, nil
-		}
+		return pkg, "", nil
 	}
 
-	pkg, err := database.GetPackageByName(name)
+	tagged, err := database.ResolveTag(name, requested)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to resolve tag %s of %s: %w", requested, name, err)
+	}
+	if tagged != nil {
+		return tagged, requested, nil
+	}
+
+	versions, err := database.GetPackageVersions(name)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to read the versions of %s: %w", name, err)
+	}
+	if len(versions) == 0 {
+		return nil, "", nil
+	}
+
+	current, err := database.GetPackageByName(name)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to look up package: %w", err)
 	}
-	if pkg == nil {
-		return nil, "", nil
+
+	if pkg, err := matchVersion(versions, current, name, requested); pkg != nil || err != nil {
+		return pkg, "", err
 	}
-	if requested != "" && pkg.Version != requested {
-		return nil, "", versionNotInStoreError(requested, name, pkg.Version)
+	if pkg, err := matchHashPrefix(versions, name, requested); pkg != nil || err != nil {
+		return pkg, "", err
 	}
-	return pkg, "", nil
+
+	return nil, "", versionNotInStoreError(requested, name, versions)
+}
+
+// matchVersion finds the retained version whose version string is exactly
+// requested, or nil when none is. current is the version the default tag names,
+// which breaks a tie in favour of the answer this lookup gave before it could
+// see past that tag.
+func matchVersion(versions []*db.Package, current *db.Package, name, requested string) (*db.Package, error) {
+	var candidates []*db.Package
+	for _, v := range versions {
+		if v.Version == requested {
+			if current != nil && v.ID == current.ID {
+				return v, nil
+			}
+			candidates = append(candidates, v)
+		}
+	}
+
+	switch len(candidates) {
+	case 0:
+		return nil, nil
+	case 1:
+		return candidates[0], nil
+	default:
+		return nil, fmt.Errorf("version %s of %s is ambiguous: %d retained versions carry it (%s); ask for one of them by hash",
+			requested, name, len(candidates), describeHashes(candidates))
+	}
+}
+
+// matchHashPrefix finds the retained version whose content hash starts with
+// requested, or nil when none does. A prefix several versions share is refused
+// with their full hashes, so the user can lengthen it rather than be handed
+// whichever record was walked first.
+func matchHashPrefix(versions []*db.Package, name, requested string) (*db.Package, error) {
+	var candidates []*db.Package
+	for _, v := range versions {
+		if strings.HasPrefix(v.ContentHash, requested) {
+			candidates = append(candidates, v)
+		}
+	}
+
+	switch len(candidates) {
+	case 0:
+		return nil, nil
+	case 1:
+		return candidates[0], nil
+	default:
+		return nil, fmt.Errorf("hash prefix %s of %s is ambiguous: it matches %d retained versions (%s); use more characters",
+			requested, name, len(candidates), describeHashes(candidates))
+	}
+}
+
+// describeHashes renders candidates as their full content hashes, which is what
+// a user has to type to tell them apart. The short hash a listing prints is by
+// definition not enough here: it is the thing that turned out to be ambiguous.
+func describeHashes(candidates []*db.Package) string {
+	hashes := make([]string, len(candidates))
+	for i, c := range candidates {
+		hashes[i] = c.ContentHash
+	}
+	return strings.Join(hashes, ", ")
 }
 
 // liveLinkTagError refuses a spec that names a dist-tag alongside --link.
@@ -706,22 +807,36 @@ func liveLinkTagError(name, tag string) error {
 	return fmt.Errorf("cannot add %s@%s with --link: --link resolves to the package's source directory, which is not the build any tag names (drop --link to get the %s build, or drop the tag to link the source)", name, tag, tag)
 }
 
-// versionNotInStoreError reports that the store holds a different version of
-// name than the one the user asked for, shared by the parallel and the
+// versionNotInStoreError reports that nothing the store retains for name
+// answers to what the user asked for, shared by the parallel and the
 // single-package add paths so both tell the user the same thing.
 //
-// The parameters are declared in the order the message reads them. All three
-// are plain strings, so a caller that swaps two still compiles and quietly
-// produces a message that lies about which version is which; keeping
-// declaration order and interpolation order identical is what makes such a
-// swap visible at the call site.
+// Every retained version is named, and that is the whole change from the message
+// this replaces. That one reported what the default tag points at as though it
+// were the only version there was - true while the store held one record per
+// name, and misleading the moment it stopped being, because the version the user
+// asked for may be sitting in the store one row down. This is exactly the moment
+// they need to be told what is there to roll back to.
 //
 // The remedy is a trailing parenthetical rather than a second sentence: the
 // parallel path wraps this error as "<spec>: %w", so the string has to compose
 // as a clause, and a terminal period would read badly there as well as trip
 // staticcheck's ST1005.
-func versionNotInStoreError(requested, name, stored string) error {
-	return fmt.Errorf("version %s of %s not found in store (latest published is %s; re-publish %s to update)", requested, name, stored, name)
+func versionNotInStoreError(requested, name string, retained []*db.Package) error {
+	return fmt.Errorf("no version of %s matches %s (retained: %s; run 'lnpm list %s --versions' for the full history)",
+		name, requested, describeVersions(retained), name)
+}
+
+// describeVersions renders retained versions as "1.3.0 (a1b2c3d4)", in the order
+// GetPackageVersions returns them, which is newest first. The short hash is the
+// one `lnpm list --versions` prints, so what the error shows is what the user
+// would type back.
+func describeVersions(retained []*db.Package) string {
+	described := make([]string, len(retained))
+	for i, v := range retained {
+		described[i] = fmt.Sprintf("%s (%s)", v.Version, shortHash(v.ContentHash))
+	}
+	return strings.Join(described, ", ")
 }
 
 // packageJSONDeps is what reading package.json tells us about a dependency

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -749,7 +749,7 @@ func resolveAddSpec(database *db.DB, name, requested string) (*db.Package, strin
 		return pkg, "", specHash, err
 	}
 
-	return nil, "", specVersion, versionNotInStoreError(requested, name, versions)
+	return nil, "", specVersion, versionNotInStoreError(name, requested, versions)
 }
 
 // matchVersion finds the retained version whose version string is exactly
@@ -838,7 +838,13 @@ func liveLinkSpecError(name, requested string, kind specKind) error {
 // answers to what the user asked for, shared by the parallel and the
 // single-package add paths so both tell the user the same thing.
 //
-// Every retained version is named, and that is the whole change from the message
+// The parameters are declared in the order the message reads them. name and
+// requested are both plain strings, so a caller that swaps them still compiles
+// and quietly produces a message that lies about which is which - "no version of
+// 1.0.0 matches mylib"; keeping declaration order and interpolation order
+// identical is what makes such a swap visible at the call site.
+//
+// The retained versions are named, and that is the whole change from the message
 // this replaces. That one reported what the default tag points at as though it
 // were the only version there was - true while the store held one record per
 // name, and misleading the moment it stopped being, because the version the user
@@ -849,19 +855,37 @@ func liveLinkSpecError(name, requested string, kind specKind) error {
 // parallel path wraps this error as "<spec>: %w", so the string has to compose
 // as a clause, and a terminal period would read badly there as well as trip
 // staticcheck's ST1005.
-func versionNotInStoreError(requested, name string, retained []*db.Package) error {
+func versionNotInStoreError(name, requested string, retained []*db.Package) error {
 	return fmt.Errorf("no version of %s matches %s (retained: %s; run 'lnpm list %s --versions' for the full history)",
 		name, requested, describeVersions(retained), name)
 }
+
+// describedVersions is how many retained versions versionNotInStoreError names
+// before falling back to a count.
+const describedVersions = 5
 
 // describeVersions renders retained versions as "1.3.0 (a1b2c3d4)", in the order
 // GetPackageVersions returns them, which is newest first. The short hash is the
 // one `lnpm list --versions` prints, so what the error shows is what the user
 // would type back.
+//
+// Only the newest describedVersions are spelled out, with the rest counted. The
+// message already points at `lnpm list <pkg> --versions`, so it does not have to
+// be the history: a package with thirty retained versions would otherwise
+// produce a single ~700-character error, which the parallel add path then wraps
+// again. Every other display path in lnpm caps what it prints the same way.
 func describeVersions(retained []*db.Package) string {
-	described := make([]string, len(retained))
-	for i, v := range retained {
-		described[i] = fmt.Sprintf("%s (%s)", v.Version, shortHash(v.ContentHash))
+	shown := retained
+	if len(shown) > describedVersions {
+		shown = shown[:describedVersions]
+	}
+
+	described := make([]string, 0, len(shown)+1)
+	for _, v := range shown {
+		described = append(described, fmt.Sprintf("%s (%s)", truncate(v.Version, 14), shortHash(v.ContentHash)))
+	}
+	if omitted := len(retained) - len(shown); omitted > 0 {
+		described = append(described, fmt.Sprintf("and %d more", omitted))
 	}
 	return strings.Join(described, ", ")
 }

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -674,6 +674,16 @@ const (
 	specHash    specKind = "hash"
 )
 
+// minHashPrefix is the shortest @suffix the hash step will consider, borrowed
+// from git's minimum for an abbreviated object name.
+//
+// Without a floor, `lnpm add mylib@2` - a user who means version 2 - is matched
+// against content hashes, and a single retained hash beginning with "2" resolves
+// it to that build. Nothing about the spec says the user meant a hash, so a
+// short suffix that matches no version has to reach the dead end that names the
+// retained versions rather than a verdict about hash prefixes.
+const minHashPrefix = 4
+
 // resolveAddSpec works out which version of name an add should link, which
 // channel the resulting link follows, and how the spec resolved.
 //
@@ -686,7 +696,8 @@ const (
 //  2. an exact version string, against every version the store has retained -
 //     not only the one the default tag names, which is all this could see while
 //     the store held one record per name;
-//  3. a content-hash prefix, against the same set.
+//  3. a content-hash prefix of at least minHashPrefix characters, against the
+//     same set.
 //
 // Steps 2 and 3 are what makes a rollback possible: `lnpm list <pkg> --versions`
 // prints a version and an eight-character short hash per row, and both have to
@@ -782,7 +793,14 @@ func matchVersion(versions []*db.Package, current *db.Package, name, requested s
 // requested, or nil when none does. A prefix several versions share is refused
 // with their full hashes, so the user can lengthen it rather than be handed
 // whichever record was walked first.
+//
+// Anything shorter than minHashPrefix is not treated as a hash at all, for the
+// reason given there.
 func matchHashPrefix(versions []*db.Package, name, requested string) (*db.Package, error) {
+	if len(requested) < minHashPrefix {
+		return nil, nil
+	}
+
 	var candidates []*db.Package
 	for _, v := range versions {
 		if strings.HasPrefix(v.ContentHash, requested) {

--- a/internal/cli/add_test.go
+++ b/internal/cli/add_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pedrosousa13/lnpm/internal/db"
@@ -266,5 +267,243 @@ func TestStoreFilesForLinkTakesTheRecordedModeNotTheStoresOwn(t *testing.T) {
 		if f.Mode.Perm() != 0644 {
 			t.Errorf("storeFilesForLink() reports index.js as %v, want the published 0644: push reports the recorded mode, and a relink across the two rewrites every file they disagree about", f.Mode)
 		}
+	}
+}
+
+// --- resolveAddSpec: version history and rollback -----------------------------
+
+// seedVersion records one version of a package, so the resolution tests read as
+// a history rather than as struct literals. StorePath is set because everything
+// downstream of a resolved package uses it; nothing here reads its contents.
+func seedVersion(t *testing.T, database *db.DB, name, version, hash string) *db.Package {
+	t.Helper()
+
+	pkg := &db.Package{
+		Name:        name,
+		Version:     version,
+		ContentHash: hash,
+		SourcePath:  filepath.Join("/src", name),
+		StorePath:   filepath.Join("/store", name, hash),
+	}
+	if err := database.InsertPackage(pkg); err != nil {
+		t.Fatalf("seed %s@%s (%s): %v", name, version, hash, err)
+	}
+	return pkg
+}
+
+// TestResolveAddSpecResolvesAContentHash covers the rollback selector the issue
+// asks for: a spec naming a content hash links that exact build, including one
+// `latest` has moved off.
+//
+// The prefix cases are the point rather than a convenience. `lnpm list --versions`
+// prints an eight-character short hash, so a user retypes a prefix and never the
+// whole thing; a resolver that only took the full hash would refuse the only
+// identifier the listing ever showed them.
+func TestResolveAddSpecResolvesAContentHash(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		requested string
+	}{
+		{"short hash, as list --versions prints it", "aaaaaaaa"},
+		{"full hash", "aaaaaaaa11111111"},
+		{"a shorter prefix that is still unique", "aaaa"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, database := newGCStore(t)
+
+			old := seedVersion(t, database, "rollback-pkg", "1.0.0", "aaaaaaaa11111111")
+			seedVersion(t, database, "rollback-pkg", "2.0.0", "bbbbbbbb22222222")
+
+			pkg, tag, err := resolveAddSpec(database, "rollback-pkg", tc.requested)
+			if err != nil {
+				t.Fatalf("resolveAddSpec(%s) error = %v", tc.requested, err)
+			}
+			if pkg == nil {
+				t.Fatalf("resolveAddSpec(%s) resolved nothing, want the version that hash names", tc.requested)
+			}
+			if pkg.ID != old.ID {
+				t.Errorf("resolveAddSpec(%s) resolved %s@%s, want the superseded 1.0.0", tc.requested, pkg.Version, pkg.ContentHash)
+			}
+			if tag != "" {
+				t.Errorf("resolveAddSpec(%s) reported tag %q; a hash names a build, not a channel", tc.requested, tag)
+			}
+		})
+	}
+}
+
+// TestResolveAddSpecResolvesASupersededVersion pins the other half of the
+// selector. `lnpm list --versions` prints a semver version beside every hash, so
+// a user will type the version; refusing it while the record is right there would
+// be showing an identifier and then declining to accept it.
+//
+// This only widens an existing selector. A version spec already resolved when it
+// matched what `latest` names; it now also resolves against the versions latest
+// has moved off, so nothing that resolved before resolves differently.
+func TestResolveAddSpecResolvesASupersededVersion(t *testing.T) {
+	_, database := newGCStore(t)
+
+	old := seedVersion(t, database, "superseded-spec-pkg", "1.0.0", "aaaaaaaa11111111")
+	seedVersion(t, database, "superseded-spec-pkg", "2.0.0", "bbbbbbbb22222222")
+
+	pkg, tag, err := resolveAddSpec(database, "superseded-spec-pkg", "1.0.0")
+	if err != nil {
+		t.Fatalf("resolveAddSpec(1.0.0) error = %v", err)
+	}
+	if pkg == nil || pkg.ID != old.ID {
+		t.Fatalf("resolveAddSpec(1.0.0) resolved %v, want the superseded 1.0.0 record", pkg)
+	}
+	if tag != "" {
+		t.Errorf("resolveAddSpec(1.0.0) reported tag %q, want the default channel", tag)
+	}
+}
+
+// TestResolveAddSpecPrefersTheVersionTheDefaultTagNames guards against the one
+// regression widening the version selector could cause.
+//
+// Two records can carry one version string: package.json can be excluded from a
+// pack, and two publishes then differ in content while claiming the same version.
+// Before, `pkg@1.0.0` compared against what latest names and got it. Preferring
+// that record keeps the answer identical, and leaves the ambiguity refusal below
+// for the case that used to be a flat error anyway.
+func TestResolveAddSpecPrefersTheVersionTheDefaultTagNames(t *testing.T) {
+	_, database := newGCStore(t)
+
+	seedVersion(t, database, "collide-pkg", "1.0.0", "aaaaaaaa11111111")
+	current := seedVersion(t, database, "collide-pkg", "1.0.0", "bbbbbbbb22222222")
+
+	pkg, _, err := resolveAddSpec(database, "collide-pkg", "1.0.0")
+	if err != nil {
+		t.Fatalf("resolveAddSpec(1.0.0) error = %v; this resolved before the history existed and must go on resolving", err)
+	}
+	if pkg == nil || pkg.ID != current.ID {
+		t.Fatalf("resolveAddSpec(1.0.0) resolved %v, want the version the default tag names", pkg)
+	}
+}
+
+// TestResolveAddSpecRefusesAnAmbiguousVersion pins that a version string carried
+// by several superseded records is refused rather than guessed at. This is the
+// command a user reaches for when a release broke something; picking one of two
+// builds for them is the last thing it should do.
+func TestResolveAddSpecRefusesAnAmbiguousVersion(t *testing.T) {
+	_, database := newGCStore(t)
+
+	seedVersion(t, database, "ambiguous-version-pkg", "1.0.0", "aaaaaaaa11111111")
+	seedVersion(t, database, "ambiguous-version-pkg", "1.0.0", "bbbbbbbb22222222")
+	seedVersion(t, database, "ambiguous-version-pkg", "2.0.0", "cccccccc33333333")
+
+	pkg, _, err := resolveAddSpec(database, "ambiguous-version-pkg", "1.0.0")
+	if err == nil {
+		t.Fatalf("resolveAddSpec(1.0.0) resolved %v, want a refusal: two retained versions carry 1.0.0", pkg)
+	}
+	for _, want := range []string{"aaaaaaaa", "bbbbbbbb"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal is %v, want it to name the candidate %s so the user can pick one", err, want)
+		}
+	}
+}
+
+// TestResolveAddSpecRefusesAnAmbiguousHashPrefix is the same rule for the looser
+// selector. A prefix is not a claim about which version was meant, so a prefix
+// two of them share has to be sent back rather than resolved to whichever record
+// bolt happened to hand over first.
+func TestResolveAddSpecRefusesAnAmbiguousHashPrefix(t *testing.T) {
+	_, database := newGCStore(t)
+
+	seedVersion(t, database, "ambiguous-hash-pkg", "1.0.0", "aaaaaaaa11111111")
+	seedVersion(t, database, "ambiguous-hash-pkg", "2.0.0", "aaaaaaaa22222222")
+
+	pkg, _, err := resolveAddSpec(database, "ambiguous-hash-pkg", "aaaaaaaa")
+	if err == nil {
+		t.Fatalf("resolveAddSpec(aaaaaaaa) resolved %v, want a refusal: the prefix matches two versions", pkg)
+	}
+	for _, want := range []string{"aaaaaaaa11111111", "aaaaaaaa22222222"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal is %v, want it to name the candidate %s so the user can lengthen the prefix", err, want)
+		}
+	}
+}
+
+// TestResolveAddSpecPrefersATagOverAVersionAndAHash pins the first step of the
+// resolution order, which predates this change and must survive it: a tag is a
+// name a human chose for this package, so it wins over both.
+func TestResolveAddSpecPrefersATagOverAVersionAndAHash(t *testing.T) {
+	_, database := newGCStore(t)
+
+	seedVersion(t, database, "tagfirst-pkg", "1.0.0", "aaaaaaaa11111111")
+	pinned := seedVersion(t, database, "tagfirst-pkg", "2.0.0", "bbbbbbbb22222222")
+	// A tag named exactly like the other version, which is the only way the two
+	// steps can be made to disagree.
+	if err := database.SetTag("tagfirst-pkg", "1.0.0", pinned.ContentHash); err != nil {
+		t.Fatalf("set the tag: %v", err)
+	}
+
+	pkg, tag, err := resolveAddSpec(database, "tagfirst-pkg", "1.0.0")
+	if err != nil {
+		t.Fatalf("resolveAddSpec(1.0.0) error = %v", err)
+	}
+	if pkg == nil || pkg.ID != pinned.ID {
+		t.Fatalf("resolveAddSpec(1.0.0) resolved %v, want the version the tag names", pkg)
+	}
+	if tag != "1.0.0" {
+		t.Errorf("resolveAddSpec reported tag %q, want the link to follow the channel that was asked for", tag)
+	}
+}
+
+// TestResolveAddSpecPrefersAVersionOverAHashPrefix pins the second step against
+// the third. An exact match on a whole version string is more specific than a
+// prefix match on a hash, so it wins - and the order has to be fixed rather than
+// incidental, because the two can be made to collide.
+func TestResolveAddSpecPrefersAVersionOverAHashPrefix(t *testing.T) {
+	_, database := newGCStore(t)
+
+	// One record is named "aaaaaaaa"; another's content hash starts with it. The
+	// named one is seeded first so the default tag has moved off it, which is
+	// what stops this passing on the old "compare against latest" rule alone.
+	named := seedVersion(t, database, "collide-order-pkg", "aaaaaaaa", "bbbbbbbb22222222")
+	seedVersion(t, database, "collide-order-pkg", "2.0.0", "aaaaaaaa11111111")
+
+	pkg, _, err := resolveAddSpec(database, "collide-order-pkg", "aaaaaaaa")
+	if err != nil {
+		t.Fatalf("resolveAddSpec(aaaaaaaa) error = %v", err)
+	}
+	if pkg == nil || pkg.ID != named.ID {
+		t.Fatalf("resolveAddSpec(aaaaaaaa) resolved %v, want the record whose version is exactly aaaaaaaa", pkg)
+	}
+}
+
+// TestResolveAddSpecErrorNamesEveryRetainedVersion pins the wording of the dead
+// end. The message used to name what `latest` points at as though it were the
+// only version there is, which stopped being true the moment the store retained
+// more than one - and it is the exact moment the user needs to be told what else
+// is available to roll back to.
+func TestResolveAddSpecErrorNamesEveryRetainedVersion(t *testing.T) {
+	_, database := newGCStore(t)
+
+	seedVersion(t, database, "deadend-pkg", "1.0.0", "aaaaaaaa11111111")
+	seedVersion(t, database, "deadend-pkg", "2.0.0", "bbbbbbbb22222222")
+
+	_, _, err := resolveAddSpec(database, "deadend-pkg", "9.9.9")
+	if err == nil {
+		t.Fatal("resolveAddSpec(9.9.9) succeeded, want a refusal: no version carries it")
+	}
+	for _, want := range []string{"1.0.0", "2.0.0", "aaaaaaaa", "bbbbbbbb"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal is %v, want it to name the retained version %s the user could roll back to", err, want)
+		}
+	}
+}
+
+// TestResolveAddSpecOnAnUnknownNameResolvesNothing pins that a name the store
+// has never held stays a nil package rather than becoming an error. The two add
+// paths word that one differently, and both wordings predate this change.
+func TestResolveAddSpecOnAnUnknownNameResolvesNothing(t *testing.T) {
+	_, database := newGCStore(t)
+
+	pkg, _, err := resolveAddSpec(database, "no-such-pkg", "1.0.0")
+	if err != nil {
+		t.Fatalf("resolveAddSpec on an unknown name error = %v, want the caller to word it", err)
+	}
+	if pkg != nil {
+		t.Errorf("resolveAddSpec on an unknown name resolved %v", pkg)
 	}
 }

--- a/internal/cli/add_test.go
+++ b/internal/cli/add_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -490,6 +491,83 @@ func TestResolveAddSpecErrorNamesEveryRetainedVersion(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("the refusal is %v, want it to name the retained version %s the user could roll back to", err, want)
 		}
+	}
+	// The name and the spec are two plain strings the message reads in order, so
+	// a caller that swaps them still compiles and produces a message that lies
+	// about which is which. Reading the opening clause is what catches that.
+	if !strings.HasPrefix(err.Error(), "no version of deadend-pkg matches 9.9.9") {
+		t.Errorf("the refusal is %v, want it to name the package and then the spec", err)
+	}
+}
+
+// TestResolveAddSpecErrorCapsTheRetainedVersions pins that the dead end stays a
+// readable clause on a package with a long history. The message points at
+// `lnpm list <pkg> --versions`, so it does not have to be the history: naming
+// every retained version of a package with thirty of them produces a single
+// ~700-character error, which the parallel add path then wraps again.
+func TestResolveAddSpecErrorCapsTheRetainedVersions(t *testing.T) {
+	_, database := newGCStore(t)
+
+	for i := 0; i < 30; i++ {
+		seedVersion(t, database, "long-history-pkg",
+			fmt.Sprintf("1.0.%d", i),
+			fmt.Sprintf("%02dcccccccccccccc", i))
+	}
+
+	_, _, _, err := resolveAddSpec(database, "long-history-pkg", "9.9.9")
+	if err == nil {
+		t.Fatal("resolveAddSpec(9.9.9) succeeded, want a refusal")
+	}
+	if strings.Contains(err.Error(), "1.0.0") {
+		t.Errorf("the refusal names all thirty retained versions:\n%v", err)
+	}
+	if !strings.Contains(err.Error(), "more") {
+		t.Errorf("the refusal is %v, want it to say how many versions it left out", err)
+	}
+	if len(err.Error()) > 250 {
+		t.Errorf("the refusal is %d characters long, want a clause a wrapped error can carry:\n%v", len(err.Error()), err)
+	}
+}
+
+// TestResolveAddSpecReportsHowTheSpecResolved pins the fact --link has to guard
+// on, and which the returned tag cannot carry.
+//
+// A tag comes back as itself, but a version and a hash both come back with an
+// empty tag, because they name a build rather than a channel - the same empty
+// tag a bare name returns. A guard reading the tag string therefore cannot tell
+// "the user asked for nothing" from "the user asked for a specific build", and
+// would let `add pkg@<hash> --link` through to live-link the working tree while
+// printing the historical version number.
+func TestResolveAddSpecReportsHowTheSpecResolved(t *testing.T) {
+	_, database := newGCStore(t)
+
+	seedVersion(t, database, "kind-pkg", "1.0.0", "aaaaaaaa11111111")
+	newest := seedVersion(t, database, "kind-pkg", "2.0.0", "bbbbbbbb22222222")
+	if err := database.SetTag("kind-pkg", "beta", newest.ContentHash); err != nil {
+		t.Fatalf("set the tag: %v", err)
+	}
+
+	for _, tc := range []struct {
+		requested string
+		want      specKind
+	}{
+		{"", specDefault},
+		{"beta", specTag},
+		{"1.0.0", specVersion},
+		{"aaaaaaaa", specHash},
+	} {
+		t.Run(string(tc.want), func(t *testing.T) {
+			pkg, _, kind, err := resolveAddSpec(database, "kind-pkg", tc.requested)
+			if err != nil {
+				t.Fatalf("resolveAddSpec(%q) error = %v", tc.requested, err)
+			}
+			if pkg == nil {
+				t.Fatalf("resolveAddSpec(%q) resolved nothing", tc.requested)
+			}
+			if kind != tc.want {
+				t.Errorf("resolveAddSpec(%q) reported kind %q, want %q", tc.requested, kind, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/cli/add_test.go
+++ b/internal/cli/add_test.go
@@ -571,6 +571,33 @@ func TestResolveAddSpecReportsHowTheSpecResolved(t *testing.T) {
 	}
 }
 
+// TestResolveAddSpecRefusesATooShortHashPrefix pins the floor under the hash
+// step. `lnpm add mylib@2` is a user who means version 2; without a minimum it
+// is tried against content hashes, and one retained hash beginning with "2"
+// silently resolves it to that build - or, worse, several do and the user is
+// told their spec is an ambiguous hash prefix.
+//
+// Four characters is git's minimum for an abbreviated object name, which the
+// hash step is modelled on.
+func TestResolveAddSpecRefusesATooShortHashPrefix(t *testing.T) {
+	for _, requested := range []string{"2", "22", "222"} {
+		t.Run(requested, func(t *testing.T) {
+			_, database := newGCStore(t)
+
+			seedVersion(t, database, "shortprefix-pkg", "1.0.0", "2222222211111111")
+			seedVersion(t, database, "shortprefix-pkg", "3.0.0", "bbbbbbbb22222222")
+
+			pkg, _, _, err := resolveAddSpec(database, "shortprefix-pkg", requested)
+			if err == nil {
+				t.Fatalf("resolveAddSpec(%s) resolved %v, want a refusal: that is too short to be a hash", requested, pkg)
+			}
+			if !strings.Contains(err.Error(), "no version of shortprefix-pkg matches") {
+				t.Errorf("resolveAddSpec(%s) error = %v, want the dead end a version spec gets, not a hash-prefix verdict", requested, err)
+			}
+		})
+	}
+}
+
 // TestResolveAddSpecOnAnUnknownNameResolvesNothing pins that a name the store
 // has never held stays a nil package rather than becoming an error. The two add
 // paths word that one differently, and both wordings predate this change.

--- a/internal/cli/add_test.go
+++ b/internal/cli/add_test.go
@@ -314,7 +314,7 @@ func TestResolveAddSpecResolvesAContentHash(t *testing.T) {
 			old := seedVersion(t, database, "rollback-pkg", "1.0.0", "aaaaaaaa11111111")
 			seedVersion(t, database, "rollback-pkg", "2.0.0", "bbbbbbbb22222222")
 
-			pkg, tag, err := resolveAddSpec(database, "rollback-pkg", tc.requested)
+			pkg, tag, _, err := resolveAddSpec(database, "rollback-pkg", tc.requested)
 			if err != nil {
 				t.Fatalf("resolveAddSpec(%s) error = %v", tc.requested, err)
 			}
@@ -345,7 +345,7 @@ func TestResolveAddSpecResolvesASupersededVersion(t *testing.T) {
 	old := seedVersion(t, database, "superseded-spec-pkg", "1.0.0", "aaaaaaaa11111111")
 	seedVersion(t, database, "superseded-spec-pkg", "2.0.0", "bbbbbbbb22222222")
 
-	pkg, tag, err := resolveAddSpec(database, "superseded-spec-pkg", "1.0.0")
+	pkg, tag, _, err := resolveAddSpec(database, "superseded-spec-pkg", "1.0.0")
 	if err != nil {
 		t.Fatalf("resolveAddSpec(1.0.0) error = %v", err)
 	}
@@ -371,7 +371,7 @@ func TestResolveAddSpecPrefersTheVersionTheDefaultTagNames(t *testing.T) {
 	seedVersion(t, database, "collide-pkg", "1.0.0", "aaaaaaaa11111111")
 	current := seedVersion(t, database, "collide-pkg", "1.0.0", "bbbbbbbb22222222")
 
-	pkg, _, err := resolveAddSpec(database, "collide-pkg", "1.0.0")
+	pkg, _, _, err := resolveAddSpec(database, "collide-pkg", "1.0.0")
 	if err != nil {
 		t.Fatalf("resolveAddSpec(1.0.0) error = %v; this resolved before the history existed and must go on resolving", err)
 	}
@@ -391,7 +391,7 @@ func TestResolveAddSpecRefusesAnAmbiguousVersion(t *testing.T) {
 	seedVersion(t, database, "ambiguous-version-pkg", "1.0.0", "bbbbbbbb22222222")
 	seedVersion(t, database, "ambiguous-version-pkg", "2.0.0", "cccccccc33333333")
 
-	pkg, _, err := resolveAddSpec(database, "ambiguous-version-pkg", "1.0.0")
+	pkg, _, _, err := resolveAddSpec(database, "ambiguous-version-pkg", "1.0.0")
 	if err == nil {
 		t.Fatalf("resolveAddSpec(1.0.0) resolved %v, want a refusal: two retained versions carry 1.0.0", pkg)
 	}
@@ -412,7 +412,7 @@ func TestResolveAddSpecRefusesAnAmbiguousHashPrefix(t *testing.T) {
 	seedVersion(t, database, "ambiguous-hash-pkg", "1.0.0", "aaaaaaaa11111111")
 	seedVersion(t, database, "ambiguous-hash-pkg", "2.0.0", "aaaaaaaa22222222")
 
-	pkg, _, err := resolveAddSpec(database, "ambiguous-hash-pkg", "aaaaaaaa")
+	pkg, _, _, err := resolveAddSpec(database, "ambiguous-hash-pkg", "aaaaaaaa")
 	if err == nil {
 		t.Fatalf("resolveAddSpec(aaaaaaaa) resolved %v, want a refusal: the prefix matches two versions", pkg)
 	}
@@ -437,7 +437,7 @@ func TestResolveAddSpecPrefersATagOverAVersionAndAHash(t *testing.T) {
 		t.Fatalf("set the tag: %v", err)
 	}
 
-	pkg, tag, err := resolveAddSpec(database, "tagfirst-pkg", "1.0.0")
+	pkg, tag, _, err := resolveAddSpec(database, "tagfirst-pkg", "1.0.0")
 	if err != nil {
 		t.Fatalf("resolveAddSpec(1.0.0) error = %v", err)
 	}
@@ -462,7 +462,7 @@ func TestResolveAddSpecPrefersAVersionOverAHashPrefix(t *testing.T) {
 	named := seedVersion(t, database, "collide-order-pkg", "aaaaaaaa", "bbbbbbbb22222222")
 	seedVersion(t, database, "collide-order-pkg", "2.0.0", "aaaaaaaa11111111")
 
-	pkg, _, err := resolveAddSpec(database, "collide-order-pkg", "aaaaaaaa")
+	pkg, _, _, err := resolveAddSpec(database, "collide-order-pkg", "aaaaaaaa")
 	if err != nil {
 		t.Fatalf("resolveAddSpec(aaaaaaaa) error = %v", err)
 	}
@@ -482,7 +482,7 @@ func TestResolveAddSpecErrorNamesEveryRetainedVersion(t *testing.T) {
 	seedVersion(t, database, "deadend-pkg", "1.0.0", "aaaaaaaa11111111")
 	seedVersion(t, database, "deadend-pkg", "2.0.0", "bbbbbbbb22222222")
 
-	_, _, err := resolveAddSpec(database, "deadend-pkg", "9.9.9")
+	_, _, _, err := resolveAddSpec(database, "deadend-pkg", "9.9.9")
 	if err == nil {
 		t.Fatal("resolveAddSpec(9.9.9) succeeded, want a refusal: no version carries it")
 	}
@@ -499,7 +499,7 @@ func TestResolveAddSpecErrorNamesEveryRetainedVersion(t *testing.T) {
 func TestResolveAddSpecOnAnUnknownNameResolvesNothing(t *testing.T) {
 	_, database := newGCStore(t)
 
-	pkg, _, err := resolveAddSpec(database, "no-such-pkg", "1.0.0")
+	pkg, _, _, err := resolveAddSpec(database, "no-such-pkg", "1.0.0")
 	if err != nil {
 		t.Fatalf("resolveAddSpec on an unknown name error = %v, want the caller to word it", err)
 	}

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -58,16 +58,23 @@ project with no further command, and package.json uses link: instead of file:.
 That trades away the isolation the default gives you - the project then builds
 against files that have not been published, or even committed.
 
-What follows the @ in a spec is read as a dist-tag first and as an exact version
-only if no tag by that name is set, so 'lnpm add my-package@beta' links whatever
-build the beta channel currently names. A spec with no @ resolves to latest, as
-it always has. A tag cannot be combined with --link: that resolves to the
-package's source directory, which is not the build any tag names.
+What follows the @ in a spec is matched in three steps, most specific first: as a
+dist-tag, so 'lnpm add my-package@beta' links whatever build the beta channel
+currently names; then as an exact version, against every version the store has
+retained and not only the one latest names; then as a content-hash prefix. The
+last two are what roll a project back to a build a later release superseded - run
+'lnpm list <pkg> --versions' to see what is there. A spec matching two retained
+versions is refused with their hashes rather than resolved to one of them.
+
+A spec with no @ resolves to latest, as it always has. A tag cannot be combined
+with --link: that resolves to the package's source directory, which is not the
+build any tag names.
 
 Examples:
   lnpm add my-package            # Add latest version
   lnpm add pkg1 pkg2 pkg3        # Add multiple packages
   lnpm add my-package@1.0.0      # Add specific version
+  lnpm add my-package@a1b2c3d4   # Roll back to a specific published build
   lnpm add my-package@beta       # Add the build tagged beta
   lnpm add my-package --dev      # Add as devDependency
   lnpm add my-package --install  # Add and run npm install
@@ -196,16 +203,27 @@ var listCmd = &cobra.Command{
 names every project consuming the package with the build each is on, whichever
 channel it followed to get there.
 
+--versions lists the history of one package: every version the store still
+holds, newest first, with its content hash, its version, when it was published,
+the dist-tags naming it and the projects on it. That is what 'lnpm add
+<pkg>@<hash>' can roll a project back to - the set 'lnpm gc' has not collected,
+since a version's record and its files go together.
+
 Examples:
   lnpm list                      # List packages in current project
   lnpm list --store              # List all packages in store
-  lnpm list my-package --projects   # List projects using my-package`,
+  lnpm list my-package --projects   # List projects using my-package
+  lnpm list my-package --versions   # List what my-package can be rolled back to`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		showStore, _ := cmd.Flags().GetBool("store")
 		showProjects, _ := cmd.Flags().GetBool("projects")
+		showVersions, _ := cmd.Flags().GetBool("versions")
 		var packageName string
 		if len(args) > 0 {
 			packageName = args[0]
+		}
+		if showVersions {
+			return RunListVersions(packageName)
 		}
 		return RunList(showStore, packageName, showProjects)
 	},
@@ -399,6 +417,7 @@ func init() {
 	// list flags
 	listCmd.Flags().Bool("store", false, "List packages in store")
 	listCmd.Flags().Bool("projects", false, "List projects using a package")
+	listCmd.Flags().Bool("versions", false, "List every retained version of a package, newest first")
 
 	// gc flags
 	gcCmd.Flags().Bool("dry-run", false, "Show what would be removed")

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -223,6 +223,13 @@ Examples:
 			packageName = args[0]
 		}
 		if showVersions {
+			// Refused rather than ignored: the two listings answer different
+			// questions about the same package, so silently serving one of them
+			// leaves the user reading an answer to a question they did not ask.
+			// RunList refuses a package name it cannot serve for the same reason.
+			if showProjects {
+				return fmt.Errorf("--versions and --projects cannot be combined: --versions lists what %s can be rolled back to, --projects lists who consumes it", packageName)
+			}
 			return RunListVersions(packageName)
 		}
 		return RunList(showStore, packageName, showProjects)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -154,7 +154,7 @@ func RunList(showStore bool, packageName string, showProjects bool) error {
 	}
 
 	if packageName != "" && !showProjects {
-		return fmt.Errorf("use --projects to list which projects use %q", packageName)
+		return fmt.Errorf("use --projects to list which projects use %q, or --versions to list what it can be rolled back to", packageName)
 	}
 
 	if packageName != "" && showProjects {
@@ -239,6 +239,85 @@ func RunList(showStore bool, packageName string, showProjects bool) error {
 	}
 
 	return nil
+}
+
+// RunListVersions lists every version of one package the store still holds:
+// its content hash, its version, when it was published, the tags naming it and
+// the projects on it.
+//
+// This is a separate listing rather than another shape for `--store` because it
+// answers a different question. `--store` and `status` say what is in the store;
+// this says what one package can be rolled back to, which is about the rows the
+// default tag has moved off - the ones every other listing shows without
+// distinguishing.
+//
+// The set is exactly what gc has not collected, because a version's record and
+// its store entry go together. There is no separate "ever published" history to
+// consult and nothing here retains anything that gc would otherwise take.
+//
+// Every read is surfaced rather than skipped. A listing whose whole job is
+// telling a user which build to roll back to must not report a version as
+// untagged or unconsumed because a read failed: that is indistinguishable on
+// screen from the version being safe to leave behind.
+func RunListVersions(packageName string) error {
+	if packageName == "" {
+		return fmt.Errorf("--versions needs a package name: try 'lnpm list <package> --versions'")
+	}
+
+	database, err := db.GetDB()
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+
+	versions, err := database.GetPackageVersions(packageName)
+	if err != nil {
+		return fmt.Errorf("failed to read the versions of %s: %w", packageName, err)
+	}
+	if len(versions) == 0 {
+		return fmt.Errorf("package %s not found", packageName)
+	}
+
+	tags, err := database.TagsForPackage(packageName)
+	if err != nil {
+		return fmt.Errorf("failed to read the tags of %s: %w", packageName, err)
+	}
+
+	fmt.Printf("%s versions:\n", packageName)
+	for _, version := range versions {
+		consumers, err := database.GetProjectsForPackage(version.ID)
+		if err != nil {
+			return fmt.Errorf("failed to get the projects on %s@%s: %w", packageName, version.Version, err)
+		}
+		fmt.Printf("  %-10s %-14s published %-20s%s%s\n",
+			shortHash(version.ContentHash),
+			truncate(version.Version, 14),
+			formatTimeAgo(version.UpdatedAt),
+			tagsNaming(tags, version.ContentHash),
+			consumersNaming(consumers),
+		)
+	}
+
+	return nil
+}
+
+// consumersNaming renders the projects on a version as a trailing "(currently
+// linked in myapp)", and nothing when none are.
+//
+// Projects are named rather than counted, and named by project name rather than
+// by path: this row exists so a maintainer deciding whether to roll a version
+// back can see who it would move, and a count does not answer that. Sorted,
+// because the links come back in whatever order the index holds them and an
+// unordered listing would reshuffle itself between runs over an unchanged store.
+func consumersNaming(projects []*db.Project) string {
+	if len(projects) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(projects))
+	for _, proj := range projects {
+		names = append(names, proj.Name)
+	}
+	sort.Strings(names)
+	return " (currently linked in " + strings.Join(names, ", ") + ")"
 }
 
 // truncate truncates a string to maxLen runes, appending "..." when shortened.

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -289,41 +289,68 @@ func RunListVersions(packageName string) error {
 	}
 
 	fmt.Printf("%s versions:\n", packageName)
+	// The rule is as wide as the columns and their separators: 10+14+20+20 plus
+	// the four single spaces between them, plus the last heading, which is the
+	// one column left unpadded because a project path is longer than any width
+	// worth reserving for it.
+	fmt.Printf("  %-10s %-14s %-20s %-20s %s\n", "HASH", "VERSION", "PUBLISHED", "TAGS", "LINKED IN")
+	fmt.Printf("  %s\n", hrule(77))
+
 	for _, version := range versions {
 		consumers, err := database.GetProjectsForPackage(version.ID)
 		if err != nil {
 			return fmt.Errorf("failed to get the projects on %s@%s: %w", packageName, version.Version, err)
 		}
-		fmt.Printf("  %-10s %-14s published %-20s%s%s\n",
+		// Trimmed because the last two columns are both often empty - most
+		// versions carry no tag and have no consumer - and a padded row would
+		// then be mostly trailing spaces.
+		fmt.Println(strings.TrimRight(fmt.Sprintf("  %-10s %-14s %-20s %-20s %s",
 			shortHash(version.ContentHash),
 			truncate(version.Version, 14),
 			formatTimeAgo(version.UpdatedAt),
-			tagsNaming(tags, version.ContentHash),
+			truncate(strings.Join(tagsNamingList(tags, version.ContentHash), ", "), 20),
 			consumersNaming(consumers),
-		)
+		), " "))
 	}
 
 	return nil
 }
 
-// consumersNaming renders the projects on a version as a trailing "(currently
-// linked in myapp)", and nothing when none are.
+// namedConsumers is how many projects consumersNaming spells out before falling
+// back to a count.
+const namedConsumers = 3
+
+// consumersNaming renders the projects on a version, and nothing when none are.
 //
-// Projects are named rather than counted, and named by project name rather than
-// by path: this row exists so a maintainer deciding whether to roll a version
-// back can see who it would move, and a count does not answer that. Sorted,
-// because the links come back in whatever order the index holds them and an
-// unordered listing would reshuffle itself between runs over an unchanged store.
+// Projects are named rather than counted, because this column exists so a
+// maintainer deciding whether to roll a version back can see who it would move,
+// and a count does not answer that. They are named by path, as `lnpm list
+// --projects` and `lnpm status` both name them: Name is a basename, so two
+// projects called myapp render identically and the column stops distinguishing
+// the thing it exists to distinguish. Paths are left untruncated for the same
+// reason - a path cut to a column width loses the segment that tells two of them
+// apart.
+//
+// Sorted, because the links come back in whatever order the index holds them and
+// an unordered listing would reshuffle itself between runs over an unchanged
+// store. Capped at namedConsumers, because a widely consumed package would
+// otherwise put a line of unbounded length on every row; `lnpm list <pkg>
+// --projects` is the listing that names them all.
 func consumersNaming(projects []*db.Project) string {
 	if len(projects) == 0 {
 		return ""
 	}
-	names := make([]string, 0, len(projects))
+	paths := make([]string, 0, len(projects))
 	for _, proj := range projects {
-		names = append(names, proj.Name)
+		paths = append(paths, proj.Path)
 	}
-	sort.Strings(names)
-	return " (currently linked in " + strings.Join(names, ", ") + ")"
+	sort.Strings(paths)
+
+	if len(paths) > namedConsumers {
+		omitted := len(paths) - namedConsumers
+		paths = append(paths[:namedConsumers:namedConsumers], fmt.Sprintf("and %d more", omitted))
+	}
+	return strings.Join(paths, ", ")
 }
 
 // truncate truncates a string to maxLen runes, appending "..." when shortened.

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -255,10 +255,16 @@ func RunList(showStore bool, packageName string, showProjects bool) error {
 // its store entry go together. There is no separate "ever published" history to
 // consult and nothing here retains anything that gc would otherwise take.
 //
-// Every read is surfaced rather than skipped. A listing whose whole job is
-// telling a user which build to roll back to must not report a version as
-// untagged or unconsumed because a read failed: that is indistinguishable on
-// screen from the version being safe to leave behind.
+// Every read this makes is surfaced rather than skipped: a listing whose whole
+// job is telling a user which build to roll back to must not report a version as
+// untagged or unconsumed because a read failed, because that is
+// indistinguishable on screen from the version being safe to leave behind. The
+// history itself goes further and fails on a version record it cannot parse, for
+// the reason GetPackageVersions gives.
+//
+// One gap remains below that line: GetProjectsForPackage drops a link row it
+// cannot read, so a consumer can still go unnamed. Fixing it means changing a
+// lookup four other commands share, which is not this listing's to do.
 func RunListVersions(packageName string) error {
 	if packageName == "" {
 		return fmt.Errorf("--versions needs a package name: try 'lnpm list <package> --versions'")

--- a/internal/cli/status_helpers_test.go
+++ b/internal/cli/status_helpers_test.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 	"unicode/utf8"
+
+	"github.com/pedrosousa13/lnpm/internal/db"
 )
 
 // TestTruncate pins the column-fitting helper the status tables rely on: a
@@ -113,5 +117,79 @@ func TestFormatTimeAgo(t *testing.T) {
 func TestFormatTimeAgoFutureTime(t *testing.T) {
 	if got := formatTimeAgo(time.Now().Add(time.Hour)); got != "just now" {
 		t.Errorf("formatTimeAgo(an hour from now) = %q, want %q", got, "just now")
+	}
+}
+
+// TestConsumersNamingNamesProjectsByPath pins the identifier the version
+// history's consumers column uses.
+//
+// Name is a basename, so two projects called app render identically and the
+// column stops distinguishing the thing it exists to distinguish: which
+// consumers a rollback would move. `lnpm list --projects` and `lnpm status` both
+// name projects by path, and this listing is read alongside them.
+func TestConsumersNamingNamesProjectsByPath(t *testing.T) {
+	got := consumersNaming([]*db.Project{
+		{Name: "app", Path: "/home/dev/two/app"},
+		{Name: "app", Path: "/home/dev/one/app"},
+	})
+
+	// Sorted, because the links come back in whatever order the index holds
+	// them and the listing must not reshuffle between runs.
+	want := "/home/dev/one/app, /home/dev/two/app"
+	if got != want {
+		t.Errorf("consumersNaming() = %q, want %q", got, want)
+	}
+}
+
+// TestConsumersNamingCapsWhatItNames pins the bound. A widely consumed package
+// would otherwise put a line of unbounded length on every row of the history;
+// `lnpm list <pkg> --projects` is the listing that names them all.
+func TestConsumersNamingCapsWhatItNames(t *testing.T) {
+	var projects []*db.Project
+	for _, path := range []string{"/p/a", "/p/b", "/p/c", "/p/d", "/p/e"} {
+		projects = append(projects, &db.Project{Name: filepath.Base(path), Path: path})
+	}
+
+	got := consumersNaming(projects)
+
+	want := "/p/a, /p/b, /p/c, and 2 more"
+	if got != want {
+		t.Errorf("consumersNaming() over five projects = %q, want %q", got, want)
+	}
+}
+
+// TestConsumersNamingOnNoProjectsIsEmpty pins that a version nothing links
+// leaves the column blank rather than printing an empty clause.
+func TestConsumersNamingOnNoProjectsIsEmpty(t *testing.T) {
+	if got := consumersNaming(nil); got != "" {
+		t.Errorf("consumersNaming(nil) = %q, want an empty column", got)
+	}
+}
+
+// TestListRefusesProjectsAndVersionsTogether pins that the two listings are not
+// silently one of them. They answer different questions about the same package,
+// and `lnpm list <pkg>` already refuses rather than guessing which was meant.
+func TestListRefusesProjectsAndVersionsTogether(t *testing.T) {
+	for _, flag := range []string{"projects", "versions"} {
+		if err := listCmd.Flags().Set(flag, "true"); err != nil {
+			t.Fatalf("set --%s: %v", flag, err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, flag := range []string{"projects", "versions"} {
+			if err := listCmd.Flags().Set(flag, "false"); err != nil {
+				t.Fatalf("reset --%s: %v", flag, err)
+			}
+		}
+	})
+
+	err := listCmd.RunE(listCmd, []string{"some-pkg"})
+	if err == nil {
+		t.Fatal("list --projects --versions succeeded, want a refusal")
+	}
+	for _, want := range []string{"--versions", "--projects"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal is %v, want it to name %s", err, want)
+		}
 	}
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -773,6 +774,56 @@ func (db *DB) GetPackageByHash(name, hash string) (*Package, error) {
 	})
 
 	return result, err
+}
+
+// GetPackageVersions returns every version of a package the store still holds,
+// most recently published first.
+//
+// GetPackageByName answers a different question: it resolves the name index,
+// which mirrors the default tag, so it names one row of a history that now has
+// several. This is the whole history — exactly the set gc has not collected,
+// because a version's record and its store entry go together.
+//
+// The order is UpdatedAt descending, and UpdatedAt rather than CreatedAt because
+// that is the timestamp the rest of lnpm calls a package's publish time:
+// `lnpm status` prints it under PUBLISHED and gc measures --older-than against
+// it. A listing that sorted or reported the other one would disagree with the
+// command that acts on it.
+//
+// The tie-break on ID is not decoration. Bolt stamps UpdatedAt from time.Now,
+// and two publishes can land inside one tick of a coarse clock — Windows' is
+// about 15ms — so without it the order would be arbitrary precisely when two
+// versions are hardest to tell apart, and would differ between runs over an
+// unchanged store.
+func (db *DB) GetPackageVersions(name string) ([]*Package, error) {
+	debug.Logf("db: get versions of %s", name)
+	db.mu.RLock()
+	defer db.mu.RUnlock()
+
+	var versions []*Package
+	err := db.db.View(func(tx *bolt.Tx) error {
+		return tx.Bucket(bucketPackages).ForEach(func(k, v []byte) error {
+			var pkg Package
+			if err := json.Unmarshal(v, &pkg); err != nil {
+				return nil // Skip invalid entries
+			}
+			if pkg.Name == name {
+				versions = append(versions, &pkg)
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(versions, func(i, j int) bool {
+		if !versions[i].UpdatedAt.Equal(versions[j].UpdatedAt) {
+			return versions[i].UpdatedAt.After(versions[j].UpdatedAt)
+		}
+		return versions[i].ID > versions[j].ID
+	})
+	return versions, nil
 }
 
 // ListPackages returns all packages in the store

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -795,6 +795,16 @@ func (db *DB) GetPackageByHash(name, hash string) (*Package, error) {
 // about 15ms — so without it the order would be arbitrary precisely when two
 // versions are hardest to tell apart, and would differ between runs over an
 // unchanged store.
+//
+// A record that will not unmarshal fails the whole lookup, unlike the listings
+// alongside it, which skip one. A version that disappears from a rollback
+// history is indistinguishable on screen from one gc collected, and the same
+// lookup answers `lnpm add <pkg>@<hash>`, so a skipped record would have the
+// user told the build they are rolling back to does not exist. GetPackageByName,
+// which the add path went through before this existed, already surfaces a record
+// it cannot parse. The cost is that the failure is not scoped to name: a damaged
+// record carries no readable name, so any one of them fails every history. That
+// is a damaged store rather than a state lnpm writes.
 func (db *DB) GetPackageVersions(name string) ([]*Package, error) {
 	debug.Logf("db: get versions of %s", name)
 	db.mu.RLock()
@@ -805,7 +815,7 @@ func (db *DB) GetPackageVersions(name string) ([]*Package, error) {
 		return tx.Bucket(bucketPackages).ForEach(func(k, v []byte) error {
 			var pkg Package
 			if err := json.Unmarshal(v, &pkg); err != nil {
-				return nil // Skip invalid entries
+				return fmt.Errorf("package record %d will not parse: %w", btoi(k), err)
 			}
 			if pkg.Name == name {
 				versions = append(versions, &pkg)

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -567,3 +567,104 @@ func TestSetTag_MergesADuplicateLinkAProjectHolds(t *testing.T) {
 		t.Errorf("The version the tag moved off still has %d consumer(s)", len(projects))
 	}
 }
+
+// --- Version history ---------------------------------------------------------
+
+// writePackageRow writes a package record straight into the bucket, without the
+// timestamps insertPackageTx stamps from time.Now.
+//
+// GetPackageVersions orders on UpdatedAt and breaks a tie on ID, and a tie is
+// the case the tie-break exists for: a coarse clock - Windows' is about 15ms -
+// hands two publishes the same instant. Nothing that goes through InsertPackage
+// can produce that on a Linux or macOS clock, so a test that wants it has to
+// write the timestamp itself.
+func writePackageRow(t *testing.T, d *DB, pkg *Package) {
+	t.Helper()
+
+	err := d.db.Update(func(tx *bolt.Tx) error {
+		id, err := d.nextID(tx)
+		if err != nil {
+			return err
+		}
+		pkg.ID = id
+		data, err := json.Marshal(pkg)
+		if err != nil {
+			return err
+		}
+		return tx.Bucket(bucketPackages).Put(itob(id), data)
+	})
+	if err != nil {
+		t.Fatalf("Failed to write a package row: %v", err)
+	}
+}
+
+// TestGetPackageVersions_BreaksATimestampTieOnID pins the second half of the
+// history's order.
+//
+// Two publishes can land inside one tick of a coarse clock, and without the
+// tie-break the order would be arbitrary precisely when two versions are hardest
+// to tell apart - and would differ between runs over an unchanged store. The
+// records here carry one timestamp because that is the only state in which the
+// tie-break is reached at all: an insert through the normal path stamps
+// time.Now, which on this platform separates them every time.
+func TestGetPackageVersions_BreaksATimestampTieOnID(t *testing.T) {
+	storeDir := t.TempDir()
+	database := openStore(t, storeDir)
+
+	published := time.Date(2024, 3, 1, 12, 0, 0, 0, time.UTC)
+	for _, hash := range []string{"h1", "h2", "h3"} {
+		writePackageRow(t, database, &Package{
+			Name:        "tied-pkg",
+			Version:     "1.0.0",
+			ContentHash: hash,
+			CreatedAt:   published,
+			UpdatedAt:   published,
+		})
+	}
+
+	versions, err := database.GetPackageVersions("tied-pkg")
+	if err != nil {
+		t.Fatalf("GetPackageVersions() error = %v", err)
+	}
+
+	var order []string
+	for _, v := range versions {
+		order = append(order, v.ContentHash)
+	}
+	if got := strings.Join(order, ","); got != "h3,h2,h1" {
+		t.Errorf("GetPackageVersions() ordered three versions sharing one timestamp %s, want the most recently written first", got)
+	}
+}
+
+// TestGetPackageVersions_SurfacesARecordThatWillNotUnmarshal pins that a version
+// whose bytes will not parse stops the history rather than disappearing from it.
+//
+// A listing whose whole job is telling a user which build to roll back to must
+// not drop a row for a read that failed: on screen that is indistinguishable
+// from gc having collected the build, and the same lookup answers `lnpm add
+// <pkg>@<hash>`, so the user would be told the build they are rolling back to
+// does not exist. GetPackageByName, which the add path went through before this
+// lookup existed, already surfaces a record it cannot parse.
+func TestGetPackageVersions_SurfacesARecordThatWillNotUnmarshal(t *testing.T) {
+	storeDir := t.TempDir()
+	database := openStore(t, storeDir)
+
+	if err := database.InsertPackage(&Package{
+		Name:        "damaged-pkg",
+		Version:     "1.0.0",
+		ContentHash: "h1",
+	}); err != nil {
+		t.Fatalf("Failed to seed a version: %v", err)
+	}
+
+	err := database.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(bucketPackages).Put(itob(9999), []byte("{ not a package"))
+	})
+	if err != nil {
+		t.Fatalf("Failed to damage a record: %v", err)
+	}
+
+	if _, err := database.GetPackageVersions("damaged-pkg"); err == nil {
+		t.Error("GetPackageVersions() skipped a record it could not read; a version missing from a rollback listing reads as one gc collected")
+	}
+}

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -988,6 +988,86 @@ func TestDatabaseDeletingAVersionDropsOnlyItsOwnTags(t *testing.T) {
 	assertTags(t, env.Database, "tagdel-pkg", map[string]string{})
 }
 
+// --- Version history ---------------------------------------------------------
+
+// TestDatabaseGetPackageVersionsListsEveryRetainedVersion covers the lookup the
+// version history rests on: every record the store still holds for one name, not
+// the single version the name index resolves to.
+//
+// GetPackageByName answers with what the default tag names, which is one row of
+// a history that now has several. A rollback needs the rest of them.
+func TestDatabaseGetPackageVersionsListsEveryRetainedVersion(t *testing.T) {
+	env := setupTest(t)
+
+	insertTagPkg(t, env.Database, "history-pkg", "h1")
+	insertTagPkg(t, env.Database, "history-pkg", "h2")
+	insertTagPkg(t, env.Database, "history-pkg", "h3")
+	// A second name, so the listing has something it must leave out.
+	insertTagPkg(t, env.Database, "other-pkg", "h9")
+
+	versions, err := env.Database.GetPackageVersions("history-pkg")
+	if err != nil {
+		t.Fatalf("GetPackageVersions() error = %v", err)
+	}
+
+	var hashes []string
+	for _, v := range versions {
+		if v.Name != "history-pkg" {
+			t.Errorf("GetPackageVersions(history-pkg) returned a version of %s", v.Name)
+		}
+		hashes = append(hashes, v.ContentHash)
+	}
+	sort.Strings(hashes)
+	if got := strings.Join(hashes, ","); got != "h1,h2,h3" {
+		t.Errorf("GetPackageVersions() returned %s, want every retained version h1,h2,h3", got)
+	}
+}
+
+// TestDatabaseGetPackageVersionsOrdersNewestFirst pins the order, because a
+// history that reshuffles between runs is not a history. bolt hands records back
+// in ID order, which is close enough to be mistaken for correct and is not the
+// order a reader rolling back is looking for.
+//
+// The tie-break on ID matters as much as the timestamp: two inserts can land
+// inside one tick of a coarse clock, and without it the listing would be
+// arbitrary exactly when the two versions are hardest to tell apart.
+func TestDatabaseGetPackageVersionsOrdersNewestFirst(t *testing.T) {
+	env := setupTest(t)
+
+	insertTagPkg(t, env.Database, "ordered-pkg", "h1")
+	insertTagPkg(t, env.Database, "ordered-pkg", "h2")
+	insertTagPkg(t, env.Database, "ordered-pkg", "h3")
+
+	versions, err := env.Database.GetPackageVersions("ordered-pkg")
+	if err != nil {
+		t.Fatalf("GetPackageVersions() error = %v", err)
+	}
+
+	var order []string
+	for _, v := range versions {
+		order = append(order, v.ContentHash)
+	}
+	if got := strings.Join(order, ","); got != "h3,h2,h1" {
+		t.Errorf("GetPackageVersions() ordered them %s, want the most recently published first", got)
+	}
+}
+
+// TestDatabaseGetPackageVersionsOfAnUnknownNameIsEmpty pins that a name the
+// store does not hold is an empty history rather than an error. The callers are
+// listings and a spec resolver, and both say what an unknown package means in
+// their own words - wording that predates this lookup.
+func TestDatabaseGetPackageVersionsOfAnUnknownNameIsEmpty(t *testing.T) {
+	env := setupTest(t)
+
+	versions, err := env.Database.GetPackageVersions("no-such-pkg")
+	if err != nil {
+		t.Fatalf("GetPackageVersions() error = %v, want no error for an unknown name", err)
+	}
+	if len(versions) != 0 {
+		t.Errorf("GetPackageVersions(no-such-pkg) returned %d versions, want none", len(versions))
+	}
+}
+
 // --- Tag operations ----------------------------------------------------------
 
 // insertTagPkg inserts a package with the given name and content hash under the

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -1028,9 +1028,11 @@ func TestDatabaseGetPackageVersionsListsEveryRetainedVersion(t *testing.T) {
 // in ID order, which is close enough to be mistaken for correct and is not the
 // order a reader rolling back is looking for.
 //
-// The tie-break on ID matters as much as the timestamp: two inserts can land
-// inside one tick of a coarse clock, and without it the listing would be
-// arbitrary exactly when the two versions are hardest to tell apart.
+// This pins the timestamp half only. Every insert here goes through the normal
+// path, which stamps UpdatedAt from time.Now, so on any clock finer than the gap
+// between two inserts the three timestamps differ and the tie-break on ID is
+// never reached. The tie-break has its own test in internal/db, where a record's
+// timestamp can be written rather than stamped.
 func TestDatabaseGetPackageVersionsOrdersNewestFirst(t *testing.T) {
 	env := setupTest(t)
 

--- a/tests/gc_test.go
+++ b/tests/gc_test.go
@@ -97,12 +97,13 @@ func TestGCDryRun(t *testing.T) {
 
 // TestGCWithAge exercises the --older-than age filter.
 //
-// COVERAGE GAP (deferred): we cannot publish a genuinely "old" package because
-// back-dating a package's UpdatedAt requires a DB/source change (e.g. a test
-// helper on db.DB), which is out of scope for a test-only change. As a result
-// this test cannot prove the filter correctly REMOVES packages older than the
-// threshold while KEEPING newer ones in the same run. Instead it pins the two
-// observable boundary behaviors that need no back-dating:
+// COVERAGE GAP (deferred): this test does not prove the filter correctly REMOVES
+// packages older than the threshold while KEEPING newer ones in the same run.
+// Back-dating a package's UpdatedAt would need a DB/source change (e.g. a test
+// helper on db.DB), and the one way to get there without it - parseDuration
+// falls through to time.ParseDuration, so a sub-second threshold parses and a
+// wall-clock sleep would cross it - buys a slow, flaky test of untouched code.
+// Instead this pins the two observable boundary behaviors that need neither:
 //   - a very large threshold must PROTECT a freshly published orphan, and
 //   - a zero threshold ("0d") must NOT protect it (filter is bypassed),
 //

--- a/tests/version_history_test.go
+++ b/tests/version_history_test.go
@@ -90,12 +90,20 @@ func TestListVersionsListsEveryRetainedVersion(t *testing.T) {
 	}
 
 	for _, row := range []string{firstRow, secondRow} {
-		if !strings.Contains(row, "published") {
+		if !strings.Contains(row, "just now") && !strings.Contains(row, "ago") {
 			t.Errorf("a version row carries no publish time:\n%s", row)
 		}
 	}
 	if !strings.Contains(out, "history-lib") {
 		t.Errorf("RunListVersions did not name the package, output was:\n%s", out)
+	}
+	// The columns are padded, so they have to be named: a reader otherwise gets
+	// four aligned fields and is left to guess which is the hash and which the
+	// version, on the one listing whose output is meant to be typed back.
+	for _, heading := range []string{"HASH", "VERSION", "PUBLISHED", "TAGS", "LINKED IN"} {
+		if !strings.Contains(out, heading) {
+			t.Errorf("RunListVersions printed no %s column heading, output was:\n%s", heading, out)
+		}
 	}
 	assertNoRawGlyphs(t, out)
 }

--- a/tests/version_history_test.go
+++ b/tests/version_history_test.go
@@ -1,0 +1,430 @@
+// Version history and rollback: `lnpm list <pkg> --versions` and
+// `lnpm add <pkg>@<hash>`, end to end through the real store.
+//
+// The store retains every version a publish wrote until gc collects it, so the
+// history is real data rather than a report assembled from somewhere else. These
+// tests drive the commands a user would run and read what they print, because
+// what the listing shows is exactly what the user will type back into add.
+package tests
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/internal/db"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
+)
+
+// rowFor returns the single line of out that mentions the given short hash,
+// failing when none or several do. The per-version facts are laid out one row
+// each, so asserting that a fact is on the right row is the only way to tell
+// "the listing says 1.2.0 is linked" from "the listing mentions linking
+// somewhere".
+func rowFor(t *testing.T, out, shortHash string) string {
+	t.Helper()
+
+	var found []string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, shortHash) {
+			found = append(found, line)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected exactly one row mentioning %s, found %d, output was:\n%s", shortHash, len(found), out)
+	}
+	return found[0]
+}
+
+// short is the eight-character hash `lnpm list --versions` prints and a user
+// types back into `lnpm add`.
+func short(hash string) string {
+	if len(hash) > 8 {
+		return hash[:8]
+	}
+	return hash
+}
+
+// TestListVersionsListsEveryRetainedVersion covers the first acceptance
+// criterion: every retained version of a package, with its hash, its semver
+// version and when it was published.
+//
+// The version the store has moved on from is the whole point. `lnpm list
+// --store` and `lnpm status` already show what is there; what neither answers is
+// "what can I roll back to", and that question is about the rows the default tag
+// no longer names.
+func TestListVersionsListsEveryRetainedVersion(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("history-lib", "1.2.0", map[string]string{
+		"index.js": "module.exports = 'v1';",
+	})
+	first, err := env.Database.GetPackageByName("history-lib")
+	if err != nil || first == nil {
+		t.Fatalf("Failed to read the first version: %v", err)
+	}
+
+	env.republish(pkgDir, "history-lib", "1.3.0", "module.exports = 'v2';")
+	second, err := env.Database.GetPackageByName("history-lib")
+	if err != nil || second == nil {
+		t.Fatalf("Failed to read the second version: %v", err)
+	}
+	if second.ContentHash == first.ContentHash {
+		t.Fatal("the republish produced the same content, so there is no history to list")
+	}
+
+	out := captureStdout(t, func() {
+		if err := cli.RunListVersions("history-lib"); err != nil {
+			t.Errorf("RunListVersions() error = %v", err)
+		}
+	})
+
+	firstRow := rowFor(t, out, short(first.ContentHash))
+	if !strings.Contains(firstRow, "1.2.0") {
+		t.Errorf("the row for the superseded version does not carry its version:\n%s", firstRow)
+	}
+	secondRow := rowFor(t, out, short(second.ContentHash))
+	if !strings.Contains(secondRow, "1.3.0") {
+		t.Errorf("the row for the current version does not carry its version:\n%s", secondRow)
+	}
+
+	for _, row := range []string{firstRow, secondRow} {
+		if !strings.Contains(row, "published") {
+			t.Errorf("a version row carries no publish time:\n%s", row)
+		}
+	}
+	if !strings.Contains(out, "history-lib") {
+		t.Errorf("RunListVersions did not name the package, output was:\n%s", out)
+	}
+	assertNoRawGlyphs(t, out)
+}
+
+// TestListVersionsOrdersTheHistoryNewestFirst pins the order a reader is
+// entitled to assume. A history is read top-down from the release that just
+// broke back to the one that worked, so the current version has to be the first
+// row rather than wherever bolt kept it.
+func TestListVersionsOrdersTheHistoryNewestFirst(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("ordered-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'v1';",
+	})
+	first, _ := env.Database.GetPackageByName("ordered-lib")
+	env.republish(pkgDir, "ordered-lib", "2.0.0", "module.exports = 'v2';")
+	second, _ := env.Database.GetPackageByName("ordered-lib")
+	if first == nil || second == nil {
+		t.Fatal("Failed to read both versions")
+	}
+
+	out := captureStdout(t, func() {
+		if err := cli.RunListVersions("ordered-lib"); err != nil {
+			t.Errorf("RunListVersions() error = %v", err)
+		}
+	})
+
+	newest := strings.Index(out, short(second.ContentHash))
+	oldest := strings.Index(out, short(first.ContentHash))
+	if newest < 0 || oldest < 0 {
+		t.Fatalf("RunListVersions did not list both versions, output was:\n%s", out)
+	}
+	if newest > oldest {
+		t.Errorf("RunListVersions listed the superseded version above the current one, output was:\n%s", out)
+	}
+}
+
+// TestListVersionsMarksTheVersionAProjectLinks covers the annotation the issue's
+// example carries: a row says which projects are on that build. Without it the
+// listing answers "what is in the store" rather than "what would rolling back
+// change", which is the question the user opened it with.
+//
+// The clause must land on the row it describes and on no other, so this asserts
+// its absence from the other row as well.
+func TestListVersionsMarksTheVersionAProjectLinks(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("linked-history-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'v1';",
+	})
+	first, _ := env.Database.GetPackageByName("linked-history-lib")
+	env.republish(pkgDir, "linked-history-lib", "2.0.0", "module.exports = 'v2';")
+	second, _ := env.Database.GetPackageByName("linked-history-lib")
+	if first == nil || second == nil {
+		t.Fatal("Failed to read both versions")
+	}
+
+	projectDir := env.newProject("consumer-app")
+	env.addPkg(projectDir, "linked-history-lib", false, false)
+
+	out := captureStdout(t, func() {
+		if err := cli.RunListVersions("linked-history-lib"); err != nil {
+			t.Errorf("RunListVersions() error = %v", err)
+		}
+	})
+
+	currentRow := rowFor(t, out, short(second.ContentHash))
+	if !strings.Contains(currentRow, "consumer-app") {
+		t.Errorf("the row for the version the project consumes does not name it:\n%s", currentRow)
+	}
+	supersededRow := rowFor(t, out, short(first.ContentHash))
+	if strings.Contains(supersededRow, "consumer-app") {
+		t.Errorf("the row for the superseded version claims the project is on it:\n%s", supersededRow)
+	}
+}
+
+// TestListVersionsNamesTheTagsOfEachVersion pins that the listing says which
+// channel names which build. A user choosing a version to roll back to has to be
+// able to tell the current release from the rest, and `latest` is the only thing
+// in the store that says which one that is.
+func TestListVersionsNamesTheTagsOfEachVersion(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("tagged-history-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'v1';",
+	})
+	first, _ := env.Database.GetPackageByName("tagged-history-lib")
+	if first == nil {
+		t.Fatal("Failed to read the first version")
+	}
+	if err := cli.RunTag("tagged-history-lib", "stable", false); err != nil {
+		t.Fatalf("Failed to tag the first version: %v", err)
+	}
+
+	env.republish(pkgDir, "tagged-history-lib", "2.0.0", "module.exports = 'v2';")
+	second, _ := env.Database.GetPackageByName("tagged-history-lib")
+	if second == nil {
+		t.Fatal("Failed to read the second version")
+	}
+
+	out := captureStdout(t, func() {
+		if err := cli.RunListVersions("tagged-history-lib"); err != nil {
+			t.Errorf("RunListVersions() error = %v", err)
+		}
+	})
+
+	supersededRow := rowFor(t, out, short(first.ContentHash))
+	if !strings.Contains(supersededRow, "stable") {
+		t.Errorf("the row for the version tagged stable does not say so:\n%s", supersededRow)
+	}
+	currentRow := rowFor(t, out, short(second.ContentHash))
+	if !strings.Contains(currentRow, db.DefaultTag) {
+		t.Errorf("the row for the current version does not name the %s tag:\n%s", db.DefaultTag, currentRow)
+	}
+	if strings.Contains(supersededRow, db.DefaultTag) {
+		t.Errorf("the row for the superseded version claims the %s tag:\n%s", db.DefaultTag, supersededRow)
+	}
+}
+
+// TestListVersionsOnAnUnknownPackageFails pins that a name the store never held
+// is an error rather than an empty listing. An empty history and a mistyped name
+// look identical on screen, and only one of them is worth acting on.
+func TestListVersionsOnAnUnknownPackageFails(t *testing.T) {
+	setupTest(t)
+
+	err := cli.RunListVersions("no-such-lib")
+	if err == nil {
+		t.Fatal("RunListVersions on an unknown package returned nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "no-such-lib") {
+		t.Errorf("RunListVersions error = %v, want it to name the package", err)
+	}
+}
+
+// TestListVersionsWithoutAPackageNameFails pins that the flag says what it needs
+// rather than listing the history of a package called "". A history is one
+// package's; there is nothing sensible for the flag to do without a name.
+func TestListVersionsWithoutAPackageNameFails(t *testing.T) {
+	setupTest(t)
+
+	err := cli.RunListVersions("")
+	if err == nil {
+		t.Fatal("RunListVersions with no package name returned nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "--versions") {
+		t.Errorf("RunListVersions error = %v, want it to point at the flag", err)
+	}
+}
+
+// TestAddByHashLinksAHistoricalBuild covers the second acceptance criterion, and
+// the motivating story whole: a consumer that a new release broke is put back on
+// the build that worked, without republishing anything from a git checkout.
+//
+// The hash is the eight-character one the listing prints, because that is what a
+// user copies out of it.
+func TestAddByHashLinksAHistoricalBuild(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("rollback-lib", "1.2.0", map[string]string{
+		"index.js": "module.exports = 'working';",
+	})
+	working, err := env.Database.GetPackageByName("rollback-lib")
+	if err != nil || working == nil {
+		t.Fatalf("Failed to read the working version: %v", err)
+	}
+
+	projectDir := env.newProject("broken-app")
+	env.addPkg(projectDir, "rollback-lib", false, false)
+
+	// The release that breaks the consumer.
+	env.republish(pkgDir, "rollback-lib", "1.3.0", "module.exports = 'broken';")
+	env.chdir(projectDir)
+	env.addPkg(projectDir, "rollback-lib", false, false)
+	env.AssertLinkedFileContent(projectDir, "rollback-lib", "index.js", "module.exports = 'broken';")
+
+	// The rollback.
+	env.addPkg(projectDir, "rollback-lib@"+short(working.ContentHash), false, false)
+
+	env.AssertLinkedFileContent(projectDir, "rollback-lib", "index.js", "module.exports = 'working';")
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		entry, ok := lock.Get("rollback-lib")
+		if !ok {
+			t.Fatal("rollback-lib is not in the lock file after the rollback")
+		}
+		if entry.Version != "1.2.0" {
+			t.Errorf("the lock file records version %s, want the 1.2.0 the rollback asked for", entry.Version)
+		}
+		if entry.Hash != working.ContentHash {
+			t.Errorf("the lock file records hash %s, want %s", entry.Hash, working.ContentHash)
+		}
+	})
+
+	// The link has to move with it, or push, remove and status all still believe
+	// the project is on the broken build.
+	links, err := env.Database.GetLinksForPackage(working.ID)
+	if err != nil {
+		t.Fatalf("Failed to read the links of the rolled-back version: %v", err)
+	}
+	if len(links) != 1 {
+		t.Errorf("the rolled-back version has %d links, want exactly the one project on it", len(links))
+	}
+}
+
+// TestAddBySupersededVersionLinksThatBuild is the same rollback by the other
+// identifier the listing prints. A user who has just read a version number off a
+// row will type that, not a hash, and refusing it would mean showing an
+// identifier and then declining to accept it.
+func TestAddBySupersededVersionLinksThatBuild(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("version-rollback-lib", "1.2.0", map[string]string{
+		"index.js": "module.exports = 'working';",
+	})
+	env.republish(pkgDir, "version-rollback-lib", "1.3.0", "module.exports = 'broken';")
+
+	projectDir := env.newProject("version-rollback-app")
+	env.addPkg(projectDir, "version-rollback-lib", false, false)
+	env.AssertLinkedFileContent(projectDir, "version-rollback-lib", "index.js", "module.exports = 'broken';")
+
+	env.addPkg(projectDir, "version-rollback-lib@1.2.0", false, false)
+	env.AssertLinkedFileContent(projectDir, "version-rollback-lib", "index.js", "module.exports = 'working';")
+}
+
+// TestAddByAnUnknownSpecNamesTheRetainedVersions pins the message at the dead
+// end. It used to report what `latest` names as though it were all the store
+// held, which is misleading now that the record the user is after may be sitting
+// one row down - and this is the moment they need to be told it is.
+func TestAddByAnUnknownSpecNamesTheRetainedVersions(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("deadend-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'v1';",
+	})
+	env.republish(pkgDir, "deadend-lib", "2.0.0", "module.exports = 'v2';")
+
+	projectDir := env.newProject("deadend-app")
+	env.chdir(projectDir)
+
+	err := cli.RunAdd("deadend-lib@9.9.9", false, false, false)
+	if err == nil {
+		t.Fatal("add deadend-lib@9.9.9 succeeded, want a refusal")
+	}
+	for _, want := range []string{"1.0.0", "2.0.0"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal is %v, want it to name the retained version %s", err, want)
+		}
+	}
+}
+
+// TestAddWithNoVersionResolvesTheMostRecentlyPublished covers the third
+// acceptance criterion, which the store's move to keeping every version had to
+// leave alone. Nothing pinned the version an unversioned add lands on - the
+// existing test asserts the symlink and the package.json reference, both of
+// which a resolution to the wrong build would satisfy.
+func TestAddWithNoVersionResolvesTheMostRecentlyPublished(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("unversioned-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'v1';",
+	})
+	env.republish(pkgDir, "unversioned-lib", "2.0.0", "module.exports = 'v2';")
+
+	projectDir := env.newProject("unversioned-app")
+	env.addPkg(projectDir, "unversioned-lib", false, false)
+
+	env.AssertLinkedFileContent(projectDir, "unversioned-lib", "index.js", "module.exports = 'v2';")
+	env.AssertLockfile(projectDir, func(lock *lockfile.LockFile) {
+		entry, ok := lock.Get("unversioned-lib")
+		if !ok {
+			t.Fatal("unversioned-lib is not in the lock file")
+		}
+		if entry.Version != "2.0.0" {
+			t.Errorf("an unversioned add landed on %s, want the most recently published 2.0.0", entry.Version)
+		}
+	})
+}
+
+// TestGCKeepsAVersionARollbackLinks covers the fourth acceptance criterion's
+// second half, which only became reachable once a project could be put back on a
+// superseded build: gc removes the historical versions nothing links, and must
+// leave the historical version a rollback does link exactly where it is.
+//
+// Before rollback existed, a superseded version had no links by construction -
+// moving the default tag carries them forward - so "an old version a project is
+// on" was a state the store could not be in and no test could cover.
+func TestGCKeepsAVersionARollbackLinks(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("gc-rollback-lib", "1.0.0", map[string]string{
+		"index.js": "module.exports = 'working';",
+	})
+	working, err := env.Database.GetPackageByName("gc-rollback-lib")
+	if err != nil || working == nil {
+		t.Fatalf("Failed to read the working version: %v", err)
+	}
+	env.republish(pkgDir, "gc-rollback-lib", "2.0.0", "module.exports = 'broken';")
+	env.republish(pkgDir, "gc-rollback-lib", "3.0.0", "module.exports = 'newest';")
+	projectDir := env.newProject("gc-rollback-app")
+	env.addPkg(projectDir, "gc-rollback-lib@"+short(working.ContentHash), false, false)
+
+	// Everything else the store holds for this name is unlinked and untagged, so
+	// the run has something to collect as well as something to keep.
+	before, err := env.Database.GetPackageVersions("gc-rollback-lib")
+	if err != nil {
+		t.Fatalf("Failed to read the history: %v", err)
+	}
+	if len(before) != 3 {
+		t.Fatalf("the store holds %d versions of gc-rollback-lib, want the 3 that were published", len(before))
+	}
+
+	if err := cli.RunGC(false, "", false, true); err != nil {
+		t.Fatalf("Failed to run GC: %v", err)
+	}
+
+	kept, err := env.Database.GetPackageByHash("gc-rollback-lib", working.ContentHash)
+	if err != nil {
+		t.Fatalf("Failed to look up the rolled-back version: %v", err)
+	}
+	if kept == nil {
+		t.Fatal("GC collected the historical version the project is linked to")
+	}
+	env.AssertDirectoryExists(kept.StorePath, true)
+	env.AssertFileExists(filepath.Join(projectDir, ".lnpm", "gc-rollback-lib", "index.js"), true)
+
+	after, err := env.Database.GetPackageVersions("gc-rollback-lib")
+	if err != nil {
+		t.Fatalf("Failed to re-read the history: %v", err)
+	}
+	if len(after) != 1 {
+		t.Errorf("the store holds %d versions after gc, want only the one the project links", len(after))
+	}
+}

--- a/tests/version_history_test.go
+++ b/tests/version_history_test.go
@@ -319,6 +319,64 @@ func TestAddBySupersededVersionLinksThatBuild(t *testing.T) {
 	env.AssertLinkedFileContent(projectDir, "version-rollback-lib", "index.js", "module.exports = 'working';")
 }
 
+// TestAddWithLinkRefusesAVersionOrAHash pins the one silent wrong resolution
+// widening the spec selector could introduce.
+//
+// --link points .lnpm/<pkg> at the source directory, which holds the working
+// tree; a version and a hash each name a build in the store. Before this
+// selector existed, both specs hard-failed with --link because neither resolved
+// at all. Now they resolve, and an add that honoured --link anyway would
+// live-link the working tree while printing the historical version number it
+// resolved to - the same contradiction --link with a dist-tag is refused for,
+// and sharper, because a hash names a build more specifically than a tag does.
+func TestAddWithLinkRefusesAVersionOrAHash(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// spec is built from the superseded build once it is published.
+		spec func(superseded *db.Package) string
+	}{
+		{"version", func(p *db.Package) string { return "live-build-lib@" + p.Version }},
+		{"hash", func(p *db.Package) string { return "live-build-lib@" + short(p.ContentHash) }},
+	} {
+		for _, path := range []string{"single", "parallel"} {
+			t.Run(tc.name+"/"+path, func(t *testing.T) {
+				env := setupTest(t)
+
+				pkgDir := env.publishPkg("live-build-lib", "1.0.0", map[string]string{
+					"index.js": "module.exports = 'working';",
+				})
+				superseded, err := env.Database.GetPackageByName("live-build-lib")
+				if err != nil || superseded == nil {
+					t.Fatalf("Failed to read the superseded version: %v", err)
+				}
+				env.republish(pkgDir, "live-build-lib", "2.0.0", "module.exports = 'broken';")
+				env.simplePkg("live-plain-lib")
+
+				projectDir := env.newProject("live-build-project")
+				env.chdir(projectDir)
+
+				specs := []string{tc.spec(superseded)}
+				if path == "parallel" {
+					specs = append(specs, "live-plain-lib")
+				}
+
+				captureStdout(t, func() {
+					err = cli.RunAddMultiple(specs, false, false, false, true)
+				})
+				if err == nil {
+					t.Fatalf("Adding %s with --link succeeded, want a refusal", specs[0])
+				}
+
+				// Nothing about the package is linked, whichever path ran: a
+				// live link here would resolve to the working tree while the
+				// summary named the superseded build.
+				env.AssertDirectoryExists(filepath.Join(projectDir, ".lnpm", "live-build-lib"), false)
+				env.AssertPackageJSONMissing(projectDir, "live-build-lib")
+			})
+		}
+	}
+}
+
 // TestAddByAnUnknownSpecNamesTheRetainedVersions pins the message at the dead
 // end. It used to report what `latest` names as though it were all the store
 // held, which is misleading now that the record the user is after may be sitting


### PR DESCRIPTION
Closes #197.

Adds `lnpm list <pkg> --versions` to see what can be rolled back to, and
`lnpm add <pkg>@<hash>` (or `@<superseded-version>`) to roll a single consumer
back to a historical build without re-publishing from a git checkout.

## Most of this issue was already done

#196 landed the day before and did the schema work. Verified rather than assumed:

- Records are already addressed by `(name, hash)` with multiple versions
  coexisting, and `GetPackageByName` still returns what `latest` names.
- `gc` already moved from per-name to per-version reachability (ADR-0002).
- So **AC3** (bare `add` unchanged) and **AC4** (`gc` removes unlinked historical
  versions) were already satisfied.

**AC3 was satisfied but completely unpinned.** The existing test published two
versions, re-added, and asserted only the symlink and the `package.json`
reference — both of which a resolution to the *wrong* build also produces. There
is now a test asserting the linked bytes and the lock version.

The issue's three open questions were answered from #196's settled decisions:
versions are retained until `gc` collects them, `--older-than` applies per
version, and a hash resolves for any version whose record still exists.

## Spec resolution

`add <pkg>@<spec>` now resolves in three steps: **dist-tag → exact version → hash
prefix**, and refuses ambiguity rather than guessing.

- A tag wins even when spelled like a version or a hash — it is a name a person
  chose for this package.
- An exact version beats a hash prefix.
- Where two records carry the same version string, **the record the default tag
  names wins** — which is byte-identical to the old behaviour, so no spec that
  resolved before resolves differently now.
- Ambiguity is always an error naming the full hashes, never a guess. This is the
  command reached for when a release broke something.
- Hash prefixes need **four characters**, git's minimum. Without it,
  `add mylib@2` from a user who meant version 2 gets matched against content
  hashes.

The old dead-end error named only `latest`'s version, which is now misleading
when other versions are right there. It lists the newest few retained versions —
capped, since a package with 30 of them would otherwise produce a 700-character
error — and points at `lnpm list <pkg> --versions`.

## `--link` is refused for a spec that names a build

Found in review, and the one silent wrong resolution this change introduced.

The existing guard refused `--link` only for a *dist-tag*, by inspecting the
returned tag string. A hash or version resolution returns an empty tag, so it
slipped through: `lnpm add mylib@9f8e7d6c --link` printed
`Adding mylib@1.2.0 (linked to source)...` — the historical version number —
while linking the current working tree.

Resolution now reports *how* it resolved rather than leaving intent to be inferred
from a string, and `--link` is refused for anything but a bare name. The kind is
string-backed rather than `iota`, so a path that forgets to report one fails
closed instead of defaulting to "bare name".

## What a rollback survives, and what it does not

Traced and documented rather than assumed. A rollback holds against everything the
publisher does: `moveLinksTx` only walks the links of the record the tag named
*immediately* before, so a link two generations back is never carried forward;
`push` and `publish --push` enumerate consumers of the newly written record; and
`restore` resolves through the snapshot's content hash.

**It does not survive `lnpm pull`**, which resolves the empty tag to `latest`,
relinks, rewrites the lock and repoints the DB link — after which `gc` can collect
the build that was being preserved. Bare `pull` refreshes every package in the
lock, so pulling one package can undo another's rollback.

A pinned-link concept would need a new `Link` state distinct from `Tag` and touch
pull, push, `publish --push`, restore, status and gc reachability — out of scope
here. **The README now says so explicitly**, rather than promising a durability
that does not exist.

## Verification

`go test ./... -count=1`, `go vet`, `golangci-lint`, `gofmt -l`, plus build and vet
for windows/amd64, darwin/arm64 and linux/arm64 — all clean, and the full suite
re-run under a symlinked `TMPDIR`.

Every new test was revert-checked. Four pass with the change reverted and are
labelled in their own comments as deliberate no-regression guards — including
AC3's, which pins behaviour that must be identical before and after.

`ARCHITECTURE.md` and `README.md` are updated; both stated the old two-step
resolution rule, and `ARCHITECTURE.md` documented every `list` flag but this one.

**`-race` could not run locally (no gcc), and Windows/macOS rest on CI.**
