### PR TITLE
docs: point vulnerability reports at GitHub private reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,11 +44,20 @@ Hard links share the same inode as the source file:
 
 ## Reporting a Vulnerability
 
-Please report security vulnerabilities by:
+Please report security vulnerabilities privately. GitHub's private vulnerability
+reporting is the preferred channel:
+
+**[Report a vulnerability](https://github.com/pedrosousa13/lnpm/security/advisories/new)**
+
+You can also reach the same form from the repository's
+[Security tab](https://github.com/pedrosousa13/lnpm/security) via the
+**Report a vulnerability** button. The report is visible only to the maintainers
+until an advisory is published.
+
+When reporting:
 
 1. **DO NOT** open a public issue
-2. Email security concerns to the maintainers
-3. Include:
+2. Include:
    - Description of the vulnerability
    - Steps to reproduce
    - Potential impact


### PR DESCRIPTION
Closes #304

`SECURITY.md` told researchers to *"Email security concerns to the maintainers"*
and gave no address, so a real report had nowhere to go. It now points at this
repository's private vulnerability reporting form, which is enabled and accepting
reports today (`gh api repos/pedrosousa13/lnpm/private-vulnerability-reporting`
returns `{"enabled": true}`).

## What changed versus `1f4c1db`

The issue asked for this delta explicitly. Two things:

1. **The stale maintainer note is gone.** `1f4c1db` was written while the toggle
   was off and embedded a 14-line `<!-- MAINTAINER NOTE ... -->` block recording
   `{"enabled": false}` and telling the maintainer to enable it and delete the
   comment. Both halves are now false. `git grep -n "<!--" -- SECURITY.md`
   returns nothing.
2. **The lead-in now names the form as the preferred channel**, rather than
   merely linking it — acceptance criterion 2 asks for that literally. Cost: three
   words. No disclosure policy, scope section or safe-harbour language was added;
   none of that is in the criteria.

The commit message was also rewritten: `1f4c1db`'s body described the toggle as
off and was tagged `Refs #195` rather than the issue it closes.

## Provenance of the branch

`1f4c1db` originally sat on `pedrosousa13/issue-195-sign-release-artifacts`,
which is #195's derived branch name and was needed there for the signing work.
The commit was moved to this branch, rebased onto current `main` and amended —
so it is `b3c5569` here. Nothing was lost.

## Acceptance criteria

- **Links to the form rather than an unspecified email.** Both URLs were checked
  against a control rather than assumed: `/security` returns 200 and
  `/security/advisories/new` returns 302 to login with the path preserved, while
  the identical paths on a nonexistent repository return 404. The 302-versus-404
  split is what confirms the slug and path shape are real.
- **States what a reporter can expect.** The form is named as the preferred
  channel, and a report is stated to stay visible only to the maintainers until
  an advisory is published. The pre-existing 48-hour response line covers what
  happens after filing.
- **No claim about release signing or artifact verification.** Checked
  deliberately over the whole file, not just the diff: a case-insensitive search
  for sign/checksum/sha256/attest/verif/provenance/gpg/sigstore/cosign across
  `SECURITY.md` returns no hits. #195 is parked and unmerged, so any such claim
  would be false on `main`.

## Note on CI

This is a markdown-only change and `ci.yaml` carries `paths-ignore: '**.md'`, so
CI reports no checks here by design. The `Conventional Commit` check is the only
one that runs, and it is the required one.