### PR TITLE
fix(workspace): fail on a broken config in the directory Detect started from

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -139,8 +139,8 @@ type checkManifest struct {
 // unknown, and unknown is not the same as "no workspace here".
 //
 // Both errors add the location and leave the wrapped error to say what is
-// wrong with it, because workspace.Detect names the offending pattern and
-// ListPackages names the offending manifest.
+// wrong with it, because workspace.Detect names the offending pattern or the
+// config file it could not read, and ListPackages names the offending manifest.
 func checkManifests(cwd string, cwdPkgJSON map[string]interface{}) ([]checkManifest, bool, error) {
 	ws, err := workspace.Detect(cwd)
 	if err != nil {

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -139,8 +139,9 @@ type checkManifest struct {
 // unknown, and unknown is not the same as "no workspace here".
 //
 // Both errors add the location and leave the wrapped error to say what is
-// wrong with it, because workspace.Detect names the offending pattern or the
-// config file it could not read, and ListPackages names the offending manifest.
+// wrong with it, because workspace.Detect names the offending pattern, or the
+// config file it could not parse or read, and ListPackages names the offending
+// manifest.
 func checkManifests(cwd string, cwdPkgJSON map[string]interface{}) ([]checkManifest, bool, error) {
 	ws, err := workspace.Detect(cwd)
 	if err != nil {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -30,15 +30,15 @@ type Package struct {
 func Detect(startPath string) (*Workspace, error) {
 	// Walk up looking for workspace root
 	current := startPath
-	for startDir := true; ; startDir = false {
+	startDir := true
+	for {
 		ws, err := detectWorkspaceAt(current)
 		// A malformed glob pattern is a config error, not a "no workspace
 		// here" signal. Walking past it would end in "no workspace found",
 		// which hides the offending pattern from the user, and docs/adr/0001
-		// requires a malformed pattern to abort naming the pattern. It aborts
-		// at every level of the walk, unlike the read and parse failures
-		// below, because it fails open: the pattern widens a publish rather
-		// than stopping one, which is the ADR's bug case.
+		// requires a malformed pattern to abort naming the pattern. This guard
+		// is unconditional, as #241 wrote it; the starting-directory rule
+		// below, settled separately in #288, deliberately does not narrow it.
 		//
 		// doublestar.ErrBadPattern is path.ErrBadPattern, so this guard would
 		// also catch a bad-pattern error raised by path.Match anywhere under
@@ -70,6 +70,7 @@ func Detect(startPath string) (*Workspace, error) {
 			break
 		}
 		current = parent
+		startDir = false
 	}
 
 	return nil, nil

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -30,18 +30,35 @@ type Package struct {
 func Detect(startPath string) (*Workspace, error) {
 	// Walk up looking for workspace root
 	current := startPath
-	for {
+	for startDir := true; ; startDir = false {
 		ws, err := detectWorkspaceAt(current)
 		// A malformed glob pattern is a config error, not a "no workspace
 		// here" signal. Walking past it would end in "no workspace found",
 		// which hides the offending pattern from the user, and docs/adr/0001
-		// requires a malformed pattern to abort naming the pattern. Every
-		// other failure keeps the existing walk-up behaviour.
+		// requires a malformed pattern to abort naming the pattern. It aborts
+		// at every level of the walk, unlike the read and parse failures
+		// below, because it fails open: the pattern widens a publish rather
+		// than stopping one, which is the ADR's bug case.
 		//
 		// doublestar.ErrBadPattern is path.ErrBadPattern, so this guard would
 		// also catch a bad-pattern error raised by path.Match anywhere under
 		// detectWorkspaceAt. Nothing under there calls path.Match today.
 		if errors.Is(err, doublestar.ErrBadPattern) {
+			return nil, err
+		}
+		// A config that will not read or will not parse aborts only in the
+		// directory Detect started from - the first iteration, and the only
+		// place along the walk where the config is one the caller is actually
+		// using. Reporting it as "no workspace found" points the user at their
+		// command line when the problem is a typo in the file beside them.
+		//
+		// Later iterations keep swallowing it, deliberately. Detect walks to
+		// the filesystem root, so a config anywhere above the user - a stray
+		// package.json in a home directory, an unrelated project this one
+		// happens to sit beneath - would otherwise break every command run
+		// here. Issue #288 weighed aborting everywhere and declined it for
+		// that reason; do not widen this to the whole loop.
+		if err != nil && startDir {
 			return nil, err
 		}
 		if err == nil && ws != nil {
@@ -75,7 +92,12 @@ func detectWorkspaceAt(dir string) (*Workspace, error) {
 	return nil, nil
 }
 
-// parsePnpmWorkspace parses a pnpm-workspace.yaml file
+// parsePnpmWorkspace parses a pnpm-workspace.yaml file.
+//
+// The parse error is wrapped with the path because yaml.Unmarshal describes
+// only the syntax problem and never says which file it was reading. The read
+// error is not: os.ReadFile returns a *fs.PathError, which already names the
+// file, and wrapping would give one file two spellings in one message.
 func parsePnpmWorkspace(root, path string) (*Workspace, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -86,7 +108,7 @@ func parsePnpmWorkspace(root, path string) (*Workspace, error) {
 		Packages []string `yaml:"packages"`
 	}
 	if err := yaml.Unmarshal(data, &config); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
 	}
 
 	if len(config.Packages) == 0 {
@@ -105,7 +127,9 @@ func parsePnpmWorkspace(root, path string) (*Workspace, error) {
 	}, nil
 }
 
-// parsePackageJSONWorkspace parses workspaces from package.json
+// parsePackageJSONWorkspace parses workspaces from package.json. It names the
+// file on a parse error and leaves a read error alone, for the reasons
+// parsePnpmWorkspace records.
 func parsePackageJSONWorkspace(root, path string) (*Workspace, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -116,7 +140,7 @@ func parsePackageJSONWorkspace(root, path string) (*Workspace, error) {
 		Workspaces interface{} `json:"workspaces"`
 	}
 	if err := json.Unmarshal(data, &pkgJSON); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
 	}
 
 	if pkgJSON.Workspaces == nil {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -210,6 +210,195 @@ func TestDetectPNPMWorkspaceExcludesNegatedPackage(t *testing.T) {
 	assertPackages(t, ws.Packages, []string{pkgA})
 }
 
+// --- a config Detect is using, versus one it is walking past ------------------
+//
+// Detect walks from startPath to the filesystem root, so the two ends of that
+// walk are not the same kind of place. The starting directory's config is one
+// the caller is actually using; anything found further up belongs to whatever
+// happens to sit above them, which on a deep enough path is an unrelated
+// project. Issue #288 settled the split there: a broken config you are using
+// aborts naming the file, a broken config you are only passing through does
+// not become your problem.
+
+func TestDetectUnparseablePackageJSONInStartDirFails(t *testing.T) {
+	root := t.TempDir()
+	writePackage(t, root, "packages/package-a")
+
+	manifest := filepath.Join(root, "package.json")
+	if err := os.WriteFile(manifest, []byte(`{"name":"root","workspaces":["packages/*",}`), 0644); err != nil {
+		t.Fatalf("Failed to write package.json: %v", err)
+	}
+
+	ws, err := Detect(root)
+	if err == nil {
+		t.Fatalf("Expected an error for the unparseable package.json, got nil and workspace %+v", ws)
+	}
+	if !strings.Contains(err.Error(), manifest) {
+		t.Errorf("Expected the error to name %s, got: %v", manifest, err)
+	}
+	// encoding/json describes the syntax problem and nothing else, so the
+	// message only reaches the file because Detect's side wraps it. Pin that
+	// the wrap keeps the original reachable rather than flattening it.
+	var syntax *json.SyntaxError
+	if !errors.As(err, &syntax) {
+		t.Errorf("Expected the error to wrap a *json.SyntaxError, got: %v", err)
+	}
+	if ws != nil {
+		t.Errorf("Expected no workspace alongside the error, got %+v", ws)
+	}
+}
+
+func TestDetectUnparseablePnpmWorkspaceInStartDirFails(t *testing.T) {
+	root := t.TempDir()
+	writePackage(t, root, "packages/package-a")
+
+	config := filepath.Join(root, "pnpm-workspace.yaml")
+	if err := os.WriteFile(config, []byte("packages: [packages/*\n"), 0644); err != nil {
+		t.Fatalf("Failed to write pnpm-workspace.yaml: %v", err)
+	}
+
+	ws, err := Detect(root)
+	if err == nil {
+		t.Fatalf("Expected an error for the unparseable pnpm-workspace.yaml, got nil and workspace %+v", ws)
+	}
+	if !strings.Contains(err.Error(), config) {
+		t.Errorf("Expected the error to name %s, got: %v", config, err)
+	}
+	// gopkg.in/yaml.v3 has no exported error type to match on, so assert the
+	// weaker but still meaningful thing: the parse error is wrapped, not
+	// replaced by a message that names only the file.
+	if errors.Unwrap(err) == nil {
+		t.Errorf("Expected the error to wrap the YAML parse error, got: %v", err)
+	}
+	if ws != nil {
+		t.Errorf("Expected no workspace alongside the error, got %+v", ws)
+	}
+}
+
+// A config that cannot be read fails the same way a config that cannot be
+// parsed does. os.ReadFile returns a *fs.PathError, which already names the
+// file, so this pins that the message stays actionable without Detect adding
+// a second spelling of the same path.
+func TestDetectUnreadableConfigInStartDirFails(t *testing.T) {
+	requirePermissionEnforcement(t)
+
+	root := t.TempDir()
+	writePackage(t, root, "packages/package-a")
+
+	manifest := filepath.Join(root, "package.json")
+	if err := os.WriteFile(manifest, []byte(`{"name":"root","workspaces":["packages/*"]}`), 0644); err != nil {
+		t.Fatalf("Failed to write package.json: %v", err)
+	}
+	if err := os.Chmod(manifest, 0000); err != nil {
+		t.Fatalf("Failed to chmod package.json: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(manifest, 0644) })
+
+	ws, err := Detect(root)
+	if err == nil {
+		t.Fatalf("Expected an error for the unreadable package.json, got nil and workspace %+v", ws)
+	}
+	if !strings.Contains(err.Error(), manifest) {
+		t.Errorf("Expected the error to name %s, got: %v", manifest, err)
+	}
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Errorf("Expected the error to wrap a permission error, got: %v", err)
+	}
+	if ws != nil {
+		t.Errorf("Expected no workspace alongside the error, got %+v", ws)
+	}
+}
+
+// The other half of the split. A project with no workspace of its own, sitting
+// under a broken one, reports "no workspace" rather than inheriting a failure
+// it cannot fix - Detect walks to the filesystem root, so propagating here
+// would let any broken config anywhere above a user's home directory break
+// every command they run.
+func TestDetectWalksPastABrokenAncestorConfig(t *testing.T) {
+	for _, tc := range []struct{ name, file, contents string }{
+		{"package.json", "package.json", `{"name":"root","workspaces":["packages/*",}`},
+		{"pnpm-workspace.yaml", "pnpm-workspace.yaml", "packages: [packages/*\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := os.WriteFile(filepath.Join(root, tc.file), []byte(tc.contents), 0644); err != nil {
+				t.Fatalf("Failed to write %s: %v", tc.file, err)
+			}
+
+			project := filepath.Join(root, "nested", "project")
+			if err := os.MkdirAll(project, 0755); err != nil {
+				t.Fatalf("Failed to create %s: %v", project, err)
+			}
+
+			ws, err := Detect(project)
+			if err != nil {
+				t.Fatalf("Expected the broken ancestor config to be walked past, got: %v", err)
+			}
+			if ws != nil {
+				t.Errorf("Expected no workspace, got %+v", ws)
+			}
+		})
+	}
+}
+
+// #241's guard has to keep working at every level of the walk, not only the
+// first. A malformed glob pattern is the one failure docs/adr/0001 requires to
+// abort wherever it is found, because it widens a publish rather than failing
+// closed - it is not covered by the starting-directory rule above and must not
+// be narrowed to it.
+func TestDetectMalformedPatternInAncestorReturnsError(t *testing.T) {
+	root := t.TempDir()
+	writePackage(t, root, "packages/public-api")
+
+	manifest := `{"name":"root","workspaces":["packages/[bad"]}`
+	if err := os.WriteFile(filepath.Join(root, "package.json"), []byte(manifest), 0644); err != nil {
+		t.Fatalf("Failed to write package.json: %v", err)
+	}
+
+	project := filepath.Join(root, "nested", "project")
+	if err := os.MkdirAll(project, 0755); err != nil {
+		t.Fatalf("Failed to create %s: %v", project, err)
+	}
+
+	ws, err := Detect(project)
+	if err == nil {
+		t.Fatalf("Expected an error for the malformed pattern, got nil and workspace %+v", ws)
+	}
+	if !strings.Contains(err.Error(), "packages/[bad") {
+		t.Errorf("Expected the error to name the offending pattern, got: %v", err)
+	}
+	if ws != nil {
+		t.Errorf("Expected no workspace alongside the error, got %+v", ws)
+	}
+}
+
+// "There is no workspace here" is not a failure, and the starting-directory
+// rule must not turn any of these three into one. Every ordinary project has a
+// package.json with no workspaces field, so getting this wrong would fail every
+// command run in one.
+func TestDetectTreatsAConfigDeclaringNoWorkspaceAsNoWorkspace(t *testing.T) {
+	for _, tc := range []struct{ name, file, contents string }{
+		{"package.json with no workspaces field", "package.json", `{"name":"solo","version":"1.0.0"}`},
+		{"pnpm-workspace.yaml with an empty packages list", "pnpm-workspace.yaml", "packages: []\n"},
+		{"neither config present", "README.md", "not a manifest\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := os.WriteFile(filepath.Join(root, tc.file), []byte(tc.contents), 0644); err != nil {
+				t.Fatalf("Failed to write %s: %v", tc.file, err)
+			}
+
+			ws, err := Detect(root)
+			if err != nil {
+				t.Fatalf("Expected no error, got: %v", err)
+			}
+			if ws != nil {
+				t.Errorf("Expected no workspace, got %+v", ws)
+			}
+		})
+	}
+}
+
 // --- ListPackages -----------------------------------------------------------
 //
 // Every path in w.Packages had a package.json when expandGlobs filtered on it,

--- a/tests/workspace_test.go
+++ b/tests/workspace_test.go
@@ -154,13 +154,47 @@ func TestPublishAllUnparseableMemberFailsAndPublishesNothing(t *testing.T) {
 	env.AssertPackageInDatabase("@npm-test/package-b", false)
 }
 
+// A workspace config in the directory `--all` was run from that will not parse
+// has to reach the user by name. "no workspace found. --all requires a monorepo
+// with workspaces configured" points at the command line when the problem is a
+// typo in the file the user is looking straight at.
+func TestPublishAllUnparseableWorkspaceConfigNamesTheFile(t *testing.T) {
+	env := setupTest(t)
+
+	wsDir := env.CopyFixture("npm-workspace")
+	env.writeFile(filepath.Join(wsDir, "package.json"), `{"name":"npm-workspace","workspaces":["packages/*",}`)
+
+	env.chdir(wsDir)
+	err := cli.RunPublish(false, true, false, true)
+	if err == nil {
+		t.Fatal("Expected publish --all to fail for the unparseable workspace config, got nil")
+	}
+	// The workspace-relative tail, not the absolute path: RunPublish builds its
+	// paths from os.Getwd, which resolves symlinks and 8.3 short names.
+	wantTail := filepath.Join("npm-workspace", "package.json")
+	if !strings.Contains(err.Error(), wantTail) {
+		t.Errorf("Expected the error to name %s, got: %v", wantTail, err)
+	}
+	if strings.Contains(err.Error(), "no workspace found") {
+		t.Errorf("Expected the error to report the broken config, not a missing workspace, got: %v", err)
+	}
+
+	env.AssertPackageInDatabase("@npm-test/package-a", false)
+	env.AssertPackageInDatabase("@npm-test/package-b", false)
+}
+
+// An empty directory of this test's own, not /tmp as this used to use: a
+// failure in the starting directory now aborts Detect, so pointing it at a
+// shared world-writable directory would make this test depend on whatever else
+// happens to have left a package.json or pnpm-workspace.yaml there.
 func TestNoWorkspace(t *testing.T) {
-	ws, err := workspace.Detect("/tmp")
+	dir := t.TempDir()
+	ws, err := workspace.Detect(dir)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	if ws != nil {
-		t.Error("Expected nil workspace for /tmp")
+		t.Errorf("Expected nil workspace for %s", dir)
 	}
 }
 


### PR DESCRIPTION
Closes #288. Implements the rule the maintainer already settled on the issue — no design questions were re-opened.

> Fail on a config you are actually using; skip past one you are merely walking through.

`Detect` discarded every read and parse failure from `detectWorkspaceAt` and walked to the parent, so a `package.json` whose `workspaces` block would not parse — or a `pnpm-workspace.yaml` with broken YAML — was indistinguishable from having no workspace at all. The user got:

```
Error: no workspace found. --all requires a monorepo with workspaces configured
```

which points at the command line when the problem is a typo in the file beside them, and names neither the file nor the error.

## What changed

Only the **first** iteration aborts — the directory `Detect` was asked about, and the only place along the walk where the config is one the caller is actually using. Later iterations keep swallowing, deliberately: `Detect` walks to the filesystem root, so a stray `package.json` in a home directory, or an unrelated project this one happens to sit beneath, would otherwise break every command run here. Aborting everywhere was weighed on the issue and **declined**.

The two parse errors are wrapped with their path, because `yaml.Unmarshal` and `json.Unmarshal` describe the syntax problem without ever saying which file they were reading. Read errors are left alone — `os.ReadFile` returns a `*fs.PathError` that already names the file, and wrapping would give one file two spellings in one message (the mistake `internal/cli/retreat.go:32` warns about).

Resulting messages, each naming the file exactly once:

```
failed to parse /x/package.json: invalid character '}' looking for beginning of value
failed to parse /x/pnpm-workspace.yaml: yaml: line 1: did not find expected ',' or ']'
open /x/package.json: permission denied
```

#241's `ErrBadPattern` guard is untouched and still aborts at every level.

## A stale premise in the brief, corrected

The Agent Brief says `Detect` has "exactly two non-test callers". There are **three** — `check.go:145` was added by #211 after the brief was written. Checked, and it needs no adjustment: `RunCheck` reads and parses cwd's `package.json` itself before `checkManifests` is reached, so a broken cwd `package.json` never gets as far as `Detect`. The only new behaviour `check` gains is on a broken cwd `pnpm-workspace.yaml`, consistent with the decision already recorded in `TestCheckFailsBelowAWorkspaceItCannotResolve`.

## Acceptance criteria

All five verified, and AC 5 traced end to end rather than accepted from a unit test — `publish.go:48` wraps preserving the path → cobra (`root.go:68` silences usage but not errors) → `main.go:54` `os.Exit(1)`.

| AC | Status |
| --- | --- |
| Unparseable `package.json` in start dir names the file | met |
| Same for `pnpm-workspace.yaml`, both formats tested | met |
| Ancestor config still walked past; no-workspace still reports "no workspace found" | met |
| #241's `ErrBadPattern` guard unchanged | met — guard still evaluated *before* the new check, preserving abort-at-every-level |
| `publish --all` exits non-zero naming the file | met |

## Tests

Six in `internal/workspace`, one integration test in `tests/`. Revert-checked, and reported honestly rather than dressed up:

- **Genuine reproductions** (fail on revert): the two parse cases, the unreadable-file case, and the integration test — whose pre-fix output was verbatim the issue's complaint.
- **Regression guards** (pass against old code, and say so): ancestor-skip, `ErrBadPattern`-in-ancestor, and the three legitimate `(nil, nil)` cases — no configs, empty `packages:` list, no `workspaces` field. Their job is to fail if someone later widens the abort to the whole loop.

A **second, partial revert** — loop change kept, error wrapping removed — confirms both halves are independently load-bearing rather than one carrying the other. The loop restructure was separately verified by mutating the flag in both directions.

## Two edits beyond `workspace.go`, both consequences of this change

- `internal/cli/check.go` — a why-comment claiming `Detect` "names the offending pattern" was made incomplete by this change; it now covers the config file too.
- `tests/workspace_test.go` — `TestNoWorkspace` called `Detect("/tmp")`. That is now a *starting* directory rather than one walked past, so the test would depend on whatever else had left a `package.json` in a shared world-writable directory. It uses a directory of its own now.

## Review caught a real inaccuracy

The first pass justified the `ErrBadPattern` guard's unconditional abort by saying a malformed pattern "widens a publish rather than stopping one, which is the ADR's bug case". Wrong twice: ADR-0001 is precise that only a discarded *negation* failure widens, and at this call site the direction inverts anyway — swallowing `ErrBadPattern` here yields `(nil, nil)` and publish reports "no workspace found", which *stops* the publish. The comment now states what #241 and #288 each decided, which is checkable, rather than a symmetry that does not hold here.

## Out of scope, untouched

`ListPackages`' per-member swallows (**#246** — decided together with this, implemented separately), #151's negation ordering, and changing `Detect`'s signature to distinguish "no workspace" from "error" (the `(nil, nil)` ambiguity noted in `workspacedeps.go` is a wider design question the issue explicitly rules out).

## Gates

`go test ./...`, the same under a symlinked `TMPDIR`, `go vet`, `golangci-lint`, `gofmt -l`, plus `vet`/`build`/test-compile for windows/amd64, darwin/arm64 and linux/arm64 — all green.