### PR TITLE
ci: check PR titles and document the 2.0.0 upgrade path

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,33 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-title:
+    name: Conventional Commit
+    runs-on: ubuntu-latest
+
+    steps:
+      # Merges are squashed, so the PR title becomes the commit subject that
+      # release-please parses. A non-conventional title is silently dropped
+      # from the changelog and the version bump.
+      - name: Check PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            test
+            ci
+            style
+            refactor
+            perf

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -2,6 +2,10 @@ name: PR Title
 
 on:
   pull_request:
+    # synchronize looks redundant - a push cannot change the title - but a
+    # required status check is recorded per commit SHA, so without it a new
+    # push leaves the newest commit with no result and the check never
+    # reports. Re-running on every push is what keeps it mergeable.
     types: [opened, edited, synchronize, reopened]
 
 permissions:
@@ -21,6 +25,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # revert is not in this repo's history yet, but GitHub's Revert
+          # button generates `Revert "feat: ..."` and release-please
+          # understands the type. Rejecting it would block a revert exactly
+          # when speed matters.
           types: |
             feat
             fix
@@ -31,3 +39,4 @@ jobs:
             style
             refactor
             perf
+            revert

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 
 ## Installation
 
+> **On lnpm 1.9.x or older? Reinstall manually.** Those versions compare versions
+> byte-wise, so `lnpm update` reports `Already up to date` and never upgrades you.
+> Run `lnpm --version` to check, then reinstall with the script below or with
+> `go install github.com/pedrosousa13/lnpm/cmd/lnpm@latest`. 1.10.0 and later are
+> unaffected.
+
 ### Quick Install (Linux/macOS)
 
 ```bash

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -198,6 +198,14 @@ func fetchLatestVersion(ctx context.Context) (string, error) {
 	return release.TagName, nil
 }
 
+// compareVersions reports whether latest supersedes current.
+//
+// Every release up to v1.12.0 shipped a byte-wise string comparison here, which
+// made "1.12.0" > "1.9.0" false and left anyone below 1.10.0 unable to
+// self-update. The fix only runs in a binary those users can never reach, so the
+// next release was forced to 2.0.0: a major bump is the only tag that is both
+// semver-greater and string-greater than every 1.x, so the stale comparison in
+// their installed binary still sees it. See issue #297.
 func compareVersions(current, latest string) *Result {
 	// Normalize mixed v-prefixed and bare inputs to canonical vX.Y.Z form
 	currentSemver := "v" + strings.TrimPrefix(current, "v")


### PR DESCRIPTION
Release preparation for 2.0.0. Relates to #297.

## Why 2.0.0

Every release up to v1.12.0 shipped a byte-wise version comparison in
`internal/update`:

```go
if latestNorm != currentNorm && latestNorm > currentNorm { ... }
```

`"1.12.0" > "1.9.0"` is false — at index 2, `'1'` sorts below `'9'`. So
`lnpm update` on 1.9.0 answers `Already up to date`. The comparison only fails
when the digit counts differ, which strands **1.7.x, 1.8.x and 1.9.x
permanently**; 1.10.0 and later are fine.

#216 fixed the comparison, but that fix runs in a binary the stranded users can
never download. Verified by running the pre-#216 function against real inputs:

| Installed | Offered 1.13.0 | Offered 2.0.0 |
| --- | --- | --- |
| 1.7.7 / 1.8.2 / 1.9.0 | **not offered** | **offered** |
| 1.10.0 / 1.11.0 / 1.12.0 | offered | offered |

A `v` prefix changes nothing. So 2.0.0 is the only tag that reaches the stranded
users while offering nobody a downgrade. The download path was checked too:
v1.9.0 builds `releases/download/v%s/lnpm_%s_%s_%s.tar.gz`, exactly what
goreleaser still produces, so a stuck binary can complete the upgrade unaided.

A major bump is also defensible on its own terms — #196 changed the database
schema with an on-open migration, made `gc` collect superseded versions, and made
the binary refuse a database written by a newer build, so downgrading is no longer
safe.

## What is here

**A PR-title check.** The repo squash-merges, so the PR title becomes the commit
subject release-please parses. Twenty of the 65 commits since v1.12.0 have
non-conventional subjects and are therefore invisible to the changelog and the
version bump — `lnpm pull`, an entire command, would have shipped undocumented.
The allowed types are taken from this repo's own history, plus `revert`, because
GitHub's Revert button generates `Revert "feat: ..."` and rejecting it would block
a revert exactly when speed matters.

**A README notice**, since documentation is the only channel that reaches a
stranded user, and **a comment on `compareVersions`** recording why the version
history jumps to 2.0.0.

## Not here

`CHANGELOG.md` is untouched — release-please owns it. The missing user-facing
entries will be added to the release PR once it regenerates.

`compareVersions` itself is untouched; #216 already fixed it.

## Two things this cannot do from a PR

- The check only *blocks* a merge once `PR Title / Conventional Commit` is marked
  a required status check in branch protection for `main`. Until then it is
  advisory.
- `.github/dependabot.yml` tracks only `gomod`, so none of the five third-party
  actions — including the one added here — will get update PRs. Worth its own
  issue.
