### PR TITLE
ci: have Dependabot track GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # "/" covers every workflow under .github/workflows/; the ecosystem does not
+  # take one entry per file.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # Without a prefix Dependabot titles its PRs "Bump actions/checkout from
+      # 4 to 5", which has no conventional type and so fails the required
+      # PR Title check. The prefix makes it "ci: bump actions/checkout from
+      # 4 to 5" - "ci" is in the allowlist in pr-title.yaml, and bumping an
+      # action is a CI change that release-please keeps out of the changelog.
+      prefix: "ci"


### PR DESCRIPTION
Closes #303

`.github/dependabot.yml` tracked only `gomod`, so none of the third-party actions
this repo runs with repository credentials would ever get an update PR — security
fixes included. This adds a `github-actions` entry on the same weekly cadence.

## The part that mattered: the required PR-title check

#299 made `Conventional Commit` a **required** status check on `main`. Dependabot
titles its own PRs, so if its default format failed that check, every Dependabot
PR would be unmergeable and this change would be actively harmful.

Verified rather than assumed, against `amannn/action-semantic-pull-request`'s
source at the `v5` tag (`e32d7e6`, `src/validatePrTitle.js`):

- `if (!result.type) { raiseError('No release type found...') }` — Dependabot's
  default `Bump actions/checkout from 4 to 5` has no type and **is rejected**.
- The subject check is gated on `if (subjectPattern)`, and `pr-title.yaml` sets
  none. So capitalisation is unconstrained — which matters, because Dependabot's
  capitalisation of `Bump`/`bump` is inferred from repo history and is not
  deterministic. Both `ci: bump …` and `ci: Bump …` pass.

`commit-message.prefix: "ci"` produces the passing shape. Confirmed against real
Dependabot PRs on public repos that set exactly this prefix, e.g.
`ci: bump github/codeql-action/analyze from 4.37.6 to 4.37.7`.

`ci` over `chore`: both are hidden from the changelog and non-bumping under
release-please, and `ci` is the more precise of the two for a workflow pin.
`build(deps)`, the common convention elsewhere, is **not** in this repo's
allowlist (`feat fix docs chore test ci style refactor perf revert`) and would
fail.

## Validation

`.github/dependabot.yml` was parsed with PyYAML and asserted on parsed *values*:
exactly two `updates` entries, the `github-actions` entry carrying
`directory: "/"`, weekly, prefix `ci`, and the `gomod` entry parsing identically
to `git show main:.github/dependabot.yml`. Every scalar was walked to confirm no
`#` leaked into a value.

## Action inventory

`directory: "/"` covers all nine actions across the three workflows. The issue's
list missed `actions/setup-node@v4` and `actions/upload-artifact@v4`, and gave no
versions for the golangci-lint (`@v9`), goreleaser (`@v6`) and codecov (`@v4`)
actions.

## Two findings reported on the issue, deliberately not fixed here

The `gomod` entry has the same missing-prefix defect, and Dependabot alerts and
security updates are disabled at the repository level. Both are recorded in
detail on #303. The first is explicitly out of scope for this issue; the second
is a settings toggle, not a code change.