### PR TITLE
chore: pin the Go toolchain for mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+# Matches the `go` directive in go.mod. CI does not read this file — it uses
+# `go-version-file: go.mod` — so keep the two in step when go.mod's directive moves.
+go = "1.26"


### PR DESCRIPTION
mise now manages the Go toolchain on the dev machine, replacing a loose `~/.local/go` install that was never on `PATH`. This pins the version for anyone using mise so a checkout resolves the same toolchain `go.mod` declares.

`go = "1.26"` resolves to 1.26.7 today, matching `go.mod`'s `go 1.26` directive.

**CI is unaffected.** Every workflow uses `go-version-file: go.mod`; nothing in CI reads `mise.toml`. The comment in the file records that, so the two don't silently drift when `go.mod`'s directive moves.

Verified locally on mise-managed Go 1.26.7: `go vet ./...` clean, `gofmt -l .` clean, `go test ./... -count=1` exit 0 (17 packages ok, 0 FAIL).