### PR TITLE
fix(link): refuse to link through a symlinked .lnpm or scope directory

### DIFF
--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -355,7 +355,7 @@ func reapTempDirs(database *db.DB, s *store.Store, projectPaths []string, dryRun
 	}
 
 	if unreadable > 0 {
-		fmt.Printf("%s Could not scan %d director(ies) for temp directories; re-run gc once they are readable\n", iconWarn(), unreadable)
+		fmt.Printf("%s Could not scan %d director(ies) for temp directories; check them and re-run gc\n", iconWarn(), unreadable)
 	}
 
 	if len(found) == 0 {

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -102,6 +102,11 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	if err := pack.ValidatePackageName(packageName); err != nil {
 		return Result{}, err
 	}
+	// Before the reuse scan below, which reads .lnpm/{package} long before
+	// anything creates it: reading through a redirected path is part of the bug.
+	if err := l.checkLnpmDirs(packageName); err != nil {
+		return Result{}, err
+	}
 
 	// The manifest's name is reserved before anything else reads the file set,
 	// so nothing below has to consider a package's file competing for it.
@@ -417,6 +422,9 @@ func (l *Linker) LinkSource(packageName string, sourcePath string) (LinkType, er
 	if err := pack.ValidatePackageName(packageName); err != nil {
 		return "", err
 	}
+	if err := l.checkLnpmDirs(packageName); err != nil {
+		return "", err
+	}
 
 	// An empty source path is rejected before it is resolved, because
 	// filepath.Abs("") returns the working directory and a working directory
@@ -504,6 +512,9 @@ func (l *Linker) Unlink(packageName string) error {
 	if err := pack.ValidatePackageName(packageName); err != nil {
 		return err
 	}
+	if err := l.checkLnpmDirs(packageName); err != nil {
+		return err
+	}
 
 	// Remove .lnpm/{package}
 	lnpmPath := filepath.Join(l.projectPath, ".lnpm", packageName)
@@ -529,6 +540,48 @@ func (l *Linker) Unlink(packageName string) error {
 	removeDirIfEmpty(filepath.Join(l.projectPath, ".lnpm"))
 
 	return nil
+}
+
+// checkLnpmDirs refuses to work through a .lnpm - or, for a scoped package, a
+// .lnpm/{scope} - that is not a real directory in the project.
+//
+// pack.ValidatePackageName guards the segments the package name contributes, but
+// nothing guarded their ancestors, and a repository can commit .lnpm itself as a
+// symlink at any directory it likes. .gitignore does not save anyone from that:
+// a tracked symlink is checked out regardless. Every path the linker builds
+// under it then lands wherever it points, so a link writes outside the project
+// and an unlink deletes outside it.
+//
+// Lstat, not Stat, is the whole point: the entry itself has to be visible rather
+// than what it resolves to. The mode bits accepted are IsLiveLinked's, for the
+// reason its comment gives - a Windows junction reads as ModeIrregular rather
+// than ModeSymlink, and junctions are what createDirSymlink falls back to.
+//
+// A missing .lnpm is not an error: both directories are created on demand, and
+// only an entry that already exists and is not a directory is refused. Nothing
+// above the project is examined, so a project legitimately reached through a
+// symlinked parent is left alone.
+func (l *Linker) checkLnpmDirs(packageName string) error {
+	lnpmDir := filepath.Join(l.projectPath, ".lnpm")
+	if isDirLink(lnpmDir) {
+		return fmt.Errorf("refusing to use %s: it is a link, not a real directory inside the project - this checkout replaced .lnpm with a link, and using it would read and write outside the project", lnpmDir)
+	}
+
+	if scope, _, scoped := strings.Cut(packageName, "/"); scoped {
+		scopeDir := filepath.Join(lnpmDir, scope)
+		if isDirLink(scopeDir) {
+			return fmt.Errorf("refusing to use %s: the scope directory is a link, not a real directory inside the project - this checkout replaced it with a link, and using it would read and write outside the project", scopeDir)
+		}
+	}
+
+	return nil
+}
+
+// isDirLink reports whether path exists and carries a link mode bit: a symlink
+// on any platform, or a Windows junction. A path that does not exist is not one.
+func isDirLink(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode()&(os.ModeSymlink|os.ModeIrregular) != 0
 }
 
 // removeDirIfEmpty removes dir when it holds no entries at all.

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -104,7 +104,7 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	}
 	// Before the reuse scan below, which reads .lnpm/{package} long before
 	// anything creates it: reading through a redirected path is part of the bug.
-	if err := l.refuseLinkedLnpmDirs(packageName); err != nil {
+	if err := l.requireRealLnpmDirs(packageName); err != nil {
 		return Result{}, err
 	}
 
@@ -422,7 +422,7 @@ func (l *Linker) LinkSource(packageName string, sourcePath string) (LinkType, er
 	if err := pack.ValidatePackageName(packageName); err != nil {
 		return "", err
 	}
-	if err := l.refuseLinkedLnpmDirs(packageName); err != nil {
+	if err := l.requireRealLnpmDirs(packageName); err != nil {
 		return "", err
 	}
 
@@ -512,7 +512,7 @@ func (l *Linker) Unlink(packageName string) error {
 	if err := pack.ValidatePackageName(packageName); err != nil {
 		return err
 	}
-	if err := l.refuseLinkedLnpmDirs(packageName); err != nil {
+	if err := l.requireRealLnpmDirs(packageName); err != nil {
 		return err
 	}
 
@@ -542,8 +542,8 @@ func (l *Linker) Unlink(packageName string) error {
 	return nil
 }
 
-// refuseLinkedLnpmDirs refuses to work through a .lnpm - or, for a scoped
-// package, a .lnpm/{scope} - that is a link rather than a directory in the
+// requireRealLnpmDirs refuses to work through a .lnpm - or, for a scoped
+// package, a .lnpm/{scope} - that is anything other than a directory in the
 // project.
 //
 // pack.ValidatePackageName guards the segments the package name contributes, but
@@ -556,43 +556,59 @@ func (l *Linker) Unlink(packageName string) error {
 // Only the two entries the project owns are examined. Nothing above the project
 // is, so a project legitimately reached through a symlinked parent is left
 // alone.
-func (l *Linker) refuseLinkedLnpmDirs(packageName string) error {
+func (l *Linker) requireRealLnpmDirs(packageName string) error {
 	lnpmDir := filepath.Join(l.projectPath, ".lnpm")
-	if err := refuseLinkedDir(".lnpm directory", lnpmDir); err != nil {
+	if err := requireRealDir("project's .lnpm", lnpmDir); err != nil {
 		return err
 	}
 
 	if scope, _, scoped := strings.Cut(packageName, "/"); scoped {
-		return refuseLinkedDir("scope directory", filepath.Join(lnpmDir, scope))
+		return requireRealDir("package scope", filepath.Join(lnpmDir, scope))
 	}
 
 	return nil
 }
 
-// refuseLinkedDir returns an error unless path is a directory the caller may
+// requireRealDir returns an error unless path is a directory the caller may
 // safely build under: one that is really there, or not there at all.
 //
-// Lstat, not Stat, is the whole point: the entry itself has to be visible rather
-// than what it resolves to. The mode bits accepted are IsLiveLinked's, for the
-// reason its comment gives - a Windows junction reads as ModeIrregular rather
-// than ModeSymlink, and junctions are what createDirSymlink falls back to.
+// Lstat, then IsDir, is Go's own documented way to see a directory without
+// following a link into whatever it points at - os/types_windows.go names this
+// exact idiom in the comment on fileStat.mode. Asking positively for a directory
+// rather than negatively for link bits is what makes it right on Windows.
+// ModeDir is suppressed only for a name-surrogate reparse tag, which is what a
+// symlink and a junction are, so both still fail IsDir and are still refused.
+// ModeIrregular, however, is set for any *other* reparse tag with no such guard,
+// and a genuine directory carries one whenever it is a OneDrive Files On-Demand
+// placeholder, a ProjFS projection or a container-isolation entry: those read as
+// ModeDir|ModeIrregular and must be allowed, or lnpm refuses to work in a synced
+// folder. Testing the link bits refused them; IsDir does not. The same holds
+// under GODEBUG=winsymlink=0, where modePreGo1_23 returns early with ModeSymlink
+// for both surrogate tags and sets ModeIrregular only when no type bit is set.
+//
+// Everything else that is not a directory - a regular file, a fifo, a device -
+// is refused here too. None of it could have been linked into, and refusing up
+// front names the path and a remedy where MkdirAll's later ENOTDIR names
+// neither.
 //
 // A path that does not exist is not refused: .lnpm and its scope directories are
 // created on demand. Every other Lstat failure is, per docs/adr/0001 - a check
 // that cannot see the entry cannot report it as safe, and treating "I could not
 // look" as "it is fine" is the fail-open direction the ADR asks to be fixed.
-// Nothing is lost by refusing: an entry lnpm cannot Lstat is not one it could
-// have linked into either.
-func refuseLinkedDir(kind, path string) error {
+//
+// IsLiveLinked tests the link bits instead, and deliberately: it asks whether an
+// entry lnpm itself created is a live link, where a positive test for a link is
+// the right question and a directory is the answer it must reject.
+func requireRealDir(kind, path string) error {
 	info, err := os.Lstat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("cannot inspect the %s %s: %w", kind, path, err)
+		return fmt.Errorf("cannot inspect the %s at %s: %w", kind, path, err)
 	}
-	if info.Mode()&(os.ModeSymlink|os.ModeIrregular) != 0 {
-		return fmt.Errorf("the %s %s is a link, not a directory - remove it and re-run", kind, path)
+	if !info.Mode().IsDir() {
+		return fmt.Errorf("the %s at %s is not a directory - remove it and re-run", kind, path)
 	}
 	return nil
 }

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -104,7 +104,7 @@ func (l *Linker) Link(packageName string, storePath string, files []*pack.FileIn
 	}
 	// Before the reuse scan below, which reads .lnpm/{package} long before
 	// anything creates it: reading through a redirected path is part of the bug.
-	if err := l.checkLnpmDirs(packageName); err != nil {
+	if err := l.refuseLinkedLnpmDirs(packageName); err != nil {
 		return Result{}, err
 	}
 
@@ -422,7 +422,7 @@ func (l *Linker) LinkSource(packageName string, sourcePath string) (LinkType, er
 	if err := pack.ValidatePackageName(packageName); err != nil {
 		return "", err
 	}
-	if err := l.checkLnpmDirs(packageName); err != nil {
+	if err := l.refuseLinkedLnpmDirs(packageName); err != nil {
 		return "", err
 	}
 
@@ -512,7 +512,7 @@ func (l *Linker) Unlink(packageName string) error {
 	if err := pack.ValidatePackageName(packageName); err != nil {
 		return err
 	}
-	if err := l.checkLnpmDirs(packageName); err != nil {
+	if err := l.refuseLinkedLnpmDirs(packageName); err != nil {
 		return err
 	}
 
@@ -542,8 +542,9 @@ func (l *Linker) Unlink(packageName string) error {
 	return nil
 }
 
-// checkLnpmDirs refuses to work through a .lnpm - or, for a scoped package, a
-// .lnpm/{scope} - that is not a real directory in the project.
+// refuseLinkedLnpmDirs refuses to work through a .lnpm - or, for a scoped
+// package, a .lnpm/{scope} - that is a link rather than a directory in the
+// project.
 //
 // pack.ValidatePackageName guards the segments the package name contributes, but
 // nothing guarded their ancestors, and a repository can commit .lnpm itself as a
@@ -552,36 +553,48 @@ func (l *Linker) Unlink(packageName string) error {
 // under it then lands wherever it points, so a link writes outside the project
 // and an unlink deletes outside it.
 //
-// Lstat, not Stat, is the whole point: the entry itself has to be visible rather
-// than what it resolves to. The mode bits accepted are IsLiveLinked's, for the
-// reason its comment gives - a Windows junction reads as ModeIrregular rather
-// than ModeSymlink, and junctions are what createDirSymlink falls back to.
-//
-// A missing .lnpm is not an error: both directories are created on demand, and
-// only an entry that already exists and is not a directory is refused. Nothing
-// above the project is examined, so a project legitimately reached through a
-// symlinked parent is left alone.
-func (l *Linker) checkLnpmDirs(packageName string) error {
+// Only the two entries the project owns are examined. Nothing above the project
+// is, so a project legitimately reached through a symlinked parent is left
+// alone.
+func (l *Linker) refuseLinkedLnpmDirs(packageName string) error {
 	lnpmDir := filepath.Join(l.projectPath, ".lnpm")
-	if isDirLink(lnpmDir) {
-		return fmt.Errorf("refusing to use %s: it is a link, not a real directory inside the project - this checkout replaced .lnpm with a link, and using it would read and write outside the project", lnpmDir)
+	if err := refuseLinkedDir(".lnpm directory", lnpmDir); err != nil {
+		return err
 	}
 
 	if scope, _, scoped := strings.Cut(packageName, "/"); scoped {
-		scopeDir := filepath.Join(lnpmDir, scope)
-		if isDirLink(scopeDir) {
-			return fmt.Errorf("refusing to use %s: the scope directory is a link, not a real directory inside the project - this checkout replaced it with a link, and using it would read and write outside the project", scopeDir)
-		}
+		return refuseLinkedDir("scope directory", filepath.Join(lnpmDir, scope))
 	}
 
 	return nil
 }
 
-// isDirLink reports whether path exists and carries a link mode bit: a symlink
-// on any platform, or a Windows junction. A path that does not exist is not one.
-func isDirLink(path string) bool {
+// refuseLinkedDir returns an error unless path is a directory the caller may
+// safely build under: one that is really there, or not there at all.
+//
+// Lstat, not Stat, is the whole point: the entry itself has to be visible rather
+// than what it resolves to. The mode bits accepted are IsLiveLinked's, for the
+// reason its comment gives - a Windows junction reads as ModeIrregular rather
+// than ModeSymlink, and junctions are what createDirSymlink falls back to.
+//
+// A path that does not exist is not refused: .lnpm and its scope directories are
+// created on demand. Every other Lstat failure is, per docs/adr/0001 - a check
+// that cannot see the entry cannot report it as safe, and treating "I could not
+// look" as "it is fine" is the fail-open direction the ADR asks to be fixed.
+// Nothing is lost by refusing: an entry lnpm cannot Lstat is not one it could
+// have linked into either.
+func refuseLinkedDir(kind, path string) error {
 	info, err := os.Lstat(path)
-	return err == nil && info.Mode()&(os.ModeSymlink|os.ModeIrregular) != 0
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("cannot inspect the %s %s: %w", kind, path, err)
+	}
+	if info.Mode()&(os.ModeSymlink|os.ModeIrregular) != 0 {
+		return fmt.Errorf("the %s %s is a link, not a directory - remove it and re-run", kind, path)
+	}
+	return nil
 }
 
 // removeDirIfEmpty removes dir when it holds no entries at all.

--- a/internal/link/link_failure_test.go
+++ b/internal/link/link_failure_test.go
@@ -547,3 +547,148 @@ func TestLinkSourceRejectsTraversingName(t *testing.T) {
 		t.Errorf("a link was created outside the project (Lstat err = %v), want none", err)
 	}
 }
+
+// linkDirAt points linkPath at target the way the linker itself points
+// .lnpm/{package} at a source directory: a symlink where the platform allows
+// one, a junction on Windows where it does not. That is what a hostile checkout
+// gets to commit, and a junction is the case a plain os.ModeSymlink test would
+// miss.
+//
+// Skipping rather than failing when neither can be created keeps the test honest
+// on a Windows runner holding no symlink privilege: the guard is not exercised
+// there, and saying so beats pretending it passed.
+func linkDirAt(t *testing.T, target, linkPath string) {
+	t.Helper()
+	if err := createDirSymlink(target, linkPath); err != nil {
+		t.Skipf("cannot create a directory link at %s: %v", linkPath, err)
+	}
+}
+
+// TestLinkRefusesASymlinkedLnpmDirectory covers the ancestor pack's name
+// validation does not reach. A repository can commit .lnpm as a symlink pointing
+// anywhere - .gitignore does not stop a tracked symlink from being checked out -
+// and every path the linker builds under it then lands outside the project.
+func TestLinkRefusesASymlinkedLnpmDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	outside := filepath.Join(tmpDir, "outside")
+	for _, dir := range []string{projectPath, outside} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	linkDirAt(t, outside, filepath.Join(projectPath, ".lnpm"))
+
+	storePath, files := storeFixture(t, tmpDir, map[string]string{
+		"package.json":  `{"name":"my-package"}`,
+		"dist/index.js": "index contents",
+	})
+
+	_, err := New(projectPath).Link("my-package", storePath, files)
+	if err == nil {
+		t.Fatal("Link() through a symlinked .lnpm error = nil, want a refusal")
+	}
+	if !strings.Contains(err.Error(), ".lnpm") {
+		t.Errorf("Link() error = %v, want it to name .lnpm", err)
+	}
+
+	// The refusal has to be effective, not merely reported: an error raised after
+	// the tree was materialised through the link would leave the same files
+	// outside the project as no check at all.
+	entries, readErr := os.ReadDir(outside)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("the directory outside the project holds %d entries after a refused Link, want it untouched", len(entries))
+	}
+	assertNoSymlink(t, projectPath, "my-package")
+}
+
+// TestLinkSourceRefusesASymlinkedLnpmDirectory is the same hole reached through
+// the live-link path, which writes .lnpm/{package} directly rather than through
+// a temp directory.
+func TestLinkSourceRefusesASymlinkedLnpmDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	sourcePath := filepath.Join(tmpDir, "source")
+	outside := filepath.Join(tmpDir, "outside")
+	for _, dir := range []string{projectPath, sourcePath, outside} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	linkDirAt(t, outside, filepath.Join(projectPath, ".lnpm"))
+
+	_, err := New(projectPath).LinkSource("demo-pkg", sourcePath)
+	if err == nil {
+		t.Fatal("LinkSource() through a symlinked .lnpm error = nil, want a refusal")
+	}
+	if !strings.Contains(err.Error(), ".lnpm") {
+		t.Errorf("LinkSource() error = %v, want it to name .lnpm", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(outside, "demo-pkg")); !os.IsNotExist(err) {
+		t.Errorf("demo-pkg was created outside the project (Lstat err = %v), want none", err)
+	}
+}
+
+// TestUnlinkRefusesASymlinkedLnpmDirectory is the destructive half. Unlink's
+// RemoveAll of .lnpm/{package} follows a symlinked .lnpm, so an attacker who
+// picks the package name picks a directory to delete outside the project.
+func TestUnlinkRefusesASymlinkedLnpmDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	victim := filepath.Join(tmpDir, "victim")
+	documents := filepath.Join(victim, "Documents")
+	for _, dir := range []string{projectPath, documents} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	taxes := filepath.Join(documents, "taxes.txt")
+	if err := os.WriteFile(taxes, []byte("keep me"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	linkDirAt(t, victim, filepath.Join(projectPath, ".lnpm"))
+
+	err := New(projectPath).Unlink("Documents")
+	if err == nil {
+		t.Fatal("Unlink() through a symlinked .lnpm error = nil, want a refusal")
+	}
+	if !strings.Contains(err.Error(), ".lnpm") {
+		t.Errorf("Unlink() error = %v, want it to name .lnpm", err)
+	}
+
+	if got, err := os.ReadFile(taxes); err != nil || string(got) != "keep me" {
+		t.Errorf("victim/Documents/taxes.txt = %q (err %v) after a refused Unlink, want it intact", string(got), err)
+	}
+}
+
+// TestLinkSourceRefusesASymlinkedScopeDirectory covers the second ancestor a
+// scoped name adds. A real .lnpm holding a symlinked @org redirects every scoped
+// package just as completely, one level down.
+func TestLinkSourceRefusesASymlinkedScopeDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	sourcePath := filepath.Join(tmpDir, "source")
+	victim := filepath.Join(tmpDir, "victim")
+	for _, dir := range []string{filepath.Join(projectPath, ".lnpm"), sourcePath, victim} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	linkDirAt(t, victim, filepath.Join(projectPath, ".lnpm", "@org"))
+
+	_, err := New(projectPath).LinkSource("@org/scoped", sourcePath)
+	if err == nil {
+		t.Fatal("LinkSource() through a symlinked scope directory error = nil, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "@org") {
+		t.Errorf("LinkSource() error = %v, want it to name the @org scope directory", err)
+	}
+
+	if _, err := os.Lstat(filepath.Join(victim, "scoped")); !os.IsNotExist(err) {
+		t.Errorf("scoped was created outside the project (Lstat err = %v), want none", err)
+	}
+}

--- a/internal/link/link_failure_test.go
+++ b/internal/link/link_failure_test.go
@@ -693,6 +693,52 @@ func TestLinkSourceRefusesASymlinkedScopeDirectory(t *testing.T) {
 	}
 }
 
+// TestLinkRefusesARegularFileWhereLnpmBelongs covers what asking for a directory
+// catches beyond a link. Everything that is not a directory is refused here
+// rather than three frames later, where the same project produced an ENOTDIR
+// from MkdirAll with no indication of what to do about it.
+//
+// The case this test cannot cover is the opposite one: a real directory
+// carrying a non-surrogate reparse tag - a OneDrive Files On-Demand placeholder,
+// ProjFS, container isolation - which Windows reports as ModeDir|ModeIrregular
+// and which must be allowed. It needs Windows and one of those filesystems, so
+// neither this suite nor a Linux runner can produce it. It is named in
+// requireRealDir's comment, which is where the reasoning belongs.
+func TestLinkRefusesARegularFileWhereLnpmBelongs(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(projectPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	lnpmPath := filepath.Join(projectPath, ".lnpm")
+	if err := os.WriteFile(lnpmPath, []byte("not a directory"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	storePath, files := storeFixture(t, tmpDir, map[string]string{
+		"package.json": `{"name":"my-package"}`,
+	})
+
+	_, err := New(projectPath).Link("my-package", storePath, files)
+	if err == nil {
+		t.Fatal("Link() with a regular file at .lnpm error = nil, want a refusal")
+	}
+	// The remedy is what says this came from the guard rather than from the
+	// MkdirAll further down, whose ENOTDIR also mentions .lnpm and "not a
+	// directory" but tells the user nothing about fixing it.
+	if !strings.Contains(err.Error(), "remove it and re-run") {
+		t.Errorf("Link() error = %v, want the guard's refusal naming a remedy", err)
+	}
+	if !strings.Contains(err.Error(), ".lnpm") {
+		t.Errorf("Link() error = %v, want it to name .lnpm", err)
+	}
+
+	// Refused, not repaired: the guard must not delete what it found.
+	if got, err := os.ReadFile(lnpmPath); err != nil || string(got) != "not a directory" {
+		t.Errorf(".lnpm = %q (err %v) after a refused Link, want it left alone", string(got), err)
+	}
+}
+
 // TestUnlinkRefusesWhenTheLnpmDirectoryCannotBeInspected pins the direction the
 // guard fails in, which is what docs/adr/0001 is about: only "the entry is not
 // there" means there is nothing to refuse. Every other Lstat failure - a

--- a/internal/link/link_failure_test.go
+++ b/internal/link/link_failure_test.go
@@ -27,6 +27,22 @@ func storeFixture(t *testing.T, root string, contents map[string]string) (string
 	return storePath, writeStoreFiles(t, storePath, contents)
 }
 
+// linkDirAt points linkPath at target the way the linker itself points
+// .lnpm/{package} at a source directory: a symlink where the platform allows
+// one, a junction on Windows where it does not. That is what a hostile checkout
+// gets to commit, and a junction is the case a plain os.ModeSymlink test would
+// miss.
+//
+// Skipping rather than failing when neither can be created keeps the test honest
+// on a Windows runner holding no symlink privilege: the guard is not exercised
+// there, and saying so beats pretending it passed.
+func linkDirAt(t *testing.T, target, linkPath string) {
+	t.Helper()
+	if err := createDirSymlink(target, linkPath); err != nil {
+		t.Skipf("cannot create a directory link at %s: %v", linkPath, err)
+	}
+}
+
 func assertNoSymlink(t *testing.T, projectPath, packageName string) {
 	t.Helper()
 	nodeModulesPath := filepath.Join(projectPath, "node_modules", packageName)
@@ -548,22 +564,6 @@ func TestLinkSourceRejectsTraversingName(t *testing.T) {
 	}
 }
 
-// linkDirAt points linkPath at target the way the linker itself points
-// .lnpm/{package} at a source directory: a symlink where the platform allows
-// one, a junction on Windows where it does not. That is what a hostile checkout
-// gets to commit, and a junction is the case a plain os.ModeSymlink test would
-// miss.
-//
-// Skipping rather than failing when neither can be created keeps the test honest
-// on a Windows runner holding no symlink privilege: the guard is not exercised
-// there, and saying so beats pretending it passed.
-func linkDirAt(t *testing.T, target, linkPath string) {
-	t.Helper()
-	if err := createDirSymlink(target, linkPath); err != nil {
-		t.Skipf("cannot create a directory link at %s: %v", linkPath, err)
-	}
-}
-
 // TestLinkRefusesASymlinkedLnpmDirectory covers the ancestor pack's name
 // validation does not reach. A repository can commit .lnpm as a symlink pointing
 // anywhere - .gitignore does not stop a tracked symlink from being checked out -
@@ -690,5 +690,53 @@ func TestLinkSourceRefusesASymlinkedScopeDirectory(t *testing.T) {
 
 	if _, err := os.Lstat(filepath.Join(victim, "scoped")); !os.IsNotExist(err) {
 		t.Errorf("scoped was created outside the project (Lstat err = %v), want none", err)
+	}
+}
+
+// TestUnlinkRefusesWhenTheLnpmDirectoryCannotBeInspected pins the direction the
+// guard fails in, which is what docs/adr/0001 is about: only "the entry is not
+// there" means there is nothing to refuse. Every other Lstat failure - a
+// permission denied on the project directory here, an I/O error or a too-long
+// name elsewhere - leaves the guard unable to tell a real directory from a link,
+// and a guard that cannot tell must not wave the caller through.
+//
+// What this test can prove is bounded, and worth stating: an unsearchable
+// project directory also blocks the RemoveAll that follows, so both the guarded
+// and the unguarded build fail here. The difference it asserts is therefore
+// which failure comes back - the guard refusing and naming the directory it
+// could not inspect, rather than a downstream error from the work it should
+// never have started. Nothing portable makes an Lstat fail while leaving the
+// work that follows able to succeed.
+func TestUnlinkRefusesWhenTheLnpmDirectoryCannotBeInspected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mode 0000 does not deny directory traversal on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: mode 0000 does not deny traversal")
+	}
+
+	tmpDir := t.TempDir()
+	projectPath := filepath.Join(tmpDir, "project")
+	if err := os.MkdirAll(filepath.Join(projectPath, ".lnpm", "my-package"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unsearchable, so Lstat of anything inside it fails with EACCES rather than
+	// with a not-exist error.
+	if err := os.Chmod(projectPath, 0000); err != nil {
+		t.Fatal(err)
+	}
+	// Restore before t.TempDir's cleanup walks the tree.
+	t.Cleanup(func() { _ = os.Chmod(projectPath, 0755) })
+
+	err := New(projectPath).Unlink("my-package")
+	if err == nil {
+		t.Fatal("Unlink() with an uninspectable .lnpm error = nil, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "inspect") {
+		t.Errorf("Unlink() error = %v, want the guard's refusal to inspect .lnpm rather than a downstream failure", err)
+	}
+	if !strings.Contains(err.Error(), ".lnpm") {
+		t.Errorf("Unlink() error = %v, want it to name .lnpm", err)
 	}
 }

--- a/internal/link/reap.go
+++ b/internal/link/reap.go
@@ -49,7 +49,7 @@ type TempEntry struct {
 // A .lnpm directory that does not exist is neither an entry nor a failure: a
 // project may never have linked anything. One that is a link rather than a
 // directory is counted as unreadable and not scanned at all, for the reason
-// refuseLinkedDir gives.
+// requireRealDir gives.
 func FindTempEntries(projectPath string) (entries []TempEntry, unreadable int) {
 	lnpmDir := filepath.Join(projectPath, ".lnpm")
 
@@ -59,7 +59,7 @@ func FindTempEntries(projectPath string) (entries []TempEntry, unreadable int) {
 	// read is the shape this function already has for a directory it must not
 	// act on: nothing is reclaimed here, the count says so, and the remaining
 	// projects are still swept.
-	if err := refuseLinkedDir(".lnpm directory", lnpmDir); err != nil {
+	if err := requireRealDir("project's .lnpm", lnpmDir); err != nil {
 		debug.Logf("link: not scanning %s for temp entries: %v", lnpmDir, err)
 		return nil, 1
 	}

--- a/internal/link/reap.go
+++ b/internal/link/reap.go
@@ -47,9 +47,22 @@ type TempEntry struct {
 // what this sweep exists to fix.
 //
 // A .lnpm directory that does not exist is neither an entry nor a failure: a
-// project may never have linked anything.
+// project may never have linked anything. One that is a link rather than a
+// directory is counted as unreadable and not scanned at all, for the reason
+// refuseLinkedDir gives.
 func FindTempEntries(projectPath string) (entries []TempEntry, unreadable int) {
 	lnpmDir := filepath.Join(projectPath, ".lnpm")
+
+	// ReadDir follows a symlinked .lnpm, so without this the sweep would list -
+	// and gc would then offer to delete - temp entries belonging to whatever a
+	// checkout pointed .lnpm at. Counting it as one directory that could not be
+	// read is the shape this function already has for a directory it must not
+	// act on: nothing is reclaimed here, the count says so, and the remaining
+	// projects are still swept.
+	if err := refuseLinkedDir(".lnpm directory", lnpmDir); err != nil {
+		debug.Logf("link: not scanning %s for temp entries: %v", lnpmDir, err)
+		return nil, 1
+	}
 
 	scopes, err := os.ReadDir(lnpmDir)
 	if err != nil {

--- a/internal/link/reap_test.go
+++ b/internal/link/reap_test.go
@@ -155,6 +155,35 @@ func TestFindTempEntriesWithoutLnpmDir(t *testing.T) {
 	}
 }
 
+// TestFindTempEntriesRefusesASymlinkedLnpmDirectory covers the sweep's half of
+// the same hole the linker's guard closes. os.ReadDir follows a symlinked .lnpm,
+// so a project whose checkout points .lnpm outside itself would have gc list -
+// and then offer to delete - temp entries that belong to whatever it points at.
+//
+// The refusal is reported as one directory the sweep could not read, which is
+// the shape this function already has for a directory it must not act on: gc
+// prints the count, reclaims nothing there, and every other project still gets
+// swept.
+func TestFindTempEntriesRefusesASymlinkedLnpmDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	project := filepath.Join(tmpDir, "project")
+	outside := filepath.Join(tmpDir, "outside")
+	if err := os.MkdirAll(project, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// A temp entry the sweep would happily reclaim if it looked here at all.
+	seedDir(t, filepath.Join(outside, ".tmp-deadbeef"))
+	linkDirAt(t, outside, filepath.Join(project, ".lnpm"))
+
+	entries, unreadable := FindTempEntries(project)
+	if len(entries) != 0 {
+		t.Errorf("FindTempEntries() found %v through a symlinked .lnpm, want nothing outside the project", foundPaths(entries))
+	}
+	if unreadable != 1 {
+		t.Errorf("FindTempEntries() reported %d unreadable director(ies), want 1 for the .lnpm it refused", unreadable)
+	}
+}
+
 // TestFindTempEntriesMatchesWhatTheConstructorsProduce ties the matcher to the
 // names newTempDir actually creates, so a change to one without the other is
 // caught here rather than by a leak nobody sees.


### PR DESCRIPTION
Closes #313.

`pack.ValidatePackageName` guards the segments a package name contributes. Nothing guarded their **ancestors**, so a repository that commits `.lnpm` — or `.lnpm/<scope>` — as a symlink redirected every write and every recursive delete the linker made to wherever it pointed. A *tracked* symlink is checked out regardless of `.gitignore`, so merely checking out a repo was enough.

## Reproduced before any code was written

All three halves, at the package level, against `9a803dd`:

| Half | Result |
| --- | --- |
| Write | `LinkSource("demo-pkg", src)` with `proj/.lnpm -> outside` created `outside/demo-pkg` |
| Delete | `Unlink("Documents")` with `proj/.lnpm -> victim` deleted `victim/Documents/taxes.txt` |
| Scope | `LinkSource("@org/scoped", src)` with `proj/.lnpm/@org -> victim` created `victim/scoped` |

## The fix

`requireRealDir` does `os.Lstat` then `IsDir()`, and `Link`, `LinkSource` and `Unlink` each call it immediately after name validation — before the reuse scan, since reading through a redirected path is part of the same bug. A missing `.lnpm` is still created on demand. Nothing above the project is examined, so a project legitimately reached through a symlinked parent is unaffected.

Three things came out of review rather than the original brief, and each is a separate commit:

- **`72483a5` — fail closed on an uninspectable `.lnpm`.** The first pass swallowed every `Lstat` error and reported "not a link", sending the caller straight through the guard. That is the fail-open direction [ADR-0001](docs/adr/0001-swallowed-errors-that-widen-a-publish-are-bugs.md) asks to be fixed: *"a fail-open path is worth fixing even when it needs a config typo to trigger."* Only `os.IsNotExist` now passes through.
- **`72483a5` — `FindTempEntries` guarded.** `os.ReadDir` follows a symlinked `.lnpm` and `gc` deletes what it returns, so the sweep could list and reclaim entries belonging to whatever a checkout pointed `.lnpm` at. Low exploitability — an attacker picks the target directory but not the `.tmp-<hex>` names inside it — but it is a delete outside the project, and shipping a fix that claims to close those while leaving one is the wrong trade.
- **`db1c4e6` — ask positively for a directory instead of testing link bits.** Testing `ModeSymlink|ModeIrregular` would have **refused genuine directories on Windows**. `os/types_windows.go` guards `ModeDir` with a name-surrogate check, so symlinks and junctions lose it, but it sets `ModeIrregular` for every *other* reparse tag with no such guard — and a real directory carries one whenever it is a OneDrive Files On-Demand placeholder, a ProjFS projection or a container-isolation entry. lnpm would have refused to work in a synced folder. `Lstat` + `IsDir()` is the idiom Go's own comment on `fileStat.mode` names, and it holds under `GODEBUG=winsymlink=0` too. It also refuses a regular file at `.lnpm` up front, naming a remedy, where `MkdirAll`'s `ENOTDIR` named neither.

## Tests

Seven, in `internal/link`. Each asserts the refusal is **effective, not merely reported** — the directory outside the project is checked for absence, and the `Unlink` test places a real file outside and asserts it survives with its contents.

Every test was revert-checked, in more than one direction:

- Guard removed from all three call sites → the four symlink tests fail.
- Guard moved to just before each successful return, i.e. a fix that errors *after* doing the damage → all four still fail, now on the effectiveness assertions rather than the error check.
- Predicate reverted to the link-bit test → only the regular-file test fails, which is the useful signal in both directions: it is the one test that distinguishes the two predicates, and the inversion demonstrably did not weaken symlink or junction coverage.
- `reap.go` guard removed → its test fails on both assertions.

## Known limits, stated rather than buried

- **The Windows cloud-placeholder fix is unverified by execution.** It needs Windows plus OneDrive Files On-Demand, ProjFS or container isolation; Linux cannot produce a `ModeDir|ModeIrregular` entry. It rests on reading both mode functions in Go's source. The reasoning is in `requireRealDir`'s comment so nobody has to rediscover it.
- **The `Lstat`-failure test is a message-shape assertion, not an outcome one.** No portable case exists where `Lstat` fails but the following work would have succeeded — an unsearchable project directory blocks the `RemoveAll` too. Both builds error; the assertion distinguishes them by *which* error.
- **Windows symlink/junction tests skip rather than fail** on a runner that can create neither. CI gets junction coverage through `createDirSymlink`'s `mklink /J` fallback.
- **TOCTOU** between the check and `MkdirAll`/`RemoveAll` is real and out of the stated threat model — a hostile static checkout, not a live local attacker. Closing it needs `openat2`/`O_NOFOLLOW`.

## Deliberately out of scope

`node_modules` and its scope directory (#339 — a symlinked `node_modules` is a legitimate setup, so refusing it is a judgement call `.lnpm` did not need), and the read-only queries `IsLinked`/`IsLiveLinked`/`ListLinked` (#340 — disclosure only, and guarding them means changing `bool` signatures).

`SECURITY.md:27-29` is left alone on purpose: its path-traversal claim stays incomplete until #314 fixes the `retreat` half, and updating it now would make it *more* misleading, not less.

## Gates

`go test ./...`, `go test` under a symlinked `TMPDIR` (the exact regression risk for a symlink guard), `go vet`, `golangci-lint`, `gofmt -l`, and `vet`/`build`/test-compile for windows/amd64, darwin/arm64 and linux/arm64 — all green.