### PR TITLE
feat(check): cover every workspace package, not just the working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,10 +280,12 @@ would carry into the tarball, and exits non-zero if there is any — drop it in 
 `lnpm.lock.retreat` snapshot described below, when nothing in the project would
 keep that snapshot out of the tarball.
 
-In a monorepo the reference scan covers every workspace package, not only the
-manifest where you ran it, and each finding names the package it came from. A
-workspace whose member list will not resolve fails the check rather than passing
-on the root manifest alone.
+In a monorepo the reference scan covers the workspace root's `package.json` and
+every workspace package's, not only the manifest where you ran it, and each
+finding names the package it came from. A workspace whose member list will not
+resolve — a malformed pattern in the `workspaces` field, a member manifest that
+will not read or parse, a member with no `name` — fails the check rather than
+passing on the manifest at hand alone.
 
 ### After Publishing to npm
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,11 @@ would carry into the tarball, and exits non-zero if there is any — drop it in 
 `lnpm.lock.retreat` snapshot described below, when nothing in the project would
 keep that snapshot out of the tarball.
 
+In a monorepo the reference scan covers every workspace package, not only the
+manifest where you ran it, and each finding names the package it came from. A
+workspace whose member list will not resolve fails the check rather than passing
+on the root manifest alone.
+
 ### After Publishing to npm
 
 ```bash

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/pedrosousa13/lnpm/internal/pack"
+	"github.com/pedrosousa13/lnpm/internal/workspace"
 	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
 
@@ -23,6 +24,12 @@ import (
 // resolves to nothing on the consumer's machine. The second is the snapshot
 // `lnpm retreat` leaves behind, which records an absolute source path per
 // linked package.
+//
+// Inside a workspace the reference scan covers every member's manifest as well
+// as the one here, because a root manifest carries no dependencies worth
+// linking and a guard that passes from the repo root while a member still holds
+// a file:.lnpm/ reference is worse than no guard at all. The snapshot half stays
+// on the current directory: the snapshot is written where retreat ran.
 func RunCheck() error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -40,18 +47,32 @@ func RunCheck() error {
 		return fmt.Errorf("failed to parse package.json: %w", err)
 	}
 
+	manifests, err := checkManifests(cwd, pkgJSON)
+	if err != nil {
+		return err
+	}
+
 	// Collect "<field>: <pkg> => <ref>" for every lnpm reference found across
-	// the standard dependency maps.
+	// the standard dependency maps of every manifest in scope, and note which
+	// packages they came from so the report can say so.
 	var found []string
-	for _, field := range []string{"dependencies", "devDependencies", "optionalDependencies", "peerDependencies"} {
-		deps, ok := pkgJSON[field].(map[string]interface{})
-		if !ok {
-			continue
-		}
-		for name, v := range deps {
-			ref, ok := v.(string)
-			if ok && isLnpmReference(ref) {
-				found = append(found, fmt.Sprintf("  %s.%s -> %s", field, name, ref))
+	guilty := make(map[string]bool)
+	for _, manifest := range manifests {
+		for _, field := range []string{"dependencies", "devDependencies", "optionalDependencies", "peerDependencies"} {
+			deps, ok := manifest.pkgJSON[field].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for name, v := range deps {
+				ref, ok := v.(string)
+				if ok && isLnpmReference(ref) {
+					if manifest.label == "" {
+						found = append(found, fmt.Sprintf("  %s.%s -> %s", field, name, ref))
+						continue
+					}
+					found = append(found, fmt.Sprintf("  %s: %s.%s -> %s", manifest.label, field, name, ref))
+					guilty[manifest.label] = true
+				}
 			}
 		}
 	}
@@ -60,12 +81,20 @@ func RunCheck() error {
 
 	if len(found) > 0 {
 		sort.Strings(found)
-		fmt.Printf("%s Found %d lnpm reference(s) in package.json:\n", iconFail(), len(found))
+		if len(guilty) > 0 {
+			fmt.Printf("%s Found %d lnpm reference(s) in %d workspace package(s):\n", iconFail(), len(found), len(guilty))
+		} else {
+			fmt.Printf("%s Found %d lnpm reference(s) in package.json:\n", iconFail(), len(found))
+		}
 		for _, line := range found {
 			fmt.Println(line)
 		}
 		fmt.Printf("\n  %s Run 'lnpm retreat --force' to restore original dependencies before publishing\n", iconTip())
-		problems = append(problems, fmt.Sprintf("%d lnpm reference(s) found in package.json", len(found)))
+		if len(guilty) > 0 {
+			problems = append(problems, fmt.Sprintf("%d lnpm reference(s) found in %d workspace package(s)", len(found), len(guilty)))
+		} else {
+			problems = append(problems, fmt.Sprintf("%d lnpm reference(s) found in package.json", len(found)))
+		}
 	}
 
 	if publishableSnapshot(cwd, filesField(pkgJSON)) {
@@ -81,6 +110,114 @@ func RunCheck() error {
 		return nil
 	}
 	return errors.New(strings.Join(problems, "; "))
+}
+
+// checkManifest is one package.json the reference scan applies to: the parsed
+// document, and a label naming the package it came from. An empty label means
+// the scan is looking at a lone project rather than a workspace, and the report
+// keeps the wording it has always had in that case.
+type checkManifest struct {
+	label   string
+	pkgJSON map[string]interface{}
+}
+
+// checkManifests returns every manifest the reference scan covers: the one in
+// the current directory, plus - when that directory sits in a workspace - the
+// workspace root's and every member's.
+//
+// A workspace whose member list will not resolve is an error rather than a
+// reason to fall back to the current directory alone. Checking only the root
+// and reporting success is precisely the failure the workspace-wide scan exists
+// to remove, so an unresolvable workspace fails loudly instead.
+func checkManifests(cwd string, cwdPkgJSON map[string]interface{}) ([]checkManifest, error) {
+	ws, err := workspace.Detect(cwd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect workspace: %w", err)
+	}
+	if ws == nil {
+		return []checkManifest{{pkgJSON: cwdPkgJSON}}, nil
+	}
+
+	packages, err := ws.ListPackages()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list workspace packages: %w", err)
+	}
+
+	// The current directory's manifest is already read and parsed; the rest are
+	// the workspace root's - which a check run from a member would otherwise
+	// leave unscanned - and one per member.
+	manifests := []checkManifest{{
+		label:   manifestLabel(nameField(cwdPkgJSON), ws.Root, cwd),
+		pkgJSON: cwdPkgJSON,
+	}}
+	seen := map[string]bool{canonicalPath(cwd): true}
+
+	for _, pkg := range append([]workspace.Package{{Path: ws.Root}}, packages...) {
+		key := canonicalPath(pkg.Path)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		manifestPath := filepath.Join(pkg.Path, "package.json")
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read workspace package %s: %w", manifestPath, err)
+		}
+
+		var pkgJSON map[string]interface{}
+		if err := json.Unmarshal(data, &pkgJSON); err != nil {
+			return nil, fmt.Errorf("failed to parse workspace package %s: %w", manifestPath, err)
+		}
+
+		name := pkg.Name
+		if name == "" {
+			name = nameField(pkgJSON)
+		}
+		manifests = append(manifests, checkManifest{
+			label:   manifestLabel(name, ws.Root, pkg.Path),
+			pkgJSON: pkgJSON,
+		})
+	}
+
+	return manifests, nil
+}
+
+// manifestLabel names a manifest in check's report. The package name is what a
+// reader can act on, and a manifest without one - a private workspace root
+// often has neither name nor version - falls back to its path relative to the
+// workspace root. The label is never empty, because an empty one is what tells
+// the report it is not looking at a workspace at all.
+func manifestLabel(name, root, path string) string {
+	if name != "" {
+		return name
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." {
+		return "workspace root"
+	}
+	return filepath.ToSlash(rel)
+}
+
+// nameField returns the package.json "name", or "" when it is absent or is not
+// a string.
+func nameField(pkgJSON map[string]interface{}) string {
+	name, _ := pkgJSON["name"].(string)
+	return name
+}
+
+// canonicalPath resolves path as far as the filesystem allows, so that two
+// spellings of one directory compare equal. The working directory and a
+// workspace member path reach this function by different routes, and on Windows
+// a cwd can come back as an 8.3 short name while the member path is spelled
+// long; EvalSymlinks reconciles both, and also the case of each component. A
+// path it cannot resolve falls back to Clean, which at worst scans a manifest
+// twice rather than reporting a false difference.
+func canonicalPath(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return filepath.Clean(path)
 }
 
 // publishableSnapshot reports whether the retreat snapshot is sitting in the

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -25,11 +25,11 @@ import (
 // `lnpm retreat` leaves behind, which records an absolute source path per
 // linked package.
 //
-// Inside a workspace the reference scan covers every member's manifest as well
-// as the one here, because a root manifest carries no dependencies worth
-// linking and a guard that passes from the repo root while a member still holds
-// a file:.lnpm/ reference is worse than no guard at all. The snapshot half stays
-// on the current directory: the snapshot is written where retreat ran.
+// Inside a workspace the reference scan covers the workspace root's manifest
+// and every member's as well as the one here, because a guard that passes from
+// the repo root while a member still holds a file:.lnpm/ reference is worse than
+// no guard at all. The snapshot half stays on the current directory: the
+// snapshot is written where retreat ran.
 func RunCheck() error {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -47,17 +47,20 @@ func RunCheck() error {
 		return fmt.Errorf("failed to parse package.json: %w", err)
 	}
 
-	manifests, err := checkManifests(cwd, pkgJSON)
+	manifests, inWorkspace, err := checkManifests(cwd, pkgJSON)
 	if err != nil {
 		return err
 	}
 
 	// Collect "<field>: <pkg> => <ref>" for every lnpm reference found across
-	// the standard dependency maps of every manifest in scope, and note which
-	// packages they came from so the report can say so.
+	// the standard dependency maps of every manifest in scope, counting the
+	// manifests that carry one. The count is of manifests rather than of the
+	// labels on them: the workspace root is one of the manifests and is not a
+	// workspace package, and two members can carry the same name.
 	var found []string
-	guilty := make(map[string]bool)
+	dirty := 0
 	for _, manifest := range manifests {
+		before := len(found)
 		for _, field := range []string{"dependencies", "devDependencies", "optionalDependencies", "peerDependencies"} {
 			deps, ok := manifest.pkgJSON[field].(map[string]interface{})
 			if !ok {
@@ -65,15 +68,18 @@ func RunCheck() error {
 			}
 			for name, v := range deps {
 				ref, ok := v.(string)
-				if ok && isLnpmReference(ref) {
-					if manifest.label == "" {
-						found = append(found, fmt.Sprintf("  %s.%s -> %s", field, name, ref))
-						continue
-					}
-					found = append(found, fmt.Sprintf("  %s: %s.%s -> %s", manifest.label, field, name, ref))
-					guilty[manifest.label] = true
+				if !ok || !isLnpmReference(ref) {
+					continue
 				}
+				if inWorkspace {
+					found = append(found, fmt.Sprintf("  %s: %s.%s -> %s", manifest.label, field, name, ref))
+					continue
+				}
+				found = append(found, fmt.Sprintf("  %s.%s -> %s", field, name, ref))
 			}
+		}
+		if len(found) > before {
+			dirty++
 		}
 	}
 
@@ -81,8 +87,8 @@ func RunCheck() error {
 
 	if len(found) > 0 {
 		sort.Strings(found)
-		if len(guilty) > 0 {
-			fmt.Printf("%s Found %d lnpm reference(s) in %d workspace package(s):\n", iconFail(), len(found), len(guilty))
+		if inWorkspace {
+			fmt.Printf("%s Found %d lnpm reference(s) in %d package.json file(s):\n", iconFail(), len(found), dirty)
 		} else {
 			fmt.Printf("%s Found %d lnpm reference(s) in package.json:\n", iconFail(), len(found))
 		}
@@ -90,8 +96,8 @@ func RunCheck() error {
 			fmt.Println(line)
 		}
 		fmt.Printf("\n  %s Run 'lnpm retreat --force' to restore original dependencies before publishing\n", iconTip())
-		if len(guilty) > 0 {
-			problems = append(problems, fmt.Sprintf("%d lnpm reference(s) found in %d workspace package(s)", len(found), len(guilty)))
+		if inWorkspace {
+			problems = append(problems, fmt.Sprintf("%d lnpm reference(s) found in %d package.json file(s)", len(found), dirty))
 		} else {
 			problems = append(problems, fmt.Sprintf("%d lnpm reference(s) found in package.json", len(found)))
 		}
@@ -113,9 +119,8 @@ func RunCheck() error {
 }
 
 // checkManifest is one package.json the reference scan applies to: the parsed
-// document, and a label naming the package it came from. An empty label means
-// the scan is looking at a lone project rather than a workspace, and the report
-// keeps the wording it has always had in that case.
+// document, and a label naming the package it came from. The label is set only
+// inside a workspace, where the report has more than one manifest to tell apart.
 type checkManifest struct {
 	label   string
 	pkgJSON map[string]interface{}
@@ -123,24 +128,31 @@ type checkManifest struct {
 
 // checkManifests returns every manifest the reference scan covers: the one in
 // the current directory, plus - when that directory sits in a workspace - the
-// workspace root's and every member's.
+// workspace root's and every member's. The second return value says which of
+// those two it was, so the report does not have to infer it from the labels.
 //
 // A workspace whose member list will not resolve is an error rather than a
 // reason to fall back to the current directory alone. Checking only the root
 // and reporting success is precisely the failure the workspace-wide scan exists
-// to remove, so an unresolvable workspace fails loudly instead.
-func checkManifests(cwd string, cwdPkgJSON map[string]interface{}) ([]checkManifest, error) {
+// to remove, so an unresolvable workspace fails loudly instead. That covers a
+// directory below a broken workspace too: a malformed pattern makes membership
+// unknown, and unknown is not the same as "no workspace here".
+//
+// Both errors add the location and leave the wrapped error to say what is
+// wrong with it, because workspace.Detect names the offending pattern and
+// ListPackages names the offending manifest.
+func checkManifests(cwd string, cwdPkgJSON map[string]interface{}) ([]checkManifest, bool, error) {
 	ws, err := workspace.Detect(cwd)
 	if err != nil {
-		return nil, fmt.Errorf("failed to detect workspace: %w", err)
+		return nil, false, fmt.Errorf("cannot resolve the workspace for %s: %w", cwd, err)
 	}
 	if ws == nil {
-		return []checkManifest{{pkgJSON: cwdPkgJSON}}, nil
+		return []checkManifest{{pkgJSON: cwdPkgJSON}}, false, nil
 	}
 
 	packages, err := ws.ListPackages()
 	if err != nil {
-		return nil, fmt.Errorf("failed to list workspace packages: %w", err)
+		return nil, false, fmt.Errorf("cannot resolve the workspace at %s: %w", ws.Root, err)
 	}
 
 	// The current directory's manifest is already read and parsed; the rest are
@@ -162,12 +174,12 @@ func checkManifests(cwd string, cwdPkgJSON map[string]interface{}) ([]checkManif
 		manifestPath := filepath.Join(pkg.Path, "package.json")
 		data, err := os.ReadFile(manifestPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read workspace package %s: %w", manifestPath, err)
+			return nil, false, fmt.Errorf("failed to read %s: %w", manifestPath, err)
 		}
 
 		var pkgJSON map[string]interface{}
 		if err := json.Unmarshal(data, &pkgJSON); err != nil {
-			return nil, fmt.Errorf("failed to parse workspace package %s: %w", manifestPath, err)
+			return nil, false, fmt.Errorf("failed to parse %s: %w", manifestPath, err)
 		}
 
 		name := pkg.Name
@@ -180,14 +192,13 @@ func checkManifests(cwd string, cwdPkgJSON map[string]interface{}) ([]checkManif
 		})
 	}
 
-	return manifests, nil
+	return manifests, true, nil
 }
 
 // manifestLabel names a manifest in check's report. The package name is what a
 // reader can act on, and a manifest without one - a private workspace root
 // often has neither name nor version - falls back to its path relative to the
-// workspace root. The label is never empty, because an empty one is what tells
-// the report it is not looking at a workspace at all.
+// workspace root.
 func manifestLabel(name, root, path string) string {
 	if name != "" {
 		return name
@@ -210,9 +221,13 @@ func nameField(pkgJSON map[string]interface{}) string {
 // spellings of one directory compare equal. The working directory and a
 // workspace member path reach this function by different routes, and on Windows
 // a cwd can come back as an 8.3 short name while the member path is spelled
-// long; EvalSymlinks reconciles both, and also the case of each component. A
-// path it cannot resolve falls back to Clean, which at worst scans a manifest
-// twice rather than reporting a false difference.
+// long; EvalSymlinks reconciles both, and also the case of each component.
+//
+// Every path reaching here exists - the current directory was just read, and
+// expandGlobs kept only directories holding a package.json - so EvalSymlinks
+// resolves it, macOS /var to /private/var included, and the Clean fallback is
+// for a directory removed underneath us. A missed match there costs a manifest
+// scanned twice, never a wrong verdict.
 func canonicalPath(path string) string {
 	if resolved, err := filepath.EvalSymlinks(path); err == nil {
 		return resolved

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -370,6 +370,9 @@ package.json, left behind by 'lnpm add'; and lnpm.lock.retreat, the snapshot
 'lnpm retreat' leaves for 'lnpm restore', when neither the package.json "files"
 field nor .npmignore nor .gitignore would keep it out.
 
+In a workspace, the reference scan covers every workspace package's
+package.json as well as this one, and names the package each finding came from.
+
 Exits non-zero if anything is found, so it can be used as a pre-publish guard
 in scripts or CI before running 'npm publish'.
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -370,8 +370,10 @@ package.json, left behind by 'lnpm add'; and lnpm.lock.retreat, the snapshot
 'lnpm retreat' leaves for 'lnpm restore', when neither the package.json "files"
 field nor .npmignore nor .gitignore would keep it out.
 
-In a workspace, the reference scan covers every workspace package's
-package.json as well as this one, and names the package each finding came from.
+In a workspace, the reference scan covers the workspace root's package.json and
+every member's as well as this one, and names the package each finding came
+from. A workspace whose member list will not resolve fails the check rather
+than passing on the manifest here alone.
 
 Exits non-zero if anything is found, so it can be used as a pre-publish guard
 in scripts or CI before running 'npm publish'.

--- a/tests/check_test.go
+++ b/tests/check_test.go
@@ -203,19 +203,19 @@ func TestCheckPassesWhenTheSnapshotCannotBePublished(t *testing.T) {
 // package.json per member, and returns the root directory. rootPkgJSON is the
 // root manifest verbatim, so a test can give it a broken "workspaces" field;
 // members maps a root-relative directory to the manifest to write there.
-func monorepo(env *TestEnvironment, rootPkgJSON map[string]interface{}, members map[string]map[string]interface{}) string {
-	env.t.Helper()
+func monorepo(t *testing.T, env *TestEnvironment, rootPkgJSON map[string]interface{}, members map[string]map[string]interface{}) string {
+	t.Helper()
 
 	root := filepath.Join(env.TempDir, "monorepo")
 	if err := os.MkdirAll(root, 0755); err != nil {
-		env.t.Fatalf("Failed to create workspace root: %v", err)
+		t.Fatalf("Failed to create workspace root: %v", err)
 	}
 	env.writePackageJSON(root, rootPkgJSON)
 
 	for rel, manifest := range members {
 		dir := filepath.Join(root, filepath.FromSlash(rel))
 		if err := os.MkdirAll(dir, 0755); err != nil {
-			env.t.Fatalf("Failed to create workspace member %s: %v", rel, err)
+			t.Fatalf("Failed to create workspace member %s: %v", rel, err)
 		}
 		env.writePackageJSON(dir, manifest)
 	}
@@ -229,7 +229,7 @@ func monorepo(env *TestEnvironment, rootPkgJSON map[string]interface{}, members 
 func TestCheckFindsAWorkspaceMemberReference(t *testing.T) {
 	env := setupTest(t)
 
-	root := monorepo(env, map[string]interface{}{
+	root := monorepo(t, env, map[string]interface{}{
 		"name":       "monorepo-root",
 		"version":    "1.0.0",
 		"private":    true,
@@ -275,7 +275,7 @@ func TestCheckFindsAWorkspaceMemberReference(t *testing.T) {
 func TestCheckFindsAWorkspaceMemberLinkReference(t *testing.T) {
 	env := setupTest(t)
 
-	root := monorepo(env, map[string]interface{}{
+	root := monorepo(t, env, map[string]interface{}{
 		"name":       "monorepo-root",
 		"version":    "1.0.0",
 		"workspaces": []interface{}{"packages/*"},
@@ -305,7 +305,7 @@ func TestCheckFindsAWorkspaceMemberLinkReference(t *testing.T) {
 func TestCheckPassesOnACleanWorkspace(t *testing.T) {
 	env := setupTest(t)
 
-	root := monorepo(env, map[string]interface{}{
+	root := monorepo(t, env, map[string]interface{}{
 		"name":       "monorepo-root",
 		"version":    "1.0.0",
 		"workspaces": []interface{}{"packages/*"},
@@ -336,14 +336,14 @@ func TestCheckPassesOnACleanWorkspace(t *testing.T) {
 func TestCheckWorkspaceReportsAnUnresolvableMemberList(t *testing.T) {
 	cases := []struct {
 		name  string
-		setup func(env *TestEnvironment) string
+		setup func(t *testing.T, env *TestEnvironment) string
 		want  string
 	}{
 		{
 			// ListPackages fails on a member whose manifest will not parse.
 			name: "a member manifest that will not parse",
-			setup: func(env *TestEnvironment) string {
-				root := monorepo(env, map[string]interface{}{
+			setup: func(t *testing.T, env *TestEnvironment) string {
+				root := monorepo(t, env, map[string]interface{}{
 					"name":       "monorepo-root",
 					"version":    "1.0.0",
 					"workspaces": []interface{}{"packages/*"},
@@ -358,8 +358,8 @@ func TestCheckWorkspaceReportsAnUnresolvableMemberList(t *testing.T) {
 		{
 			// Detect itself fails on a malformed workspace glob.
 			name: "a workspace pattern that will not parse",
-			setup: func(env *TestEnvironment) string {
-				return monorepo(env, map[string]interface{}{
+			setup: func(t *testing.T, env *TestEnvironment) string {
+				return monorepo(t, env, map[string]interface{}{
 					"name":       "monorepo-root",
 					"version":    "1.0.0",
 					"workspaces": []interface{}{"packages/["},
@@ -367,12 +367,31 @@ func TestCheckWorkspaceReportsAnUnresolvableMemberList(t *testing.T) {
 			},
 			want: "packages/[",
 		},
+		{
+			// ListPackages fails a member with no name, so check fails with it.
+			// A nameless member is broken for `lnpm publish --all` and for a
+			// single publish that resolves workspace: dependencies, and check
+			// has no way to tell it apart from a member whose manifest it
+			// cannot trust. The error has to name the manifest to be
+			// actionable, since the whole point is that it has no name.
+			name: "a member with no name",
+			setup: func(t *testing.T, env *TestEnvironment) string {
+				return monorepo(t, env, map[string]interface{}{
+					"name":       "monorepo-root",
+					"version":    "1.0.0",
+					"workspaces": []interface{}{"packages/*"},
+				}, map[string]map[string]interface{}{
+					"packages/nameless": {"version": "1.0.0"},
+				})
+			},
+			want: filepath.Join("packages", "nameless", "package.json"),
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			env := setupTest(t)
-			root := tc.setup(env)
+			root := tc.setup(t, env)
 			env.chdir(root)
 
 			var err error
@@ -387,6 +406,85 @@ func TestCheckWorkspaceReportsAnUnresolvableMemberList(t *testing.T) {
 				t.Errorf("Expected no success report when the workspace cannot be resolved, got:\n%s", out)
 			}
 		})
+	}
+}
+
+// TestCheckCountsManifestsNotWorkspacePackages pins the wording of a workspace
+// report whose only findings are in the root manifest. The root is one of the
+// manifests scanned and is not a workspace package, so a count of "workspace
+// package(s)" would be wrong; the count is of package.json files. The root here
+// is private and nameless, which also pins the path-relative label fallback.
+func TestCheckCountsManifestsNotWorkspacePackages(t *testing.T) {
+	env := setupTest(t)
+
+	root := monorepo(t, env, map[string]interface{}{
+		"private":    true,
+		"workspaces": []interface{}{"packages/*"},
+		"devDependencies": map[string]interface{}{
+			"my-tool": "file:.lnpm/my-tool",
+		},
+	}, map[string]map[string]interface{}{
+		"packages/app": {"name": "@mono/app", "version": "1.0.0"},
+	})
+	env.chdir(root)
+
+	var err error
+	out := captureStdout(t, func() { err = cli.RunCheck() })
+	if err == nil {
+		t.Fatal("Expected check to fail on the root manifest's lnpm reference, got nil")
+	}
+	if !strings.Contains(out, "in 1 package.json file(s)") {
+		t.Errorf("Expected the report to count package.json files, got:\n%s", out)
+	}
+	if strings.Contains(out, "workspace package(s)") {
+		t.Errorf("Expected the root not to be counted as a workspace package, got:\n%s", out)
+	}
+	if !strings.Contains(out, "workspace root: devDependencies.my-tool") {
+		t.Errorf("Expected the nameless root to be labelled by position, got:\n%s", out)
+	}
+}
+
+// TestCheckFailsBelowAWorkspaceItCannotResolve pins a deliberate decision. A
+// project with no workspace of its own, nested under an ancestor whose
+// workspaces field carries a malformed pattern, fails the check instead of
+// printing the ordinary report.
+//
+// The alternative was to treat a broken ancestor config as "no workspace here"
+// and check the project alone. That is the silent fallback AC 5 exists to
+// remove, one level up: whether this project is a member of that workspace is
+// exactly what the unparseable pattern makes unknowable, and answering
+// "not a member" is a guess. Every other caller of workspace.Detect already
+// aborts on a malformed pattern - docs/adr/0001 requires it - so check erring
+// here keeps it consistent with publish rather than singular. The error names
+// the pattern, so the fix is one edit away.
+func TestCheckFailsBelowAWorkspaceItCannotResolve(t *testing.T) {
+	env := setupTest(t)
+
+	root := monorepo(t, env, map[string]interface{}{
+		"name":       "monorepo-root",
+		"version":    "1.0.0",
+		"workspaces": []interface{}{"packages/["},
+	}, map[string]map[string]interface{}{
+		"nested/project": {
+			"name":    "nested-project",
+			"version": "1.0.0",
+			"dependencies": map[string]interface{}{
+				"left-pad": "^1.0.0",
+			},
+		},
+	})
+	env.chdir(filepath.Join(root, "nested", "project"))
+
+	var err error
+	out := captureStdout(t, func() { err = cli.RunCheck() })
+	if err == nil {
+		t.Fatalf("Expected check to fail below a workspace it cannot resolve, got nil (stdout:\n%s)", out)
+	}
+	if !strings.Contains(err.Error(), "packages/[") {
+		t.Errorf("Expected the error to name the malformed pattern, got: %v", err)
+	}
+	if strings.Contains(out, "Nothing lnpm left behind") {
+		t.Errorf("Expected no success report, got:\n%s", out)
 	}
 }
 

--- a/tests/check_test.go
+++ b/tests/check_test.go
@@ -198,3 +198,255 @@ func TestCheckPassesWhenTheSnapshotCannotBePublished(t *testing.T) {
 		})
 	}
 }
+
+// monorepo writes a workspace root under the test's temp dir, with one
+// package.json per member, and returns the root directory. rootPkgJSON is the
+// root manifest verbatim, so a test can give it a broken "workspaces" field;
+// members maps a root-relative directory to the manifest to write there.
+func monorepo(env *TestEnvironment, rootPkgJSON map[string]interface{}, members map[string]map[string]interface{}) string {
+	env.t.Helper()
+
+	root := filepath.Join(env.TempDir, "monorepo")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		env.t.Fatalf("Failed to create workspace root: %v", err)
+	}
+	env.writePackageJSON(root, rootPkgJSON)
+
+	for rel, manifest := range members {
+		dir := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			env.t.Fatalf("Failed to create workspace member %s: %v", rel, err)
+		}
+		env.writePackageJSON(dir, manifest)
+	}
+
+	return root
+}
+
+// TestCheckFindsAWorkspaceMemberReference is the issue's core case: the root
+// manifest is clean, so the guard used to pass from the repo root while a member
+// still carried a file:.lnpm/ reference that an npm publish would ship.
+func TestCheckFindsAWorkspaceMemberReference(t *testing.T) {
+	env := setupTest(t)
+
+	root := monorepo(env, map[string]interface{}{
+		"name":       "monorepo-root",
+		"version":    "1.0.0",
+		"private":    true,
+		"workspaces": []interface{}{"packages/*"},
+	}, map[string]map[string]interface{}{
+		"packages/app": {
+			"name":    "@mono/app",
+			"version": "1.0.0",
+			"dependencies": map[string]interface{}{
+				"my-lib": "file:.lnpm/my-lib",
+			},
+		},
+		"packages/clean": {
+			"name":    "@mono/clean",
+			"version": "1.0.0",
+			"dependencies": map[string]interface{}{
+				"left-pad": "^1.0.0",
+			},
+		},
+	})
+	env.chdir(root)
+
+	var err error
+	out := captureStdout(t, func() { err = cli.RunCheck() })
+	if err == nil {
+		t.Fatal("Expected check to fail on a workspace member's lnpm reference, got nil")
+	}
+	// AC 4: the report has to say which package, or a monorepo result sends the
+	// reader hunting through every manifest by hand.
+	if !strings.Contains(out, "@mono/app") {
+		t.Errorf("Expected the report to name the offending package, got:\n%s", out)
+	}
+	if !strings.Contains(out, "file:.lnpm/my-lib") {
+		t.Errorf("Expected the report to show the reference, got:\n%s", out)
+	}
+	if strings.Contains(out, "@mono/clean") {
+		t.Errorf("Expected the clean member to stay out of the report, got:\n%s", out)
+	}
+}
+
+// TestCheckFindsAWorkspaceMemberLinkReference covers the link: half of the same
+// case through the shared reference helper.
+func TestCheckFindsAWorkspaceMemberLinkReference(t *testing.T) {
+	env := setupTest(t)
+
+	root := monorepo(env, map[string]interface{}{
+		"name":       "monorepo-root",
+		"version":    "1.0.0",
+		"workspaces": []interface{}{"packages/*"},
+	}, map[string]map[string]interface{}{
+		"packages/app": {
+			"name":    "@mono/app",
+			"version": "1.0.0",
+			"devDependencies": map[string]interface{}{
+				"my-lib": "link:.lnpm/my-lib",
+			},
+		},
+	})
+	env.chdir(root)
+
+	var err error
+	out := captureStdout(t, func() { err = cli.RunCheck() })
+	if err == nil {
+		t.Fatal("Expected check to fail on a workspace member's link:.lnpm/ reference, got nil")
+	}
+	if !strings.Contains(out, "@mono/app") || !strings.Contains(out, "link:.lnpm/my-lib") {
+		t.Errorf("Expected the report to name the package and the reference, got:\n%s", out)
+	}
+}
+
+// TestCheckPassesOnACleanWorkspace keeps the widened scan from becoming a false
+// alarm: a workspace with nothing lnpm left behind still exits zero.
+func TestCheckPassesOnACleanWorkspace(t *testing.T) {
+	env := setupTest(t)
+
+	root := monorepo(env, map[string]interface{}{
+		"name":       "monorepo-root",
+		"version":    "1.0.0",
+		"workspaces": []interface{}{"packages/*"},
+	}, map[string]map[string]interface{}{
+		"packages/app": {
+			"name":    "@mono/app",
+			"version": "1.0.0",
+			"dependencies": map[string]interface{}{
+				"@mono/lib": "workspace:*",
+				"left-pad":  "^1.0.0",
+			},
+		},
+		"packages/lib": {
+			"name":    "@mono/lib",
+			"version": "1.0.0",
+		},
+	})
+	env.chdir(root)
+
+	if err := cli.RunCheck(); err != nil {
+		t.Fatalf("Expected check to pass on a clean workspace, got: %v", err)
+	}
+}
+
+// TestCheckWorkspaceReportsAnUnresolvableMemberList is AC 5. Silently checking
+// only the root when the member list will not resolve is the exact failure this
+// widening exists to remove, so an unresolvable workspace has to be loud.
+func TestCheckWorkspaceReportsAnUnresolvableMemberList(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(env *TestEnvironment) string
+		want  string
+	}{
+		{
+			// ListPackages fails on a member whose manifest will not parse.
+			name: "a member manifest that will not parse",
+			setup: func(env *TestEnvironment) string {
+				root := monorepo(env, map[string]interface{}{
+					"name":       "monorepo-root",
+					"version":    "1.0.0",
+					"workspaces": []interface{}{"packages/*"},
+				}, map[string]map[string]interface{}{
+					"packages/app": {"name": "@mono/app", "version": "1.0.0"},
+				})
+				env.writeFile(filepath.Join(root, "packages", "app", "package.json"), "{ not json")
+				return root
+			},
+			want: "app",
+		},
+		{
+			// Detect itself fails on a malformed workspace glob.
+			name: "a workspace pattern that will not parse",
+			setup: func(env *TestEnvironment) string {
+				return monorepo(env, map[string]interface{}{
+					"name":       "monorepo-root",
+					"version":    "1.0.0",
+					"workspaces": []interface{}{"packages/["},
+				}, nil)
+			},
+			want: "packages/[",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupTest(t)
+			root := tc.setup(env)
+			env.chdir(root)
+
+			var err error
+			out := captureStdout(t, func() { err = cli.RunCheck() })
+			if err == nil {
+				t.Fatalf("Expected check to fail when the workspace cannot be resolved, got nil (stdout:\n%s)", out)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("Expected the error to point at %q, got: %v", tc.want, err)
+			}
+			if strings.Contains(out, "Nothing lnpm left behind") {
+				t.Errorf("Expected no success report when the workspace cannot be resolved, got:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestCheckOutsideAWorkspacePrintsExactlyWhatItAlwaysHas is AC 3, and it is the
+// assertion most easily broken by widening the scan: outside a workspace the
+// report stays byte-for-byte what it is today, not merely the same exit code.
+// captureStdout redirects stdout to a pipe, so the icons render as their
+// plain-ASCII fallbacks and the expected text is stable.
+func TestCheckOutsideAWorkspacePrintsExactlyWhatItAlwaysHas(t *testing.T) {
+	t.Run("the failing case", func(t *testing.T) {
+		env := setupTest(t)
+
+		projectDir := env.CreateTestPackage("byte-for-byte-dirty", "1.0.0", nil)
+		env.writePackageJSON(projectDir, map[string]interface{}{
+			"name":    "byte-for-byte-dirty",
+			"version": "1.0.0",
+			"dependencies": map[string]interface{}{
+				"my-lib": "file:.lnpm/my-lib",
+			},
+		})
+		env.chdir(projectDir)
+
+		var err error
+		out := captureStdout(t, func() { err = cli.RunCheck() })
+
+		want := "x Found 1 lnpm reference(s) in package.json:\n" +
+			"  dependencies.my-lib -> file:.lnpm/my-lib\n" +
+			"\n" +
+			"  tip: Run 'lnpm retreat --force' to restore original dependencies before publishing\n"
+		if out != want {
+			t.Errorf("Report changed outside a workspace.\n got: %q\nwant: %q", out, want)
+		}
+		if err == nil {
+			t.Fatal("Expected check to fail, got nil")
+		}
+		if got, want := err.Error(), "1 lnpm reference(s) found in package.json"; got != want {
+			t.Errorf("Error message changed outside a workspace.\n got: %q\nwant: %q", got, want)
+		}
+	})
+
+	t.Run("the passing case", func(t *testing.T) {
+		env := setupTest(t)
+
+		projectDir := env.CreateTestPackage("byte-for-byte-clean", "1.0.0", nil)
+		env.writePackageJSON(projectDir, map[string]interface{}{
+			"name":    "byte-for-byte-clean",
+			"version": "1.0.0",
+			"dependencies": map[string]interface{}{
+				"left-pad": "^1.0.0",
+			},
+		})
+		env.chdir(projectDir)
+
+		var err error
+		out := captureStdout(t, func() { err = cli.RunCheck() })
+		if err != nil {
+			t.Fatalf("Expected check to pass, got: %v", err)
+		}
+		if want := "OK Nothing lnpm left behind would be published\n"; out != want {
+			t.Errorf("Report changed outside a workspace.\n got: %q\nwant: %q", out, want)
+		}
+	})
+}


### PR DESCRIPTION
Closes #211

`RunCheck` read `package.json` from the working directory only. In a monorepo,
running `lnpm check` from the root inspected the root manifest — usually free of
interesting dependencies — reported success, and missed a workspace member still
carrying `file:.lnpm/<pkg>`. The guard passed exactly when it should fail, and it
is wired into pre-commit hooks and CI precisely so people can stop checking by
hand.

## The change

`checkManifests` calls `workspace.Detect` and `ws.ListPackages` — no re-globbing,
no re-parsing of workspace config — and returns the cwd manifest plus the
workspace root's and every member's, deduped. Recognition still goes through
`isLnpmReference`; the four dependency fields are untouched. Only the number of
manifests they are applied to changed.

Findings in a workspace are prefixed with the package they came from:

```
  @mono/app: dependencies.my-lib -> file:.lnpm/my-lib
```

Outside a workspace the output is byte-for-byte what it was, pinned by a test
that asserts exact stdout for both the passing and the failing case.

## Two behaviour decisions, made deliberately

**A project below an ancestor with a malformed workspace glob now errors.**
`Detect` walks to `/` and propagates `doublestar.ErrBadPattern`. A malformed
pattern is exactly what makes membership *unknowable*, so answering "not a
member, check only here" would be a guess — AC 5's silent fallback one level up.
Every other `Detect` caller (`publishAll`, `pack.indexWorkspace`) already
propagates it, so narrowing would make `check` the one command that swallows it.
The error names the offending pattern.

**A member manifest with no `name` now fails the check.** It already hard-fails
`lnpm publish --all` through this same `ListPackages` contract. Making `check`
the one caller that tolerates it would mean `check` passes on a workspace
`publish` refuses — the wrong way round for a pre-publish guard. The error names
the offending manifest path.

Both are pinned by tests whose comments record the reasoning and the rejected
alternative.

## Known limitation — AC 5 is partially met, and #288 closes the gap

`workspace.Detect` returns `(nil, nil)` for a malformed `pnpm-workspace.yaml`
and for a `"workspaces"` field of the wrong type: it only propagates
`ErrBadPattern` and swallows the rest. For those two shapes there is no workspace
for `check` to be loud about, so it scans the cwd manifest only and can still
report success.

This was verified independently by a reviewer against
`internal/workspace/workspace.go` rather than taken on trust. It is **#288**, and
fixing it there closes this gap with no change to `check`. Working around it here
would mean duplicating detection, which the issue puts out of scope.

## Verification

`go test ./...`, the symlinked-`TMPDIR` suite, `go vet`, `golangci-lint` v2.12.2
(0 issues), `gofmt`, and Windows/darwin cross-compile and test-compile are all
clean. Every new test was revert-checked against `main`; the ones that also pass
against the first commit are decision pins and are labelled as such rather than
presented as new coverage.