### PR TITLE
fix(retreat): validate lock-file package names before deleting the path

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,11 +28,11 @@ A package name is untrusted input: it comes from a `package.json` or an
 `lnpm.lock` that is checked into the repository, so whoever wrote the repository
 chose it. Against that, lnpm:
 
-- Validates the name before building a path from it, at each boundary that does
-  so — the store, the linker's `Link`/`LinkSource`/`Unlink`, packing, and
-  `retreat`'s pass over `lnpm.lock`. A name that is absolute, holds a `.` or
-  `..` segment, holds a backslash or a NUL, or has more than the one `/` a
-  scope allows, is rejected there.
+- Validates the name before building a path it will **write to or delete**, at
+  each boundary that does so — `Store.Store`, the linker's
+  `Link`/`LinkSource`/`Unlink`, packing, and `retreat`'s pass over `lnpm.lock`.
+  A name that is absolute, holds a `.` or `..` segment, holds a backslash or a
+  NUL, or has more than the one `/` a scope allows, is rejected there.
 - Requires `.lnpm` — and, for a scoped package, `.lnpm/{scope}` — to be a real
   directory, so a repository cannot commit either as a symlink and redirect
   every write and delete underneath it.
@@ -46,9 +46,11 @@ Known limits, which this section deliberately does not claim otherwise about:
 - The checks are not atomic. A path validated as safe can be replaced between
   the check and the use.
 - Entries under `node_modules/` are not guarded the way `.lnpm` is.
-- Read-only lookups — for example the link-status queries `pull` runs — do not
-  validate the name first. They only `Lstat`, so they read rather than write,
-  but they are not covered by the guarantee above.
+- Read paths are not covered. `Store.GetFiles` walks the store path it builds
+  from a name, and the link-status queries `pull` runs only `Lstat` it, and
+  neither validates the name first. They read rather than write, so they cannot
+  destroy anything, but a name chosen by the repository can still steer where
+  they look.
 
 ### Database
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,9 +24,31 @@ lnpm operates within these directories:
 - **Project**: Current working directory and its `.lnpm/` subdirectory
 - **node_modules**: Symlinks created in project's `node_modules/`
 
-Path traversal attacks are mitigated by:
-- Using `filepath.Join()` for all path construction
-- Validating package names don't contain path separators
+A package name is untrusted input: it comes from a `package.json` or an
+`lnpm.lock` that is checked into the repository, so whoever wrote the repository
+chose it. Against that, lnpm:
+
+- Validates the name before building a path from it, at each boundary that does
+  so — the store, the linker's `Link`/`LinkSource`/`Unlink`, packing, and
+  `retreat`'s pass over `lnpm.lock`. A name that is absolute, holds a `.` or
+  `..` segment, holds a backslash or a NUL, or has more than the one `/` a
+  scope allows, is rejected there.
+- Requires `.lnpm` — and, for a scoped package, `.lnpm/{scope}` — to be a real
+  directory, so a repository cannot commit either as a symlink and redirect
+  every write and delete underneath it.
+
+Note that `filepath.Join()` is not itself a defence: it cleans the path it
+builds, so `..` segments in a name survive into the result. The validation
+above is what stops them.
+
+Known limits, which this section deliberately does not claim otherwise about:
+
+- The checks are not atomic. A path validated as safe can be replaced between
+  the check and the use.
+- Entries under `node_modules/` are not guarded the way `.lnpm` is.
+- Read-only lookups — for example the link-status queries `pull` runs — do not
+  validate the name first. They only `Lstat`, so they read rather than write,
+  but they are not covered by the guarantee above.
 
 ### Database
 

--- a/internal/cli/output_tty_linux_test.go
+++ b/internal/cli/output_tty_linux_test.go
@@ -183,15 +183,6 @@ func runRetreatOnTTY(t *testing.T) string {
 	})
 }
 
-// writeFile writes content to path, failing the test if it cannot.
-func writeFile(t *testing.T, path, content string) {
-	t.Helper()
-
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
-}
-
 // captureTTYStdout runs fn with os.Stdout pointed at the slave side of a
 // pseudo-terminal and returns what it printed. A pipe would not do: the icon
 // helpers ask whether stdout is a character device, so only a terminal

--- a/internal/cli/retreat.go
+++ b/internal/cli/retreat.go
@@ -58,7 +58,7 @@ func RunRetreat(force bool, runInstall bool) error {
 				// dependency would describe a retreat that is not going to
 				// happen, at the one moment the developer is reading.
 				if err := pack.ValidatePackageName(name); err != nil {
-					fmt.Printf("    %s %s: not a valid package name, will be skipped (%v)\n", iconWarn(), name, err)
+					fmt.Printf("    %s %s: will be skipped, not a valid package name: %v\n", iconWarn(), name, err)
 					continue
 				}
 
@@ -114,7 +114,7 @@ func RunRetreat(force bool, runInstall bool) error {
 
 	// Remove each linked package
 	linkedPkgs := lock.List()
-	refused := 0
+	var refused []string
 	for _, name := range linkedPkgs {
 		// lnpm.lock is a checked-in artifact, so its keys come from whoever
 		// wrote the repository rather than from lnpm. Everything below joins the
@@ -125,21 +125,21 @@ func RunRetreat(force bool, runInstall bool) error {
 		// does this same job for 'lnpm remove', has always validated first; the
 		// asymmetry was the bug.
 		//
-		// The entry is skipped whole rather than aborting the retreat. Retreat
-		// is the documented way out of lnpm, and a developer who has just been
-		// handed a tampered lock file is exactly the person who needs to leave:
-		// aborting would strand them with .lnpm/ and the file: references still
-		// in place. Skipping narrows what the command does, which is the safe
-		// direction under docs/adr/0001, and the summary below says the retreat
-		// was incomplete so the narrowing is never silent.
+		// The entry is skipped whole rather than aborting the retreat. Per
+		// ADR-0001 the direction is what decides: skipping narrows what this
+		// retreat does and leaves the entry where the user can see it, where
+		// aborting would strand a developer who has just been handed a tampered
+		// lock file with .lnpm/ and every file: reference still in place -
+		// retreat being the documented way out of lnpm, that developer is
+		// exactly the one who needs it to work. The summary below reports the
+		// count, so the narrowing is never silent.
 		//
 		// The refused entry is still carried into lnpm.lock.retreat with the
 		// rest. It is a record, not an instruction, and 'lnpm restore' links
 		// through Link, which validates the name again.
 		if err := pack.ValidatePackageName(name); err != nil {
-			fmt.Printf("  %s Refused %s: not a valid package name, so nothing was removed for it (%v)\n", iconWarn(), name, err)
-			fmt.Printf("  %s lnpm did not write that entry; check lnpm.lock for tampering or corruption\n", iconWarn())
-			refused++
+			fmt.Printf("  %s Refused %s: not a valid package name: %v\n", iconWarn(), name, err)
+			refused = append(refused, name)
 			continue
 		}
 
@@ -220,12 +220,13 @@ func RunRetreat(force bool, runInstall bool) error {
 
 	fmt.Println()
 	// A retreat that refused part of its work is not a complete one, and saying
-	// so is the whole point of counting: package.json may still hold a
-	// file:.lnpm reference for every refused entry.
-	if refused > 0 {
-		fmt.Printf("%s Retreat incomplete: refused %d of %d lnpm.lock entr(ies), see above\n", iconWarn(), refused, len(linkedPkgs))
-	} else {
+	// so is the whole point of counting: package.json still holds a file:.lnpm
+	// reference for every refused entry.
+	if len(refused) == 0 {
 		fmt.Printf("%s Retreat complete!\n", iconOK())
+	} else {
+		fmt.Printf("%s Retreat incomplete: refused %d of %d lnpm.lock entr(ies)\n", iconWarn(), len(refused), len(linkedPkgs))
+		reportRefused(cwd, refused)
 	}
 
 	if !runInstall {
@@ -234,12 +235,47 @@ func RunRetreat(force bool, runInstall bool) error {
 
 	// Non-zero exit, as remove does for the packages it could not remove: a
 	// script that retreats before publishing must not read a partial retreat as
-	// a clean one.
-	if refused > 0 {
-		return fmt.Errorf("%d of %d lnpm.lock entr(ies) were refused as invalid package names", refused, len(linkedPkgs))
+	// a clean one. The wording is deliberately not the summary line's: rootCmd
+	// silences the usage dump but not the error, so cobra prints this straight
+	// after it, and two spellings of one sentence read as a stutter. The summary
+	// counts what was refused; this names what is left.
+	if len(refused) > 0 {
+		return fmt.Errorf("package.json still references %d unretreated lnpm.lock entr(ies)", len(refused))
 	}
 
 	return nil
+}
+
+// reportRefused says what a refusal left behind and what to do about it. It runs
+// after the rest of the retreat, so it can name where things actually ended up
+// rather than where they were when the entry was refused.
+//
+// That ordering is the whole reason this is separate. The retreat carries on
+// past a refusal: .lnpm/ is deleted and lnpm.lock is moved to the snapshot. So a
+// refusal cannot tell the user to go and look at lnpm.lock - by the time they
+// read it, there is no lnpm.lock, and re-running retreat reports no links at
+// all. It has to name the snapshot instead.
+//
+// What is left behind is safe to leave, which is why naming it beats quietly
+// editing package.json under a name lnpm just refused to act on. lnpm never
+// wrote these entries: 'lnpm add' validates the name, so there was never a
+// .lnpm/{name} directory for them and no link to undo. The file: reference and
+// the lock key are both the tampering itself, not damage the retreat did, and
+// removing them is a decision for the person who owns the repository.
+func reportRefused(cwd string, refused []string) {
+	// Where the record went. The snapshot in the ordinary case; lnpm.lock still
+	// in place if stashing failed, which it reports for itself above.
+	record := lockfile.RetreatFileName
+	if _, err := os.Stat(lockfile.Path(cwd)); err == nil {
+		record = "lnpm.lock"
+	}
+
+	fmt.Printf("%s lnpm never wrote those entries, so there was nothing of its own to clean up for them\n", iconWarn())
+	fmt.Printf("%s Left in package.json, to remove by hand:\n", iconWarn())
+	for _, name := range refused {
+		fmt.Printf("    %q\n", name)
+	}
+	fmt.Printf("%s The entries themselves are in %s; inspect it for tampering or corruption\n", iconWarn(), record)
 }
 
 // stashLockForRestore moves lnpm.lock aside rather than deleting it. The move

--- a/internal/cli/retreat.go
+++ b/internal/cli/retreat.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pedrosousa13/lnpm/internal/config"
 	"github.com/pedrosousa13/lnpm/internal/db"
 	"github.com/pedrosousa13/lnpm/internal/gitignore"
+	"github.com/pedrosousa13/lnpm/internal/pack"
 	"github.com/pedrosousa13/lnpm/internal/shellcmd"
 	"github.com/pedrosousa13/lnpm/pkg/lockfile"
 )
@@ -51,6 +52,16 @@ func RunRetreat(force bool, runInstall bool) error {
 		if len(linkedPkgs) > 0 {
 			fmt.Printf("  - Remove %d linked package(s)\n", len(linkedPkgs))
 			for _, name := range linkedPkgs {
+				// The preview exists to tell the developer what --force is about
+				// to do, and refusing an entry is part of that. Listing a key
+				// that is not a package name as though it were an ordinary
+				// dependency would describe a retreat that is not going to
+				// happen, at the one moment the developer is reading.
+				if err := pack.ValidatePackageName(name); err != nil {
+					fmt.Printf("    %s %s: not a valid package name, will be skipped (%v)\n", iconWarn(), name, err)
+					continue
+				}
+
 				pkg, _ := lock.Get(name)
 				originalVersion := pkg.OriginalVersion
 				// Ignore lnpm's own reference as original version (bug from older versions)
@@ -103,7 +114,35 @@ func RunRetreat(force bool, runInstall bool) error {
 
 	// Remove each linked package
 	linkedPkgs := lock.List()
+	refused := 0
 	for _, name := range linkedPkgs {
+		// lnpm.lock is a checked-in artifact, so its keys come from whoever
+		// wrote the repository rather than from lnpm. Everything below joins the
+		// key into a path or edits package.json under it, and the node_modules
+		// delete in particular escapes the project outright for a key like
+		// "../../nm-victim/id_rsa" - filepath.Join cleans as it joins, so the
+		// ".." segments survive into the path os.Remove is handed. Unlink, which
+		// does this same job for 'lnpm remove', has always validated first; the
+		// asymmetry was the bug.
+		//
+		// The entry is skipped whole rather than aborting the retreat. Retreat
+		// is the documented way out of lnpm, and a developer who has just been
+		// handed a tampered lock file is exactly the person who needs to leave:
+		// aborting would strand them with .lnpm/ and the file: references still
+		// in place. Skipping narrows what the command does, which is the safe
+		// direction under docs/adr/0001, and the summary below says the retreat
+		// was incomplete so the narrowing is never silent.
+		//
+		// The refused entry is still carried into lnpm.lock.retreat with the
+		// rest. It is a record, not an instruction, and 'lnpm restore' links
+		// through Link, which validates the name again.
+		if err := pack.ValidatePackageName(name); err != nil {
+			fmt.Printf("  %s Refused %s: not a valid package name, so nothing was removed for it (%v)\n", iconWarn(), name, err)
+			fmt.Printf("  %s lnpm did not write that entry; check lnpm.lock for tampering or corruption\n", iconWarn())
+			refused++
+			continue
+		}
+
 		pkg, _ := lock.Get(name)
 
 		fmt.Printf("  Removing %s...\n", name)
@@ -180,10 +219,24 @@ func RunRetreat(force bool, runInstall bool) error {
 	}
 
 	fmt.Println()
-	fmt.Printf("%s Retreat complete!\n", iconOK())
+	// A retreat that refused part of its work is not a complete one, and saying
+	// so is the whole point of counting: package.json may still hold a
+	// file:.lnpm reference for every refused entry.
+	if refused > 0 {
+		fmt.Printf("%s Retreat incomplete: refused %d of %d lnpm.lock entr(ies), see above\n", iconWarn(), refused, len(linkedPkgs))
+	} else {
+		fmt.Printf("%s Retreat complete!\n", iconOK())
+	}
 
 	if !runInstall {
 		fmt.Printf("\n%s Run 'npm install' to restore original packages\n", iconTip())
+	}
+
+	// Non-zero exit, as remove does for the packages it could not remove: a
+	// script that retreats before publishing must not read a partial retreat as
+	// a clean one.
+	if refused > 0 {
+		return fmt.Errorf("%d of %d lnpm.lock entr(ies) were refused as invalid package names", refused, len(linkedPkgs))
 	}
 
 	return nil

--- a/internal/cli/retreat_test.go
+++ b/internal/cli/retreat_test.go
@@ -1,0 +1,264 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/db"
+	"github.com/pedrosousa13/lnpm/pkg/lockfile"
+)
+
+// The tests here cover what retreat does with a package name it did not choose.
+// lnpm.lock is a checked-in artifact, so its keys are attacker-controlled in any
+// repository the developer did not write, and retreat joins them straight into
+// paths it deletes.
+//
+// The load-bearing assertion in each hostile case is that the file outside the
+// project is still there, with its contents. A test that only looked for a
+// warning would pass against a "fix" that printed one after the delete.
+
+const victimContents = "PRIVATE KEY\n"
+
+// newRetreatProject lays out a project with a sibling directory holding a file
+// retreat has no business touching, chdirs into the project, and returns both
+// paths. The victim is a sibling because filepath.Join cleans as it joins:
+// Join(project, "node_modules", "../../nm-victim/id_rsa") collapses to
+// project/../nm-victim/id_rsa, one level above the project.
+func newRetreatProject(t *testing.T) (project, victim string) {
+	t.Helper()
+
+	newDoctorStoreConfig(t)
+	db.ResetForTesting()
+	t.Cleanup(db.ResetForTesting)
+
+	root := t.TempDir()
+	project = filepath.Join(root, "project")
+	if err := os.MkdirAll(filepath.Join(project, ".lnpm"), 0755); err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(project, "node_modules"), 0755); err != nil {
+		t.Fatalf("create node_modules: %v", err)
+	}
+
+	victimDir := filepath.Join(root, "nm-victim")
+	if err := os.MkdirAll(victimDir, 0755); err != nil {
+		t.Fatalf("create victim directory: %v", err)
+	}
+	victim = filepath.Join(victimDir, "id_rsa")
+	writeFile(t, victim, victimContents)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	return project, victim
+}
+
+// writeRetreatLock writes package.json and lnpm.lock describing the given
+// entries, each as a live lnpm link. An empty original version means the
+// dependency was added by lnpm and retreat should drop it from package.json.
+func writeRetreatLock(t *testing.T, project string, originalVersions map[string]string) {
+	t.Helper()
+
+	deps := make([]string, 0, len(originalVersions))
+	lock := &lockfile.LockFile{Version: 1, Packages: map[string]lockfile.Package{}}
+	for name, original := range originalVersions {
+		deps = append(deps, `"`+name+`":"file:.lnpm/`+name+`"`)
+		lock.Packages[name] = lockfile.Package{Version: "1.0.0", OriginalVersion: original}
+	}
+
+	writeFile(t, filepath.Join(project, "package.json"),
+		`{"name":"victim-project","version":"1.0.0","dependencies":{`+strings.Join(deps, ",")+`}}`)
+	if err := lock.Save(project); err != nil {
+		t.Fatalf("save lock file: %v", err)
+	}
+}
+
+// requireVictimIntact is the assertion every hostile case turns on: the file
+// outside the project is still there and still holds what it held.
+func requireVictimIntact(t *testing.T, victim string) {
+	t.Helper()
+
+	data, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("retreat deleted %s, a file outside the project: %v", victim, err)
+	}
+	if string(data) != victimContents {
+		t.Errorf("retreat changed %s, a file outside the project: contents are %q, want %q",
+			victim, string(data), victimContents)
+	}
+}
+
+// TestRunRetreatRefusesATraversingLockEntry is the issue's own reproduction: a
+// lock file whose only key climbs out of node_modules.
+func TestRunRetreatRefusesATraversingLockEntry(t *testing.T) {
+	project, victim := newRetreatProject(t)
+	const hostile = "../../nm-victim/id_rsa"
+	writeRetreatLock(t, project, map[string]string{hostile: ""})
+
+	var err error
+	out := captureStdout(t, func() { err = RunRetreat(true, false) })
+
+	requireVictimIntact(t, victim)
+
+	if err == nil {
+		t.Errorf("RunRetreat() = nil after refusing an entry, want an error saying the retreat was incomplete; output was:\n%s", out)
+	}
+	if !strings.Contains(out, hostile) {
+		t.Errorf("retreat did not name the refused entry %q, output was:\n%s", hostile, out)
+	}
+	if !strings.Contains(out, "not a valid package name") {
+		t.Errorf("retreat did not say why the entry was refused, output was:\n%s", out)
+	}
+	if strings.Contains(out, "Retreat complete!") {
+		t.Errorf("retreat claimed to be complete after refusing an entry, output was:\n%s", out)
+	}
+
+	// The refusal has to cover everything the entry drives, not only the delete.
+	pkgJSON := readFileString(t, filepath.Join(project, "package.json"))
+	if !strings.Contains(pkgJSON, hostile) {
+		t.Errorf("retreat edited package.json for a refused entry, package.json is now:\n%s", pkgJSON)
+	}
+}
+
+// TestRunRetreatCleansValidEntriesBesideARefusedOne is the test that proves the
+// refusal skips one entry rather than aborting the retreat: a developer with a
+// tampered lock file must still be able to get out of lnpm.
+func TestRunRetreatCleansValidEntriesBesideARefusedOne(t *testing.T) {
+	project, victim := newRetreatProject(t)
+	const hostile = "../../nm-victim/id_rsa"
+	writeRetreatLock(t, project, map[string]string{hostile: "", "good-pkg": "^1.0.0"})
+
+	goodLink := filepath.Join(project, "node_modules", "good-pkg")
+	writeFile(t, goodLink, "module.exports = {}\n")
+
+	var err error
+	out := captureStdout(t, func() { err = RunRetreat(true, false) })
+
+	requireVictimIntact(t, victim)
+
+	if _, statErr := os.Lstat(goodLink); !os.IsNotExist(statErr) {
+		t.Errorf("retreat left node_modules/good-pkg behind (%v); a refused entry must not stop the valid ones", statErr)
+	}
+	pkgJSON := readFileString(t, filepath.Join(project, "package.json"))
+	if !strings.Contains(pkgJSON, `"good-pkg":"^1.0.0"`) {
+		t.Errorf("retreat did not restore good-pkg's original version, package.json is now:\n%s", pkgJSON)
+	}
+	if _, statErr := os.Stat(filepath.Join(project, ".lnpm")); !os.IsNotExist(statErr) {
+		t.Errorf(".lnpm/ was not removed (%v); a refused entry must not abort the retreat", statErr)
+	}
+	if err == nil {
+		t.Errorf("RunRetreat() = nil after refusing an entry, want an error; output was:\n%s", out)
+	}
+}
+
+// TestRunRetreatRefusesOtherUnsafeLockEntries covers the shapes that are not "..
+// climbing out" but are equally not package names. filepath.Join swallows a
+// leading separator, so an absolute key does not itself escape - it is refused
+// because it is not a name lnpm could ever have linked, and letting it through
+// would mean deleting whatever node_modules/<the whole path> happened to be.
+func TestRunRetreatRefusesOtherUnsafeLockEntries(t *testing.T) {
+	for _, tc := range []struct {
+		desc string
+		name string
+	}{
+		{"absolute path", "/etc/ssh/ssh_host_rsa_key"},
+		{"parent directory", ".."},
+		{"traversal under a scope", "@scope/.."},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			project, victim := newRetreatProject(t)
+			writeRetreatLock(t, project, map[string]string{tc.name: ""})
+
+			var err error
+			out := captureStdout(t, func() { err = RunRetreat(true, false) })
+
+			requireVictimIntact(t, victim)
+
+			if err == nil {
+				t.Errorf("RunRetreat() = nil for the %s key %q, want an error; output was:\n%s", tc.desc, tc.name, out)
+			}
+			if !strings.Contains(out, "not a valid package name") {
+				t.Errorf("retreat did not refuse the %s key %q, output was:\n%s", tc.desc, tc.name, out)
+			}
+			pkgJSON := readFileString(t, filepath.Join(project, "package.json"))
+			if !strings.Contains(pkgJSON, tc.name) {
+				t.Errorf("retreat edited package.json for the refused %s key, package.json is now:\n%s", tc.desc, pkgJSON)
+			}
+		})
+	}
+}
+
+// TestRunRetreatWithOnlyValidEntriesIsUnchanged pins the other side: the guard
+// must be invisible to every project that is not under attack.
+func TestRunRetreatWithOnlyValidEntriesIsUnchanged(t *testing.T) {
+	project, _ := newRetreatProject(t)
+	writeRetreatLock(t, project, map[string]string{"good-pkg": "^1.0.0", "@org/scoped": ""})
+
+	var err error
+	out := captureStdout(t, func() { err = RunRetreat(true, false) })
+
+	if err != nil {
+		t.Errorf("RunRetreat() = %v for a lock file of valid names, want nil", err)
+	}
+	if !strings.Contains(out, "Retreat complete!") {
+		t.Errorf("retreat did not report completion, output was:\n%s", out)
+	}
+	if strings.Contains(out, "not a valid package name") || strings.Contains(out, "refused") {
+		t.Errorf("retreat warned about a lock file of valid names, output was:\n%s", out)
+	}
+}
+
+// TestRunRetreatPreviewFlagsAnUnsafeLockEntry covers the branch that runs
+// without --force. It exists to tell the developer what retreat is about to do,
+// so listing a hostile key as though it were an ordinary package is its own
+// small lie - and this is the moment the developer is actually reading.
+func TestRunRetreatPreviewFlagsAnUnsafeLockEntry(t *testing.T) {
+	project, victim := newRetreatProject(t)
+	const hostile = "../../nm-victim/id_rsa"
+	writeRetreatLock(t, project, map[string]string{hostile: "", "good-pkg": "^1.0.0"})
+
+	var err error
+	out := captureStdout(t, func() { err = RunRetreat(false, false) })
+
+	requireVictimIntact(t, victim)
+
+	if err != nil {
+		t.Errorf("RunRetreat(force=false) = %v, want nil: a preview changes nothing", err)
+	}
+	if !strings.Contains(out, "not a valid package name") {
+		t.Errorf("the preview listed the hostile entry as an ordinary package, output was:\n%s", out)
+	}
+	if !strings.Contains(out, "good-pkg") {
+		t.Errorf("the preview dropped the valid entry, output was:\n%s", out)
+	}
+}
+
+// writeFile writes content to path, failing the test if it cannot. It lives
+// here rather than beside its first caller in output_tty_linux_test.go, which
+// carries a linux build tag the tests above do not.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// readFileString reads path, failing the test if it cannot.
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/cli/retreat_test.go
+++ b/internal/cli/retreat_test.go
@@ -114,17 +114,69 @@ func TestRunRetreatRefusesATraversingLockEntry(t *testing.T) {
 	if !strings.Contains(out, hostile) {
 		t.Errorf("retreat did not name the refused entry %q, output was:\n%s", hostile, out)
 	}
-	if !strings.Contains(out, "not a valid package name") {
+	// ": %v" is how every other error in this package trails, so the refusal
+	// reads the same way as the rest of the command's output.
+	if !strings.Contains(out, "not a valid package name: ") {
 		t.Errorf("retreat did not say why the entry was refused, output was:\n%s", out)
 	}
 	if strings.Contains(out, "Retreat complete!") {
 		t.Errorf("retreat claimed to be complete after refusing an entry, output was:\n%s", out)
 	}
 
+	// rootCmd silences the usage dump but not the error, so cobra prints
+	// err.Error() straight after everything above. Repeating the summary
+	// verbatim there would read as a stutter.
+	if strings.Contains(out, err.Error()) {
+		t.Errorf("the returned error repeats the summary line verbatim; error was %q, output was:\n%s", err, out)
+	}
+
 	// The refusal has to cover everything the entry drives, not only the delete.
 	pkgJSON := readFileString(t, filepath.Join(project, "package.json"))
 	if !strings.Contains(pkgJSON, hostile) {
 		t.Errorf("retreat edited package.json for a refused entry, package.json is now:\n%s", pkgJSON)
+	}
+}
+
+// TestRunRetreatSaysWhatARefusedEntryLeftBehind covers the advice, which has to
+// survive the rest of the retreat running to completion around it. .lnpm/ is
+// gone and lnpm.lock has been renamed by the time the user reads any of this,
+// so telling them to go and look at lnpm.lock would name a file that is no
+// longer there - and the file: reference the refusal declined to touch is still
+// in package.json with nothing pointing it out.
+func TestRunRetreatSaysWhatARefusedEntryLeftBehind(t *testing.T) {
+	project, _ := newRetreatProject(t)
+	const hostile = "../../nm-victim/id_rsa"
+	writeRetreatLock(t, project, map[string]string{hostile: "", "good-pkg": "^1.0.0"})
+
+	out := captureStdout(t, func() { _ = RunRetreat(true, false) })
+
+	// What the advice has to be true about.
+	if _, err := os.Stat(filepath.Join(project, "lnpm.lock")); !os.IsNotExist(err) {
+		t.Fatalf("lnpm.lock is still in place (%v); this test is about the case where it was stashed", err)
+	}
+	if _, err := os.Stat(filepath.Join(project, lockfile.RetreatFileName)); err != nil {
+		t.Fatalf("%s was not written: %v", lockfile.RetreatFileName, err)
+	}
+
+	// The advice is read after the summary, so that is where it has to be, and
+	// scoping the assertions to it stops the earlier "saved as lnpm.lock.retreat"
+	// progress line from satisfying them by accident.
+	_, advice, ok := strings.Cut(out, "Retreat incomplete")
+	if !ok {
+		t.Fatalf("retreat did not report an incomplete retreat, output was:\n%s", out)
+	}
+	if !strings.Contains(advice, lockfile.RetreatFileName) {
+		t.Errorf("the advice did not point at %s, where the refused entry actually went, advice was:\n%s",
+			lockfile.RetreatFileName, advice)
+	}
+	if !strings.Contains(advice, "by hand") {
+		t.Errorf("the advice did not say the leftover package.json dependency has to be removed by hand, advice was:\n%s", advice)
+	}
+	if !strings.Contains(advice, hostile) {
+		t.Errorf("the advice did not name the dependency left in package.json, advice was:\n%s", advice)
+	}
+	if strings.Contains(advice, "good-pkg") {
+		t.Errorf("the advice named good-pkg, which was retreated normally, advice was:\n%s", advice)
 	}
 }
 


### PR DESCRIPTION
Closes #314. Pairs with #313, landed earlier as `d9beea2` (PR #341) — same class, different guard, neither covering the other.

`lnpm.lock` is a checked-in artifact, so its keys come from whoever wrote the repository. `RunRetreat` joined each key straight into `node_modules/<name>` and called `os.Remove` on the result. `Unlink`, which does this same job for `lnpm remove`, has always validated first. **That asymmetry was the bug.**

`filepath.Join` is no defence here — it *cleans* as it joins, so `..` segments survive into the path `os.Remove` is handed.

## Reproduced before any code was written

`lnpm.lock` with the key `../../nm-victim/id_rsa`, then `lnpm retreat --force`:

```
Retreating from lnpm...
  Removing ../../nm-victim/id_rsa...
    OK Removed ../../nm-victim/id_rsa from package.json
  OK Removed .lnpm/
  OK Removed lnpm.lock (saved as lnpm.lock.retreat for 'lnpm restore')

OK Retreat complete!
```

The file outside the project was gone, and the command reported **complete success**.

## The enumeration question is answered

The triage note warned the sweep's list was "unproven-complete" and asked whether any other command builds a path from a lock key without validating. Enumerated once here and re-verified independently by the Spec reviewer:

| Site | Verdict |
| --- | --- |
| `internal/cli/retreat.go` | **The only dangerous one.** Fixed. |
| `internal/cli/remove.go` | Routes through `Unlink`, which validates. Safe. |
| `internal/cli/restore.go` | Names go to DB lookups and `package.json` keys; the only path built is `pkgJSONPath`, which does not include the name. Links via `Link`, which validates. Safe. |
| `internal/cli/pull.go` | `IsLiveLinked`, a read-only `Lstat`. Out of scope — #340. |
| `internal/cli/status.go` | Prints only. Safe. |

## Behaviour

A refused entry is **skipped whole** — the `node_modules` delete, the `package.json` rewrite and the database link delete alike — rather than aborting the retreat. Per ADR-0001 the direction is what decides: skipping narrows what the retreat does, where aborting would strand a developer handed a tampered lock file with `.lnpm/` and every `file:` reference still in place, and retreat is the documented way out of lnpm.

The narrowing is never silent:

```
! Retreat incomplete: refused 1 of 2 lnpm.lock entr(ies)
! lnpm never wrote those entries, so there was nothing of its own to clean up for them
! Left in package.json, to remove by hand:
    "../../nm-victim/id_rsa"
! The entries themselves are in lnpm.lock.retreat; inspect it for tampering or corruption
```

The command also exits non-zero, as `remove.go:141` already does for packages it could not remove, so a script cannot read a partial retreat as a clean one. The `--force` preview flags the same entries — telling the developer what `--force` will do is its job.

**Why the leftovers are left.** `lnpm add` validates, so lnpm never wrote those entries: there was never a `.lnpm/<name>` directory and no link to undo. The `file:` reference and the lock key are the tampering itself, not damage the retreat caused, and removing them is the repository owner's decision — not something to do quietly under a name we just refused to act on.

The second commit exists because review caught that the first version told the user to *"check `lnpm.lock`"* while the retreat had already moved it to the snapshot — advice naming a file that no longer existed, with `lnpm retreat` then reporting "No lnpm links found" on a retry. `reportRefused` now runs after the rest of the retreat so it can name where things actually ended up.

## `ValidatePackageName` was checked, not assumed

The Spec reviewer attacked it directly. Rejected on **all** platforms, not just Windows: `..`/`.` segments, absolute paths, backslashes (so UNC `\\server\share` and `C:\foo` die on Linux too), trailing `/`, bare `@scope/`, NUL, more than one `/`. `node_modules` and `C:foo` pass but stay inside `node_modules/`, and `os.Remove` unlinks one entry. Nothing escapes.

## `SECURITY.md`

Its path-traversal section claimed traversal was mitigated by "Using `filepath.Join()`" and "Validating package names don't contain path separators". The first was never true and the second was not applied everywhere — which is what #313 and this issue both were. #313 left it alone deliberately, because the claim stayed wrong until this landed.

It now states what is actually enforced, and separately what is not: the checks are not atomic (TOCTOU), `node_modules` is not guarded the way `.lnpm` is (#339), and read paths — `Store.GetFiles` and `pull`'s link-status queries — do not validate (#340).

## Tests

Seven cases in `internal/cli/retreat_test.go`. The load-bearing assertion is **file survival outside the project**, not "a warning was printed".

Revert-checked at two levels, plus a mutant:

- **Pre-fix (`d9beea2`)** → 6 of 7 fail. The seventh is `WithOnlyValidEntriesIsUnchanged`, the regression guard proving the fix is invisible to healthy projects.
- **First-pass fix** → only the two guidance tests fail, correctly: the vulnerability was already closed, and those two pin the new advice.
- **Mutant — correct warning printed *after* `os.Remove`** → the two tests that can actually escape the project catch it. Reported honestly: the absolute-path and bare-`..` cases pass the mutant, because `filepath.Join` swallows a leading separator and `..` resolves to `cwd`, so there is no file outside the project for them to save. They carry a `package.json`-state assertion instead.

## Known limit, stated

One assertion is weaker than it looks: the stutter check asserts the error text is not a literal substring of the output, which is narrower than "does not read as a stutter" — a judgement no test can make. That fix rests on reading the output.

## Gates

`go test ./...`, the same under a symlinked `TMPDIR`, `go vet`, `golangci-lint`, `gofmt -l`, and `vet`/`build`/test-compile for windows/amd64, darwin/arm64 and linux/arm64 — all green.