### PR TITLE
fix(gc): abort when a package's links cannot be read

### DIFF
--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -279,8 +279,17 @@ func RunAddMultiple(packageSpecs []string, dev bool, pure bool, runInstall bool,
 			LinkType:  string(r.linkType),
 			Tag:       r.tag,
 		}
+		// A link that cannot be recorded is a failure, not a warning to add
+		// beneath a success line. The files are in the project either way, but
+		// without the row nothing knows the project consumes this package: gc
+		// reads the store entry as unreferenced and deletes what the project is
+		// importing. Warning and carrying on printed "Added" over exactly that
+		// state - the fail-open shape #329 removed from gc, arriving instead
+		// through the write that feeds it.
 		if err := database.InsertLink(dbLink); err != nil {
 			fmt.Printf("  %s Failed to record link for %s: %v\n", iconWarn(), r.pkg.Name, err)
+			errors = append(errors, fmt.Errorf("%s: failed to record the link: %w", r.pkg.Name, err))
+			continue
 		}
 
 		// Reported exactly as the single-package path reports it, so a live link

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -64,6 +64,14 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 		// below stops it: this pass decides what gets deleted, and a read that
 		// failed is indistinguishable here from a version nothing links - so
 		// carrying on would delete a version gc cannot show is unreachable.
+		//
+		// This check was here and did nothing until #329. The lookup dropped a
+		// link row or an index entry it could not parse and returned a nil
+		// error, so the state this guard describes arrived as an empty list and
+		// went straight past it: the run deleted the store entry of a package a
+		// project was still consuming, and reported success. The guard is worth
+		// no more than the error it inspects, which is why the fix was made
+		// there rather than by adding a branch here.
 		links, err := database.GetLinksForPackage(pkg.ID)
 		if err != nil {
 			return fmt.Errorf("failed to read the links of %s@%s: %w", pkg.Name, pkg.Version, err)

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -65,13 +65,14 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 		// failed is indistinguishable here from a version nothing links - so
 		// carrying on would delete a version gc cannot show is unreachable.
 		//
-		// This check was here and did nothing until #329. The lookup dropped a
-		// link row or an index entry it could not parse and returned a nil
-		// error, so the state this guard describes arrived as an empty list and
-		// went straight past it: the run deleted the store entry of a package a
-		// project was still consuming, and reported success. The guard is worth
-		// no more than the error it inspects, which is why the fix was made
-		// there rather than by adding a branch here.
+		// Until #329 this guard caught a failed bolt read and nothing else. The
+		// damage that matters here - a link row or an index entry that will not
+		// parse - was dropped by the lookup, which then returned a nil error, so
+		// the very state this describes arrived as an empty list and went
+		// straight past: the run deleted the store entry of a package a project
+		// was still consuming, and reported success. A guard is worth no more
+		// than the error it inspects, which is why the fix was made there rather
+		// than by adding a branch here.
 		links, err := database.GetLinksForPackage(pkg.ID)
 		if err != nil {
 			return fmt.Errorf("failed to read the links of %s@%s: %w", pkg.Name, pkg.Version, err)

--- a/internal/cli/gc_test.go
+++ b/internal/cli/gc_test.go
@@ -1,10 +1,14 @@
 package cli
 
 import (
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
 
 	"github.com/pedrosousa13/lnpm/internal/config"
 	"github.com/pedrosousa13/lnpm/internal/db"
@@ -532,4 +536,160 @@ func TestRunGCReportsAPathThatNormalisationRewrote(t *testing.T) {
 	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
 		t.Errorf("RunGC left %s behind (stat err = %v)", orphan, err)
 	}
+}
+
+// --- Unreadable links --------------------------------------------------------
+
+// seedCollectableLink records a package with a store entry on disk and one
+// project linked to it, and returns the entry's directory and the link's ID.
+//
+// The entry is the thing the regression is about: with the link readable gc
+// keeps it, and the sweep on #329 showed that damaging the link is enough to
+// make gc delete it while the project is still consuming it.
+func seedCollectableLink(t *testing.T, database *db.DB, storeRoot string) (string, int64) {
+	t.Helper()
+
+	entry := filepath.Join(storeRoot, "linked-pkg", "0123456789abcdef")
+	if err := os.MkdirAll(entry, 0755); err != nil {
+		t.Fatalf("seed entry: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(entry, "index.js"), []byte("payload"), 0644); err != nil {
+		t.Fatalf("seed entry file: %v", err)
+	}
+
+	proj := &db.Project{Path: t.TempDir(), Name: "consumer"}
+	if err := database.InsertProject(proj); err != nil {
+		t.Fatalf("insert project: %v", err)
+	}
+	pkg := &db.Package{
+		Name:        "linked-pkg",
+		Version:     "1.0.0",
+		ContentHash: "0123456789abcdef",
+		StorePath:   entry,
+	}
+	if err := database.InsertPackage(pkg); err != nil {
+		t.Fatalf("insert package: %v", err)
+	}
+	lnk := &db.Link{PackageID: pkg.ID, ProjectID: proj.ID, LinkType: "hardlink"}
+	if err := database.InsertLink(lnk); err != nil {
+		t.Fatalf("insert link: %v", err)
+	}
+	return entry, lnk.ID
+}
+
+// damageDatabase writes bytes straight into a bucket of the store's bbolt file,
+// standing in for the damage a torn write leaves behind.
+//
+// It closes lnpm's handle first and leaves it closed, because bbolt holds an
+// exclusive file lock: the run under test reopens the database itself, which is
+// also what makes the damage look to gc exactly like damage it found on open.
+func damageDatabase(t *testing.T, bucket string, key []byte, value []byte) {
+	t.Helper()
+
+	storePath, err := config.GetStorePath()
+	if err != nil {
+		t.Fatalf("resolve store path: %v", err)
+	}
+	db.ResetForTesting()
+
+	handle, err := bolt.Open(filepath.Join(storePath, "lnpm.db"), 0600, &bolt.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("open the database directly: %v", err)
+	}
+	err = handle.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte(bucket)).Put(key, value)
+	})
+	if closeErr := handle.Close(); closeErr != nil {
+		t.Fatalf("close the database: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("damage %s: %v", bucket, err)
+	}
+}
+
+// linkKey encodes a link or package ID the way the link buckets key their rows.
+func linkKey(id int64) []byte {
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, uint64(id))
+	return key
+}
+
+// assertGCDeletedNothing fails unless the store entry and the database row are
+// both still there after the run.
+func assertGCDeletedNothing(t *testing.T, entry string) {
+	t.Helper()
+
+	if _, err := os.Stat(entry); err != nil {
+		t.Errorf("gc removed the store entry of a package whose links it could not read: %v", err)
+	}
+	database, err := db.GetDB()
+	if err != nil {
+		t.Fatalf("reopen database: %v", err)
+	}
+	packages, err := database.ListPackages()
+	if err != nil {
+		t.Fatalf("list packages: %v", err)
+	}
+	if len(packages) != 1 {
+		t.Errorf("gc dropped the database row of a package whose links it could not read, %d package(s) left", len(packages))
+	}
+}
+
+// TestRunGCAbortsWhenALinkRowCannotBeRead is the sweep's first reproduction on
+// #329, turned into a regression test.
+//
+// gc's orphan scan already states the rule - a read that failed is
+// indistinguishable from a version nothing links - and already aborts when the
+// lookup returns an error. Before the fix the lookup dropped the unreadable row
+// and returned a nil error, so gc collected the package and reported success
+// while a project was still consuming it.
+func TestRunGCAbortsWhenALinkRowCannotBeRead(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	entry, linkID := seedCollectableLink(t, database, storeRoot)
+
+	damageDatabase(t, "links", linkKey(linkID), []byte("{ not a link"))
+
+	out := captureStdout(t, func() {
+		err := RunGC(false, "", false, true)
+		if err == nil {
+			t.Fatal("RunGC() returned no error for a link row it could not read")
+		}
+		if !strings.Contains(err.Error(), "linked-pkg@1.0.0") {
+			t.Errorf("RunGC() error = %v, want it to name the package it could not read", err)
+		}
+	})
+
+	if strings.Contains(out, "orphaned package") {
+		t.Errorf("gc called a package orphaned on links it could not read, output was:\n%s", out)
+	}
+	assertGCDeletedNothing(t, entry)
+}
+
+// TestRunGCAbortsWhenALinkIndexEntryCannotBeRead is the sweep's second
+// reproduction: the by-package index entry is the damaged one, which hides every
+// link the package has rather than one of them.
+func TestRunGCAbortsWhenALinkIndexEntryCannotBeRead(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	entry, _ := seedCollectableLink(t, database, storeRoot)
+
+	packages, err := database.ListPackages()
+	if err != nil || len(packages) != 1 {
+		t.Fatalf("list packages: %v (%d found)", err, len(packages))
+	}
+	damageDatabase(t, "links_by_package", linkKey(packages[0].ID), []byte("[ not ids"))
+
+	out := captureStdout(t, func() {
+		err := RunGC(false, "", false, true)
+		if err == nil {
+			t.Fatal("RunGC() returned no error for a link index entry it could not read")
+		}
+		if !strings.Contains(err.Error(), "linked-pkg@1.0.0") {
+			t.Errorf("RunGC() error = %v, want it to name the package it could not read", err)
+		}
+	})
+
+	if strings.Contains(out, "orphaned package") {
+		t.Errorf("gc called a package orphaned on an index entry it could not read, output was:\n%s", out)
+	}
+	assertGCDeletedNothing(t, entry)
 }

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -188,8 +188,15 @@ func RunPull(packageNames []string) error {
 				LinkType:  l.LinkType,
 				Tag:       l.Tag,
 			}
+			// Reported as a failed pull, not warned past. Leaving the old row in
+			// place is not a smaller version of the same state: it names the
+			// build this project no longer has, so gc keeps that one as linked
+			// and reads the build now on disk as consumed by nobody - and
+			// deletes it. The files were refreshed above, which is what makes
+			// the stale row dangerous rather than merely untidy.
 			if err := database.InsertLink(repointed); err != nil {
 				fmt.Printf("  %s Failed to record the link for %s: %v\n", iconWarn(), name, err)
+				failed = append(failed, fmt.Errorf("%s: failed to record the link: %w", name, err))
 			}
 		}
 	}

--- a/internal/cli/restore.go
+++ b/internal/cli/restore.go
@@ -230,7 +230,11 @@ func RunRestore() error {
 		}
 		consumeSnapshotEntry(snapshot, cwd, name)
 
-		recordRestoredLink(database, cwd, pkg, linkRes.Type)
+		if err := recordRestoredLink(database, cwd, pkg, linkRes.Type); err != nil {
+			fmt.Printf("  %s %s: %v\n", iconFail(), name, err)
+			failed++
+			continue
+		}
 		warnIfOffTheDefaultChannel(database, name, pkg)
 
 		fmt.Printf("%s Restored %s@%s\n", iconOK(), name, pkg.Version)
@@ -285,24 +289,30 @@ func consumeSnapshotEntry(snapshot *lockfile.LockFile, cwd, name string) {
 }
 
 // recordRestoredLink registers the project and its link to pkg, so `lnpm list`
-// and `lnpm push` see the restored package the way they see an added one. A
-// failure here costs only bookkeeping - the link on disk is already in place -
-// so it is reported and not treated as a failed restore.
-func recordRestoredLink(database *db.DB, cwd string, pkg *db.Package, linkType link.LinkType) {
+// and `lnpm push` see the restored package the way they see an added one.
+//
+// A failure here used to be reported and not counted as a failed restore, on
+// the grounds that it cost only bookkeeping because the link on disk was
+// already in place. That was wrong in the one direction that matters: the row
+// is what tells gc the project consumes this package, so without it the store
+// entry the restored link points at reads as unreferenced and is deleted. The
+// files on disk are what make that a live consumer, not a harmless orphan. So
+// the error is returned and the restore counts as failed - the snapshot entry
+// then survives for the re-run, which is exactly what a half-restored package
+// needs.
+func recordRestoredLink(database *db.DB, cwd string, pkg *db.Package, linkType link.LinkType) error {
 	proj := &db.Project{
 		Path:           cwd,
 		Name:           getProjectName(cwd),
 		PackageManager: string(config.DetectPackageManager(cwd)),
 	}
 	if err := database.InsertProject(proj); err != nil {
-		fmt.Printf("  %s Failed to register project: %v\n", iconWarn(), err)
-		return
+		return fmt.Errorf("failed to register project: %w", err)
 	}
 
 	existingProj, err := database.GetProjectByPath(cwd)
 	if err != nil {
-		fmt.Printf("  %s Failed to get project: %v\n", iconWarn(), err)
-		return
+		return fmt.Errorf("failed to get project: %w", err)
 	}
 
 	// The link follows the default tag, which is what an unset Tag means. Nothing
@@ -326,8 +336,9 @@ func recordRestoredLink(database *db.DB, cwd string, pkg *db.Package, linkType l
 		LinkType:  string(linkType),
 	}
 	if err := database.InsertLink(dbLink); err != nil {
-		fmt.Printf("  %s Failed to record link for %s: %v\n", iconWarn(), pkg.Name, err)
+		return fmt.Errorf("failed to record the link: %w", err)
 	}
+	return nil
 }
 
 // warnIfOffTheDefaultChannel reports that a restored package is on a build the

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -547,7 +547,7 @@ func moveLinksTx(tx *bolt.Tx, fromID, toID int64, tag string) error {
 	// source as empty would leave every consumer on the version the tag moved
 	// off; treating the destination as empty would rewrite its entry from the
 	// links carried across alone, dropping the ones already there.
-	fromIDs, err := indexIDs(byPackage, itob(fromID))
+	fromIDs, err := indexIDs(byPackage, itob(fromID), "package")
 	if err != nil {
 		return err
 	}
@@ -555,7 +555,7 @@ func moveLinksTx(tx *bolt.Tx, fromID, toID int64, tag string) error {
 		return nil
 	}
 
-	toIDs, err := indexIDs(byPackage, itob(toID))
+	toIDs, err := indexIDs(byPackage, itob(toID), "package")
 	if err != nil {
 		return err
 	}
@@ -621,14 +621,18 @@ func moveLinksTx(tx *bolt.Tx, fromID, toID int64, tag string) error {
 // one is reported rather than absorbed. The opposite direction is left alone -
 // ListPackages still skips a package record it cannot parse, which leaks a store
 // entry instead of deleting one.
-func indexIDs(b *bolt.Bucket, key []byte) ([]int64, error) {
+//
+// owner names what the key counts as - "package" or "project" - because the same
+// number means either depending on which index is being read, and an error that
+// says only "key 3" tells the reader nothing about where to look.
+func indexIDs(b *bolt.Bucket, key []byte, owner string) ([]int64, error) {
 	data := b.Get(key)
 	if data == nil {
 		return nil, nil
 	}
 	var ids []int64
 	if err := json.Unmarshal(data, &ids); err != nil {
-		return nil, fmt.Errorf("link index entry for key %d is unreadable: %w", btoi(key), err)
+		return nil, fmt.Errorf("the link index for %s %d will not parse: %w; run lnpm doctor to see what else the store disagrees about", owner, btoi(key), err)
 	}
 	return ids, nil
 }
@@ -1160,10 +1164,19 @@ func (db *DB) InsertLink(link *Link) error {
 		// project would then hold two answers to which version it consumes -
 		// the state the doc comment above says everything downstream assumes
 		// away.
-		existingIDs, err := indexIDs(byProject, itob(link.ProjectID))
+		existingIDs, err := indexIDs(byProject, itob(link.ProjectID), "project")
 		if err != nil {
 			return err
 		}
+		// The two skips below are deliberate, and they are not the tolerance
+		// #329 removed. ADR-0001's test is direction: this walk's only
+		// destructive act is deleting the row a link supersedes, so skipping a
+		// row it cannot read declines to delete rather than deleting on a
+		// guess. Erroring instead would lock the project out of add entirely -
+		// one damaged row would refuse every later package, unrelated ones
+		// included, and nothing repairs links_by_project. The damage is still
+		// not ignored: gc reads the same rows through GetLinksForPackage, which
+		// now refuses them, so nothing is deleted on their strength either way.
 		var updated bool
 		for _, id := range existingIDs {
 			data := links.Get(itob(id))
@@ -1223,29 +1236,43 @@ func (db *DB) InsertLink(link *Link) error {
 			return err
 		}
 
-		// Update indexes (store as JSON arrays of IDs)
+		// Update indexes (store as JSON arrays of IDs).
+		//
+		// Both entries are read through indexIDs, so an entry that will not
+		// parse fails the insert rather than being appended to. Decoding into a
+		// nil slice and writing it back replaced the entry with a one-element
+		// array, discarding every link ID it named - and those IDs are the
+		// consumers gc reads to decide what to delete. Losing them there is the
+		// same widening of a destructive set as losing them on the read path,
+		// which is what #329 is about, so ADR-0001 decides it the same way.
 		pkgKey := itob(link.PackageID)
 		projKey := itob(link.ProjectID)
 
 		// Add to package index
-		var pkgLinks []int64
-		if existing := byPackage.Get(pkgKey); existing != nil {
-			_ = json.Unmarshal(existing, &pkgLinks)
+		pkgLinks, err := indexIDs(byPackage, pkgKey, "package")
+		if err != nil {
+			return err
 		}
 		pkgLinks = append(pkgLinks, id)
-		pkgLinksData, _ := json.Marshal(pkgLinks)
-		_ = byPackage.Put(pkgKey, pkgLinksData)
+		pkgLinksData, err := json.Marshal(pkgLinks)
+		if err != nil {
+			return err
+		}
+		if err := byPackage.Put(pkgKey, pkgLinksData); err != nil {
+			return err
+		}
 
 		// Add to project index
-		var projLinks []int64
-		if existing := byProject.Get(projKey); existing != nil {
-			_ = json.Unmarshal(existing, &projLinks)
+		projLinks, err := indexIDs(byProject, projKey, "project")
+		if err != nil {
+			return err
 		}
 		projLinks = append(projLinks, id)
-		projLinksData, _ := json.Marshal(projLinks)
-		_ = byProject.Put(projKey, projLinksData)
-
-		return nil
+		projLinksData, err := json.Marshal(projLinks)
+		if err != nil {
+			return err
+		}
+		return byProject.Put(projKey, projLinksData)
 	})
 }
 
@@ -1261,11 +1288,18 @@ func (db *DB) InsertLink(link *Link) error {
 // swallowed error that widens a destructive set is a bug.
 //
 // The index entry naming no row is included even though no flow lnpm has
-// produces one. Every path that deletes a link row - moveLinksTx, DeletePackage,
-// deleteLinkRowTx, DeleteLink - scrubs the ID from both indexes inside the same
-// bolt transaction, and bolt commits a transaction whole or not at all, so the
-// state is unreachable except through damage to the file. Tolerating it would be
-// tolerating exactly the class of damage the other two cases refuse.
+// produces one here. The claim needed is only about links_by_package, the index
+// this reads: DeletePackage deletes that key outright, moveLinksTx rewrites it
+// from the IDs that stay, and deleteLinkRowTx and DeleteLink scrub the ID from
+// it - each inside one bolt transaction, which commits whole or not at all. So a
+// dangling ID in this index is unreachable except through damage to the file,
+// and tolerating it would be tolerating the class of damage the other two cases
+// refuse.
+//
+// Deliberately no wider a claim than that. DeletePackage does not hold the same
+// line on links_by_project: an entry there it cannot parse leaves the rows
+// undeleted and the index unscrubbed while the links_by_package key goes anyway.
+// That, and the readers still swallowing this damage, are #355.
 //
 // Returning the links read so far alongside the error was rejected: a caller
 // that checks the error is no better off for them, and one that does not gets a
@@ -1279,7 +1313,7 @@ func (db *DB) GetLinksForPackage(packageID int64) ([]*Link, error) {
 		links := tx.Bucket(bucketLinks)
 		byPackage := tx.Bucket(bucketLinksByPackage)
 
-		linkIDs, err := indexIDs(byPackage, itob(packageID))
+		linkIDs, err := indexIDs(byPackage, itob(packageID), "package")
 		if err != nil {
 			return err
 		}
@@ -1287,11 +1321,11 @@ func (db *DB) GetLinksForPackage(packageID int64) ([]*Link, error) {
 		for _, id := range linkIDs {
 			linkData := links.Get(itob(id))
 			if linkData == nil {
-				return fmt.Errorf("link index names link %d, which is not in the database", id)
+				return fmt.Errorf("the link index for package %d names link %d, which the database does not hold; run lnpm doctor to see what else the store disagrees about", packageID, id)
 			}
 			var link Link
 			if err := json.Unmarshal(linkData, &link); err != nil {
-				return fmt.Errorf("link %d is unreadable: %w", id, err)
+				return fmt.Errorf("link %d, which package %d is linked by, will not parse: %w; run lnpm doctor to see what else the store disagrees about", id, packageID, err)
 			}
 			result = append(result, &link)
 		}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -542,12 +542,23 @@ func moveLinksTx(tx *bolt.Tx, fromID, toID int64, tag string) error {
 	byPackage := tx.Bucket(bucketLinksByPackage)
 	byProject := tx.Bucket(bucketLinksByProject)
 
-	fromIDs := indexIDs(byPackage, itob(fromID))
+	// Both index entries are read before anything moves, and an unreadable one
+	// abandons the tag move rather than being treated as empty. Treating the
+	// source as empty would leave every consumer on the version the tag moved
+	// off; treating the destination as empty would rewrite its entry from the
+	// links carried across alone, dropping the ones already there.
+	fromIDs, err := indexIDs(byPackage, itob(fromID))
+	if err != nil {
+		return err
+	}
 	if len(fromIDs) == 0 {
 		return nil
 	}
 
-	toIDs := indexIDs(byPackage, itob(toID))
+	toIDs, err := indexIDs(byPackage, itob(toID))
+	if err != nil {
+		return err
+	}
 	onDestination := make(map[int64]bool, len(toIDs))
 	for _, id := range toIDs {
 		if data := links.Get(itob(id)); data != nil {
@@ -598,17 +609,28 @@ func moveLinksTx(tx *bolt.Tx, fromID, toID int64, tag string) error {
 	return putIndexIDs(byPackage, itob(toID), toIDs)
 }
 
-// indexIDs reads a link index entry, which holds a JSON array of link IDs.
-func indexIDs(b *bolt.Bucket, key []byte) []int64 {
+// indexIDs reads a link index entry, which holds a JSON array of link IDs. A
+// key that is not there is not an error: it is a package or project nothing
+// links, which is the ordinary state of most of them.
+//
+// An entry that will not parse is an error, and the distinction is the whole of
+// #329. Returning no IDs for it made "this package has no consumers" and "this
+// package's consumers could not be read" the same answer, and gc acts on the
+// first by deleting the version. Per ADR-0001 the direction is what decides: a
+// swallowed error that widens what a destructive pass removes is a bug, so this
+// one is reported rather than absorbed. The opposite direction is left alone -
+// ListPackages still skips a package record it cannot parse, which leaks a store
+// entry instead of deleting one.
+func indexIDs(b *bolt.Bucket, key []byte) ([]int64, error) {
 	data := b.Get(key)
 	if data == nil {
-		return nil
+		return nil, nil
 	}
 	var ids []int64
-	if json.Unmarshal(data, &ids) != nil {
-		return nil
+	if err := json.Unmarshal(data, &ids); err != nil {
+		return nil, fmt.Errorf("link index entry for key %d is unreadable: %w", btoi(key), err)
 	}
-	return ids
+	return ids, nil
 }
 
 // putIndexIDs writes a link index entry, deleting the key when no IDs are left
@@ -1131,8 +1153,19 @@ func (db *DB) InsertLink(link *Link) error {
 
 		// indexIDs decodes into a slice of its own, so deleting rows below does
 		// not disturb this walk.
+		//
+		// An unreadable index entry refuses the insert instead of walking no
+		// rows. This walk is what keeps one row per project and package name:
+		// skipping it would leave the row this link replaces in place, and the
+		// project would then hold two answers to which version it consumes -
+		// the state the doc comment above says everything downstream assumes
+		// away.
+		existingIDs, err := indexIDs(byProject, itob(link.ProjectID))
+		if err != nil {
+			return err
+		}
 		var updated bool
-		for _, id := range indexIDs(byProject, itob(link.ProjectID)) {
+		for _, id := range existingIDs {
 			data := links.Get(itob(id))
 			if data == nil {
 				continue // Index entry naming no link row
@@ -1216,7 +1249,27 @@ func (db *DB) InsertLink(link *Link) error {
 	})
 }
 
-// GetLinksForPackage returns all links for a package
+// GetLinksForPackage returns every link a package has, and reports rather than
+// hides any it could not read.
+//
+// This is gc's reachability check, so the three ways the answer can be short - an
+// unreadable index entry, an index entry naming a row that is not there, and a
+// row that will not parse - all have to be errors. Each of them otherwise leaves
+// a consumer out of a list gc reads as "nothing is using this version", and gc
+// then deletes the store entry that project is linked to and reports success.
+// That is the whole of #329, and ADR-0001 is the rule it is decided by: a
+// swallowed error that widens a destructive set is a bug.
+//
+// The index entry naming no row is included even though no flow lnpm has
+// produces one. Every path that deletes a link row - moveLinksTx, DeletePackage,
+// deleteLinkRowTx, DeleteLink - scrubs the ID from both indexes inside the same
+// bolt transaction, and bolt commits a transaction whole or not at all, so the
+// state is unreachable except through damage to the file. Tolerating it would be
+// tolerating exactly the class of damage the other two cases refuse.
+//
+// Returning the links read so far alongside the error was rejected: a caller
+// that checks the error is no better off for them, and one that does not gets a
+// short list that looks complete, which is the bug.
 func (db *DB) GetLinksForPackage(packageID int64) ([]*Link, error) {
 	db.mu.RLock()
 	defer db.mu.RUnlock()
@@ -1226,29 +1279,29 @@ func (db *DB) GetLinksForPackage(packageID int64) ([]*Link, error) {
 		links := tx.Bucket(bucketLinks)
 		byPackage := tx.Bucket(bucketLinksByPackage)
 
-		data := byPackage.Get(itob(packageID))
-		if data == nil {
-			return nil
-		}
-
-		var linkIDs []int64
-		if err := json.Unmarshal(data, &linkIDs); err != nil {
-			return nil
+		linkIDs, err := indexIDs(byPackage, itob(packageID))
+		if err != nil {
+			return err
 		}
 
 		for _, id := range linkIDs {
 			linkData := links.Get(itob(id))
-			if linkData != nil {
-				var link Link
-				if json.Unmarshal(linkData, &link) == nil {
-					result = append(result, &link)
-				}
+			if linkData == nil {
+				return fmt.Errorf("link index names link %d, which is not in the database", id)
 			}
+			var link Link
+			if err := json.Unmarshal(linkData, &link); err != nil {
+				return fmt.Errorf("link %d is unreadable: %w", id, err)
+			}
+			result = append(result, &link)
 		}
 		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
 
-	return result, err
+	return result, nil
 }
 
 // GetLinksForProject returns all links for a project

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -471,11 +472,12 @@ func writeLinkRow(t *testing.T, d *DB, link *Link) {
 		for _, index := range []struct {
 			bucket *bolt.Bucket
 			key    []byte
+			owner  string
 		}{
-			{tx.Bucket(bucketLinksByPackage), itob(link.PackageID)},
-			{tx.Bucket(bucketLinksByProject), itob(link.ProjectID)},
+			{tx.Bucket(bucketLinksByPackage), itob(link.PackageID), "package"},
+			{tx.Bucket(bucketLinksByProject), itob(link.ProjectID), "project"},
 		} {
-			ids, err := indexIDs(index.bucket, index.key)
+			ids, err := indexIDs(index.bucket, index.key, index.owner)
 			if err != nil {
 				return err
 			}
@@ -779,6 +781,49 @@ func TestGetLinksForPackage_ErrorsOnAnIndexEntryNamingNoLinkRow(t *testing.T) {
 	}
 	if links != nil {
 		t.Errorf("GetLinksForPackage() returned %d link(s) alongside its error", len(links))
+	}
+}
+
+// TestInsertLink_DoesNotOverwriteAnIndexEntryItCannotRead pins the write half of
+// #329, which is the half that destroys rather than hides.
+//
+// The index append used to decode the existing entry into a slice, ignore the
+// failure, and write the slice back holding the one new ID. An entry that would
+// not parse was therefore replaced by a one-element array, discarding every link
+// ID it named - and those IDs are the consumers gc reads to decide what to
+// delete. Losing them on the write path costs exactly what losing them on the
+// read path costs, so ADR-0001 decides it the same way: refuse the insert and
+// leave the damaged entry for lnpm doctor to report.
+func TestInsertLink_DoesNotOverwriteAnIndexEntryItCannotRead(t *testing.T) {
+	database := openStore(t, t.TempDir())
+	pkg, _ := seedLink(t, database)
+
+	damaged := []byte("[ not ids")
+	putRaw(t, database, bucketLinksByPackage, itob(pkg.ID), damaged)
+
+	// A second project linking the same package is what reaches the append.
+	secondProject := t.TempDir()
+	if err := database.InsertProject(&Project{Path: secondProject, Name: "second"}); err != nil {
+		t.Fatalf("Failed to seed a second project: %v", err)
+	}
+	proj, err := database.GetProjectByPath(secondProject)
+	if err != nil || proj == nil {
+		t.Fatalf("Failed to read the second project back: %v", err)
+	}
+
+	if err := database.InsertLink(&Link{PackageID: pkg.ID, ProjectID: proj.ID, LinkType: "hardlink"}); err == nil {
+		t.Error("InsertLink() accepted a link for a package whose index entry it could not read")
+	}
+
+	var after []byte
+	if err := database.db.View(func(tx *bolt.Tx) error {
+		after = append(after, tx.Bucket(bucketLinksByPackage).Get(itob(pkg.ID))...)
+		return nil
+	}); err != nil {
+		t.Fatalf("Failed to read the index entry back: %v", err)
+	}
+	if !bytes.Equal(after, damaged) {
+		t.Errorf("InsertLink() rewrote an index entry it could not read: %q became %q; every link ID it named is gone", damaged, after)
 	}
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -475,7 +475,11 @@ func writeLinkRow(t *testing.T, d *DB, link *Link) {
 			{tx.Bucket(bucketLinksByPackage), itob(link.PackageID)},
 			{tx.Bucket(bucketLinksByProject), itob(link.ProjectID)},
 		} {
-			if err := putIndexIDs(index.bucket, index.key, append(indexIDs(index.bucket, index.key), id)); err != nil {
+			ids, err := indexIDs(index.bucket, index.key)
+			if err != nil {
+				return err
+			}
+			if err := putIndexIDs(index.bucket, index.key, append(ids, id)); err != nil {
 				return err
 			}
 		}
@@ -666,5 +670,130 @@ func TestGetPackageVersions_SurfacesARecordThatWillNotUnmarshal(t *testing.T) {
 
 	if _, err := database.GetPackageVersions("damaged-pkg"); err == nil {
 		t.Error("GetPackageVersions() skipped a record it could not read; a version missing from a rollback listing reads as one gc collected")
+	}
+}
+
+// --- Unreadable link data ----------------------------------------------------
+
+// seedLink records a package, a project and the link between them, and returns
+// both so a test can damage exactly one row or index entry by ID.
+func seedLink(t *testing.T, d *DB) (*Package, *Link) {
+	t.Helper()
+
+	pkg := insertVersion(t, d, "linked-pkg", "h1")
+
+	projectPath := filepath.FromSlash("/projects/consumer")
+	if err := d.InsertProject(&Project{Path: projectPath, Name: "consumer"}); err != nil {
+		t.Fatalf("Failed to insert the project: %v", err)
+	}
+	proj, err := d.GetProjectByPath(projectPath)
+	if err != nil || proj == nil {
+		t.Fatalf("Failed to read the project back: %v", err)
+	}
+
+	link := &Link{PackageID: pkg.ID, ProjectID: proj.ID, LinkType: "hardlink"}
+	if err := d.InsertLink(link); err != nil {
+		t.Fatalf("Failed to insert the link: %v", err)
+	}
+	return pkg, link
+}
+
+// putRaw writes bytes straight into a bucket, standing in for the damage a torn
+// write leaves behind.
+func putRaw(t *testing.T, d *DB, bucket, key, value []byte) {
+	t.Helper()
+
+	err := d.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(bucket).Put(key, value)
+	})
+	if err != nil {
+		t.Fatalf("Failed to write into %s: %v", bucket, err)
+	}
+}
+
+// TestGetLinksForPackage_ErrorsOnALinkRowThatWillNotUnmarshal pins the half of
+// #329 the sweep reproduced first.
+//
+// gc treats this lookup's answer as the list of projects that would break if the
+// version went away, so a row silently dropped is a consumer gc cannot see and a
+// store entry gc deletes while a project is still using it. Per ADR-0001 the
+// direction decides: this read widens a destructive set, so it fails loudly.
+func TestGetLinksForPackage_ErrorsOnALinkRowThatWillNotUnmarshal(t *testing.T) {
+	database := openStore(t, t.TempDir())
+	pkg, link := seedLink(t, database)
+
+	putRaw(t, database, bucketLinks, itob(link.ID), []byte("{ not a link"))
+
+	links, err := database.GetLinksForPackage(pkg.ID)
+	if err == nil {
+		t.Fatalf("GetLinksForPackage() returned %d link(s) and no error for a row it could not read; gc reads that as a version nothing links", len(links))
+	}
+	if links != nil {
+		t.Errorf("GetLinksForPackage() returned %d link(s) alongside its error, which a caller could mistake for the whole list", len(links))
+	}
+}
+
+// TestGetLinksForPackage_ErrorsOnAnIndexEntryThatWillNotUnmarshal pins the other
+// half the sweep reproduced: the index entry, not the row, is the damaged one.
+//
+// It is the worse of the two, because one unreadable entry hides every link the
+// package has rather than one of them.
+func TestGetLinksForPackage_ErrorsOnAnIndexEntryThatWillNotUnmarshal(t *testing.T) {
+	database := openStore(t, t.TempDir())
+	pkg, _ := seedLink(t, database)
+
+	putRaw(t, database, bucketLinksByPackage, itob(pkg.ID), []byte("[ not ids"))
+
+	links, err := database.GetLinksForPackage(pkg.ID)
+	if err == nil {
+		t.Fatalf("GetLinksForPackage() returned %d link(s) and no error for an index entry it could not read", len(links))
+	}
+	if links != nil {
+		t.Errorf("GetLinksForPackage() returned %d link(s) alongside its error", len(links))
+	}
+}
+
+// TestGetLinksForPackage_ErrorsOnAnIndexEntryNamingNoLinkRow pins the third
+// shape, which the report did not name.
+//
+// Every path that deletes a link row scrubs the ID from both indexes inside the
+// same bolt transaction - moveLinksTx, DeletePackage, deleteLinkRowTx and
+// DeleteLink all do - and bolt commits a transaction whole or not at all. So no
+// flow lnpm has leaves an index naming a row that is gone: reaching this state
+// means the file was damaged, exactly as an unparseable row does. Tolerating it
+// here would undercount the same consumers the two cases above hide.
+func TestGetLinksForPackage_ErrorsOnAnIndexEntryNamingNoLinkRow(t *testing.T) {
+	database := openStore(t, t.TempDir())
+	pkg, link := seedLink(t, database)
+
+	err := database.db.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket(bucketLinks).Delete(itob(link.ID))
+	})
+	if err != nil {
+		t.Fatalf("Failed to remove the link row: %v", err)
+	}
+
+	links, err := database.GetLinksForPackage(pkg.ID)
+	if err == nil {
+		t.Fatalf("GetLinksForPackage() returned %d link(s) and no error for an index entry naming no row", len(links))
+	}
+	if links != nil {
+		t.Errorf("GetLinksForPackage() returned %d link(s) alongside its error", len(links))
+	}
+}
+
+// TestGetLinksForPackage_ReturnsNothingForAPackageNothingLinks pins the case the
+// three above have to stay distinguishable from: a package with no consumers is
+// not damage, and gc must go on collecting it.
+func TestGetLinksForPackage_ReturnsNothingForAPackageNothingLinks(t *testing.T) {
+	database := openStore(t, t.TempDir())
+	pkg := insertVersion(t, database, "unlinked-pkg", "h1")
+
+	links, err := database.GetLinksForPackage(pkg.ID)
+	if err != nil {
+		t.Fatalf("GetLinksForPackage() error = %v for a package nothing links", err)
+	}
+	if len(links) != 0 {
+		t.Errorf("GetLinksForPackage() returned %d link(s) for a package nothing links", len(links))
 	}
 }

--- a/tests/add_test.go
+++ b/tests/add_test.go
@@ -5,9 +5,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/internal/config"
+	"github.com/pedrosousa13/lnpm/internal/db"
 	"github.com/pedrosousa13/lnpm/pkg/lockfile"
+	bolt "go.etcd.io/bbolt"
 )
 
 // TestAddVariants table-drives the core "publish then add" behaviors across the
@@ -418,4 +422,78 @@ func TestAddMultipleLeavesSucceedingPackageIntactWhenSiblingFails(t *testing.T) 
 		}
 	})
 	env.AssertSymlinkMissing(projectDir, "missing-pkg")
+}
+
+// damageLinkIndex writes bytes straight into a link index bucket of the store's
+// bbolt file, standing in for the damage a torn write leaves behind.
+//
+// lnpm's handle is closed first and left closed, because bbolt holds an
+// exclusive file lock: the command under test reopens the database itself, which
+// is also what makes the damage look exactly like damage it found on open.
+func damageLinkIndex(t *testing.T, bucket string, id int64, value []byte) {
+	t.Helper()
+
+	storePath, err := config.GetStorePath()
+	if err != nil {
+		t.Fatalf("resolve store path: %v", err)
+	}
+	db.ResetForTesting()
+
+	handle, err := bolt.Open(filepath.Join(storePath, "lnpm.db"), 0600, &bolt.Options{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("open the database directly: %v", err)
+	}
+	key := make([]byte, 8)
+	for i := 7; i >= 0; i-- {
+		key[i] = byte(id)
+		id >>= 8
+	}
+	err = handle.Update(func(tx *bolt.Tx) error {
+		return tx.Bucket([]byte(bucket)).Put(key, value)
+	})
+	if closeErr := handle.Close(); closeErr != nil {
+		t.Fatalf("close the database: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("damage %s: %v", bucket, err)
+	}
+}
+
+// TestAddMultipleFailsWhenALinkCannotBeRecorded pins the write half of #329 on
+// the multi-package path - the one that used to warn and carry on.
+//
+// The link row is what tells gc a project consumes a package. Without it the
+// store entry reads as consumed by nobody, and gc deletes what the project is
+// importing. That is the same fail-open shape #329 removed from gc's own read,
+// arriving instead through the command that should have written the row, so add
+// must not report success over it.
+//
+// The single-package path already returned this error; only the loop swallowed
+// it, printing "Added" per package and exiting zero. So the test drives
+// RunAddMultiple with two specs, which is what routes through the loop at all.
+func TestAddMultipleFailsWhenALinkCannotBeRecorded(t *testing.T) {
+	env := setupTest(t)
+
+	env.simplePkg("linked-pkg")
+	env.simplePkg("second-pkg")
+	projectDir := env.newProject("test-project")
+
+	// Register the project so there is a links_by_project entry to damage, then
+	// damage it. Nothing in lnpm produces this state; a torn write does.
+	if err := env.Database.InsertProject(&db.Project{Path: projectDir, Name: "test-project"}); err != nil {
+		t.Fatalf("Failed to register the project: %v", err)
+	}
+	proj, err := env.Database.GetProjectByPath(projectDir)
+	if err != nil || proj == nil {
+		t.Fatalf("Failed to read the project back: %v", err)
+	}
+	damageLinkIndex(t, "links_by_project", proj.ID, []byte("[ not ids"))
+
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("Failed to enter the project: %v", err)
+	}
+	err = cli.RunAddMultiple([]string{"linked-pkg", "second-pkg"}, false, false, false, false)
+	if err == nil {
+		t.Fatal("RunAddMultiple() reported success for packages whose links it could not record; gc reads those store entries as consumed by nobody and deletes them")
+	}
 }


### PR DESCRIPTION
Closes #329.

## The bug

`gc`'s orphan scan already stated the correct invariant in a comment — a read that failed is indistinguishable from a version nothing links, so carrying on would delete a version gc cannot show is unreachable — and it already checked the error the link lookup returned.

**The check was vacuous.** `GetLinksForPackage` dropped rows whose JSON would not unmarshal and index entries it could not parse, returning a nil error either way. Damaged data reached the scan as "zero links, no error", the valid-link count reached zero, the package was declared orphaned, and both the store entry and the DB row were deleted — reported as success. The sweep reproduced it: the store entry was deleted despite a live consumer link.

## The fix

`indexIDs` and `GetLinksForPackage` now distinguish "no links" from "could not read the links". A missing key stays `(nil, nil)` — a package nothing links is the ordinary state of most of them — while an entry that will not parse, a row that will not parse, and an index entry naming a row the database does not hold are all errors. gc needed no new branch; its existing abort became real.

Per the maintainer ruling recorded on the issue and ADR-0001, the direction decides: a swallowed error that widens a destructive set is a bug. The opposite direction is deliberately untouched — `ListPackages` still skips a package record it cannot parse, which leaks a store entry rather than deleting one.

## What review caught, and why there is a second commit

Making the read strict left the *write* side fail-open in the same shape, so the first commit alone would have moved the bug rather than fixed it:

- `InsertLink`'s index appends decoded the existing entry, ignored the failure, and wrote the slice back holding only the new ID — replacing an unparseable entry with a one-element array and **discarding every link ID it named**. Those are the consumers gc reads.
- `InsertLink`'s new error then reached three callers that only printed a warning: `add`'s multi-package loop, `restore`'s link recording, and `pull`'s repointing. Each carried on to report success over a project holding files with no link row — which gc reads as consumed by nobody. They now count it as a failure using the mechanism each already had.
- `restore`'s doc comment claimed a failure there "costs only bookkeeping". That was the assumption this corrects.

A claim in the new doc comment was also narrowed: it said every delete path scrubs both indexes, but `DeletePackage` does not hold that line on `links_by_project`. The claim actually needed is only about `links_by_package`, the index it reads. The rest is #355.

## Deliberate non-changes

- The two skips inside `InsertLink`'s walk stay. ADR-0001's test is direction: skipping a row it cannot read declines to delete rather than deleting on a guess, and erroring would refuse every later `add` for that project — unrelated packages included — with no repair path, while gc still refuses the same damage through `GetLinksForPackage`.
- `GetLinksForProject`, `GetProjectsForPackage`, `DeletePackage`'s own swallow and `doctor.go`'s discarded errors are **#355**, kept out to avoid colliding with the rest of the gc chain (#292, #291, #335).

## Tests

- `TestGetLinksForPackage_ErrorsOnALinkRowThatWillNotUnmarshal`, `...ErrorsOnAnIndexEntryThatWillNotUnmarshal`, `...ErrorsOnAnIndexEntryNamingNoLinkRow`
- `TestGetLinksForPackage_ReturnsNothingForAPackageNothingLinks` — keeps "no consumers" distinguishable from "unreadable"
- `TestRunGCAbortsWhenALinkRowCannotBeRead`, `TestRunGCAbortsWhenALinkIndexEntryCannotBeRead` — the sweep's two reproductions
- `TestInsertLink_DoesNotOverwriteAnIndexEntryItCannotRead` — pins the write half
- `TestAddMultipleFailsWhenALinkCannotBeRecorded` — pins the caller wiring

Two-directional revert checks pass on both commits: removing a fix fails its tests, and moving the abort after the deletion pass reproduces the original deletion verbatim.

Healthy-store gc behaviour and its reported counts are unchanged — the existing gc suite passes untouched.