### PR TITLE
fix(pack): make the files whitelist win over .npmignore and .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,10 +515,10 @@ package.json    ──►       pkg/abc123/      (reflink/hardlink)     (symlink
 
 lnpm decides which files to publish in Go — it does not shell out to the `npm` CLI. The rules are closely modeled on npm's conventions:
 
-- Respects `package.json` `files` field
-- Honors a root `.npmignore`, falling back to a root `.gitignore` (ignore files in subdirectories are not read)
+- Respects `package.json` `files` field. A file it selects is published whatever the ignore files say, as it is for npm — a `.gitignore` holding `dist/` out of version control does not stop `files: ["dist"]` publishing the build output
+- Honors a root `.npmignore`, falling back to a root `.gitignore` (ignore files in subdirectories are not read). They decide every path the `files` field does not select, including the always-included set below
 - Supports gitignore pattern syntax — root anchoring (`/dist`), directory patterns (`dist/`) and negation (`*.txt` followed by `!keep.txt`), with the last matching pattern deciding
-- Applies a built-in exclusion list — VCS metadata and ignore files (`.git`, `.hg`, `.svn`, `CVS`, `.gitignore`, `.gitattributes`, `.npmignore`, `.npmrc`), `node_modules`, OS cruft (`.DS_Store`, `Thumbs.db`), editor and merge backups (`*.swp`, `*.swo`, `*~`, `*.orig`), lnpm and yalc state (`.lnpm/`, `.yalc/`, `lnpm.lock`, `lnpm.lock.retreat`, `yalc.lock`), `*.log`, `*.tgz`, and exactly `.env` and `.env.*` — that a `!` pattern cannot re-include. The patterns are literal, not prefixes: `.envrc` matches neither `.env` nor `.env.*`, so it is published
+- Applies a built-in exclusion list — VCS metadata and ignore files (`.git`, `.hg`, `.svn`, `CVS`, `.gitignore`, `.gitattributes`, `.npmignore`, `.npmrc`), `node_modules`, OS cruft (`.DS_Store`, `Thumbs.db`), editor and merge backups (`*.swp`, `*.swo`, `*~`, `*.orig`), lnpm and yalc state (`.lnpm/`, `.yalc/`, `lnpm.lock`, `lnpm.lock.retreat`, `yalc.lock`), `*.log`, `*.tgz`, and exactly `.env` and `.env.*` — that neither a `!` pattern nor a `files` entry can re-include. The patterns are literal, not prefixes: `.envrc` matches neither `.env` nor `.env.*`, so it is published
 - **Additional safety**: Explicit `.git` filtering prevents any VCS files from being linked
 - **Symlinks are skipped, never followed** — a symlink inside a package can't pull files from outside it (e.g. `~/.ssh`) into the store
 - Package names are restricted to a plain name (`my-pkg`) or a single scope (`@org/my-pkg`), because the name is joined into the store path. Everything else is rejected: a second `/`, a single `/` whose first segment is not a scope, `.` or `..` segments, absolute paths, backslashes and NUL bytes
@@ -526,8 +526,7 @@ lnpm decides which files to publish in Go — it does not shell out to the `npm`
 Because the filtering is lnpm's own, some cases differ from `npm publish`:
 
 - The default exclusion list is not npm's. lnpm additionally drops `.env`/`.env.*`, logs and `*.tgz`, and does not drop the lockfiles (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`) that npm always ignores
-- Ignore patterns are applied before the `files` whitelist, so a root `.npmignore` can drop a file that `files` listed; for npm the `files` field wins
-- An excluded directory is pruned during the walk, so a negation can't reach back into it: `dist/` plus `!dist/keep.js` publishes neither file. npm diverges in the opposite direction — the negation defeats the `dist/` rule entirely and npm publishes the whole directory, `dist/other.js` included. Spelled `dist/*` instead, the negation does what it looks like in both
+- With no `files` field, an excluded directory is pruned during the walk, so a negation can't reach back into it: `dist/` plus `!dist/keep.js` publishes neither file. npm diverges in the opposite direction — the negation defeats the `dist/` rule entirely and npm publishes the whole directory, `dist/other.js` included. Spelled `dist/*` instead, the negation does what it looks like in both
 - Entries in `files` are matched against the full path and never against a basename, so `**/*.md` picks up `docs/guide.md` but misses `top.md` at the package root, which npm includes
 - The always-included set differs: lnpm adds `CHANGELOG*`, `CHANGES*` and `HISTORY*`, and does not automatically include the files named by `main` and `bin`. Those files are exempt from the `files` whitelist only — an ignore pattern still drops them
 

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -147,9 +147,10 @@ func collectFiles(packageDir string, filesField []string) ([]*FileInfo, error) {
 	var filesToHash []*FileInfo
 	fileCount := 0
 
-	// Load .npmignore or .gitignore patterns
+	// Load .npmignore or .gitignore patterns. They are kept apart from
+	// defaultExcludes because the two rank differently against the "files"
+	// whitelist: the user's patterns lose to it, defaultExcludes beat it.
 	ignorePatterns := loadIgnorePatterns(packageDir)
-	ignorePatterns = append(ignorePatterns, defaultExcludes...)
 
 	// If files field is specified, use whitelist mode
 	useWhitelist := len(filesField) > 0
@@ -182,15 +183,37 @@ func collectFiles(packageDir string, filesField []string) ([]*FileInfo, error) {
 		// Normalize path separators for pattern matching
 		relPath = filepath.ToSlash(relPath)
 
-		// Check if excluded
-		if isExcluded(relPath, ignorePatterns) {
+		// Check if excluded. defaultExcludes are checked on their own and
+		// first, because nothing overrides them — not a user "!" negation, not
+		// the "files" field.
+		if isExcluded(relPath, defaultExcludes) {
 			if info.IsDir() {
-				// Pruning is the one place last-match-wins does not hold end
-				// to end: the walk never descends, so a later "!" pattern
-				// inside this directory is never consulted.
+				// Nothing inside a default-excluded directory can be wanted, so
+				// the walk never descends. This is what keeps a large
+				// node_modules off the walk entirely.
 				return filepath.SkipDir
 			}
 			return nil
+		}
+
+		// The user's ignore patterns decide the whole tree only when there is no
+		// whitelist. With one they drop nothing here, and are consulted again
+		// further down for default includes alone — a "files" entry may be a
+		// glob, so which paths under an ignored directory it selects cannot be
+		// known without descending into it and asking isIncluded per file.
+		// Walking into ignored directories costs something in whitelist mode;
+		// publishing an empty package because .gitignore held the build output
+		// costs more.
+		if !useWhitelist {
+			if isExcluded(relPath, ignorePatterns) {
+				if info.IsDir() {
+					// Pruning is the one place last-match-wins does not hold
+					// end to end: the walk never descends, so a later "!"
+					// pattern inside this directory is never consulted.
+					return filepath.SkipDir
+				}
+				return nil
+			}
 		}
 
 		// Skip directories (we only care about files)
@@ -200,7 +223,19 @@ func collectFiles(packageDir string, filesField []string) ([]*FileInfo, error) {
 
 		// Check if included
 		if useWhitelist {
-			if !isIncluded(relPath, filesField) && !isDefaultInclude(relPath) {
+			switch {
+			case isIncluded(relPath, filesField):
+				// npm documents that a file included with the "files" field
+				// cannot be excluded through .npmignore or .gitignore, so the
+				// user's ignore patterns are not consulted at all here.
+			case isDefaultInclude(relPath):
+				// A default include arrives on its own steam rather than
+				// through the "files" field, so an ignore pattern still drops
+				// it. Nothing skipped the check above for this path.
+				if isExcluded(relPath, ignorePatterns) {
+					return nil
+				}
+			default:
 				return nil
 			}
 		}
@@ -321,8 +356,8 @@ func readIgnoreFile(path string) []string {
 //
 // It follows gitignore semantics: every pattern is evaluated and the last one
 // that matches decides the outcome, so a later "!pattern" re-includes a path an
-// earlier pattern excluded. collectFiles appends defaultExcludes after the
-// user's patterns, which is what keeps a user negation from re-including a
+// earlier pattern excluded. collectFiles evaluates defaultExcludes in a call of
+// their own, which is what keeps a user negation from re-including a
 // default-excluded path such as .env or node_modules.
 func isExcluded(relPath string, patterns []string) bool {
 	baseName := filepath.Base(relPath)

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -713,9 +713,10 @@ func TestPackNpmignoreNegationReincludesFile(t *testing.T) {
 }
 
 // TestIsExcludedDefaultExcludesCannotBeNegated proves a user "!" pattern cannot
-// re-include a default-excluded path. collectFiles appends defaultExcludes
-// after the user's patterns, and the last matching pattern wins, so a default
-// exclude always has the final say.
+// re-include a default-excluded path when the two lists are concatenated: the
+// last matching pattern wins, so a default exclude always has the final say.
+// collectFiles reaches the same answer by evaluating defaultExcludes on their
+// own, where a user negation is not in the list to begin with.
 func TestIsExcludedDefaultExcludesCannotBeNegated(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -740,9 +741,9 @@ func TestIsExcludedDefaultExcludesCannotBeNegated(t *testing.T) {
 }
 
 // TestPackDefaultExcludesWinInWhitelistMode proves default excludes still win
-// when package.json has a "files" whitelist and .npmignore tries to negate
-// them: excludes are evaluated before the whitelist, and defaultExcludes are
-// appended last so they have the final say.
+// when package.json has a "files" whitelist naming them and .npmignore tries to
+// negate them: defaultExcludes are evaluated first and on their own, ahead of
+// both the user's patterns and the whitelist.
 func TestPackDefaultExcludesWinInWhitelistMode(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -794,6 +795,211 @@ func TestPackDefaultExcludesWinInWhitelistMode(t *testing.T) {
 		if packed[name] {
 			t.Errorf("default-excluded %q was packed: a user negation must not re-include it", name)
 		}
+	}
+}
+
+// TestPackFilesFieldWinsOverGitignore packs the standard TypeScript setup: a
+// .gitignore holding the build output out of version control, and a "files"
+// field asking for exactly that build output. npm documents that a path the
+// "files" field names cannot be excluded by .npmignore or .gitignore, so dist
+// ships even though it is ignored.
+//
+// The .gitignore also names two paths the "files" field does not — a coverage
+// directory and README.md, which would otherwise arrive through
+// defaultIncludes — to prove the ignore rules still apply everywhere the
+// whitelist is silent.
+//
+// Regression test for #318.
+func TestPackFilesFieldWinsOverGitignore(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pkgJSON := `{
+		"name": "ts-build",
+		"version": "1.0.0",
+		"main": "dist/index.js",
+		"files": ["dist"]
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(pkgJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("dist/\ncoverage/\nREADME.md\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "README.md"), []byte("# ts-build"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	distDir := filepath.Join(tmpDir, "dist", "nested")
+	if err := os.MkdirAll(distDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "dist", "index.js"), []byte("exports.x = 1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "dist", "index.d.ts"), []byte("export const x: number"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(distDir, "util.js"), []byte("exports.y = 2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	srcDir := filepath.Join(tmpDir, "src")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "index.ts"), []byte("export const x = 1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	coverageDir := filepath.Join(tmpDir, "coverage")
+	if err := os.MkdirAll(coverageDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(coverageDir, "report.html"), []byte("<html></html>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, files, err := Pack(tmpDir)
+	if err != nil {
+		t.Fatalf("Pack() error: %v", err)
+	}
+
+	packed := make(map[string]bool)
+	for _, f := range files {
+		packed[f.RelPath] = true
+	}
+
+	for _, name := range []string{"package.json", "dist/index.js", "dist/index.d.ts", "dist/nested/util.js"} {
+		if !packed[name] {
+			t.Errorf("expected whitelisted file %q to be packed, packed set was %v", name, packed)
+		}
+	}
+	for _, name := range []string{"src/index.ts", "coverage/report.html", "README.md", ".gitignore"} {
+		if packed[name] {
+			t.Errorf("expected file %q to be excluded, packed set was %v", name, packed)
+		}
+	}
+}
+
+// TestPackFilesFieldGlobReachesIntoIgnoredDirectory packs a glob "files" entry
+// selecting into a .gitignored directory. No lexical reading of the pattern can
+// tell in advance which directories a glob selects out of, so the walk has to
+// descend into the ignored directory and ask isIncluded per file.
+//
+// lib/top.js is in dropFiles for "lib/**/*.js" on purpose. It is not packed
+// even with no ignore file present: filepath.Match does not let "**" span a
+// path separator, so the three-segment pattern never matches a two-segment
+// path. That is a pre-existing isIncluded limitation, independent of the
+// whitelist-versus-ignore precedence under test, and the case is here to pin it
+// so it is not mistaken for a bug in that precedence.
+//
+// Regression test for #318.
+func TestPackFilesFieldGlobReachesIntoIgnoredDirectory(t *testing.T) {
+	tests := []struct {
+		name      string
+		filesJSON string
+		wantFile  string
+		dropFiles []string
+	}{
+		{"double star glob", `["lib/**/*.js"]`, "lib/sub/a.js", []string{"lib/sub/a.txt", "lib/top.js"}},
+		{"single star directory glob", `["*/keep.js"]`, "lib/keep.js", []string{"lib/drop.js"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			pkgJSON := `{
+				"name": "glob-reach",
+				"version": "1.0.0",
+				"files": ` + tt.filesJSON + `
+			}`
+			if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(pkgJSON), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("lib/\n"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			for _, rel := range append([]string{tt.wantFile}, tt.dropFiles...) {
+				path := filepath.Join(tmpDir, filepath.FromSlash(rel))
+				if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			_, files, err := Pack(tmpDir)
+			if err != nil {
+				t.Fatalf("Pack() error: %v", err)
+			}
+
+			packed := make(map[string]bool)
+			for _, f := range files {
+				packed[f.RelPath] = true
+			}
+
+			if !packed[tt.wantFile] {
+				t.Errorf("expected %q, selected by files %s, to be packed despite the .gitignore; packed set was %v", tt.wantFile, tt.filesJSON, packed)
+			}
+			for _, rel := range tt.dropFiles {
+				if packed[rel] {
+					t.Errorf("expected %q, which files %s does not select, to be excluded; packed set was %v", rel, tt.filesJSON, packed)
+				}
+			}
+		})
+	}
+}
+
+// TestPackFilesFieldReachesIntoIgnoredDirectory covers the case where the
+// "files" field names a path *inside* an ignored directory rather than the
+// directory itself. The walk must not prune "lib", or it never reaches the file
+// the whitelist asked for. Everything else under lib stays ignored.
+//
+// Regression test for #318.
+func TestPackFilesFieldReachesIntoIgnoredDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pkgJSON := `{
+		"name": "reach-into",
+		"version": "1.0.0",
+		"files": ["lib/keep.js"]
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(pkgJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("lib/\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	libDir := filepath.Join(tmpDir, "lib")
+	if err := os.MkdirAll(libDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "keep.js"), []byte("keep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "drop.js"), []byte("drop"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, files, err := Pack(tmpDir)
+	if err != nil {
+		t.Fatalf("Pack() error: %v", err)
+	}
+
+	packed := make(map[string]bool)
+	for _, f := range files {
+		packed[f.RelPath] = true
+	}
+
+	if !packed["lib/keep.js"] {
+		t.Errorf("expected whitelisted file %q to be packed, packed set was %v", "lib/keep.js", packed)
+	}
+	if packed["lib/drop.js"] {
+		t.Errorf("expected file %q to be excluded, packed set was %v", "lib/drop.js", packed)
 	}
 }
 


### PR DESCRIPTION
Closes #318.

## Problem

`collectFiles` ran the ignore-pattern exclusion **before** it consulted the `files` whitelist, so an ignore rule pruned a directory the manifest had explicitly asked to publish. The standard TypeScript setup — `.gitignore` holding `dist/`, `package.json` holding `"files": ["dist"]` — published a package containing only `package.json`, and reported success with no warning.

npm documents the opposite: a file included with the `files` field cannot be excluded through `.npmignore` or `.gitignore`.

## Change

- The user's ignore patterns are kept apart from `defaultExcludes` so the two can rank differently against the whitelist. `defaultExcludes` are evaluated first and on their own, so `node_modules`, `.env` and friends still win over everything — including a `files` entry naming them.
- The user's patterns prune only when there is no whitelist. A `files` entry may be a glob, so which paths under an ignored directory it selects cannot be decided from the pattern text — the walk has to descend and ask `isIncluded` per concrete file.
- Default includes reach that check having skipped nothing, so an ignore pattern still drops a `README` the `files` field did not name.

Behaviour with no `files` field is unchanged. `defaultExcludes` contains no `!` patterns, which is what makes splitting one `isExcluded(user ++ defaults)` call into two provably equivalent in that mode.

## Tests

Three regression tests, all through the real `Pack()` path rather than the matchers in isolation:

- the TypeScript setup, asserting `dist/**` in and `src/`, `coverage/`, `README.md` out
- glob `files` entries reaching into an ignored directory — `["lib/**/*.js"]` and `["*/keep.js"]`, both of which packed nothing before
- a literal nested entry, `["lib/keep.js"]`

The pre-existing `TestPackDefaultExcludesWinInWhitelistMode` still passes unchanged, which is the guard that #321 has not been built by accident.

## Documentation

`README.md`'s File Filtering section is the designated spec for these rules (see `ARCHITECTURE.md`). It previously listed this as a deliberate divergence from npm; that divergence is gone, so the fact moved up into the rules list, and the directory-pruning bullet is now scoped to the no-`files` case.

## Follow-ups filed, deliberately not fixed here

- #346 — `files: ["./dist"]` matches nothing. Pre-existing; reproduces with no ignore file at all.
- #347 — `ExcludedByProjectRules` has the same precedence inversion. `lnpm check`-only, unverified.
- #348 — publish aborts on an unreadable directory even when an ignore file names it. Pre-existing; confirmed identical on `2406b1a`.