### PR TITLE
fix(gc): abort when a project row cannot be read

### DIFF
--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -82,7 +82,24 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 		// Named lnk, not link, so it does not shadow the link package the
 		// temp-directory sweep below calls into.
 		for _, lnk := range links {
-			proj, _ := database.GetProjectByID(lnk.ProjectID)
+			// A failure to read the project stops the run too, and for the same
+			// reason the link read above stops it: both reasons below are
+			// statements about a project, and a read that failed establishes
+			// neither. This is the #292 half. Discarding the error left "the
+			// record would not parse" indistinguishable from "no record answers
+			// for this ID", and the link was filed as orphaned either way -
+			// which, with --fix-links, deletes it, and then leaves the version
+			// looking like one nothing consumes.
+			//
+			// The lookup returning nil with its error is what makes this guard
+			// enough on its own; before #292 it returned a zero-valued project
+			// instead, so the nil check below let damage through to os.Stat("")
+			// and on to the wrong reason. Checking the error first does not
+			// depend on that, which is why it is checked first.
+			proj, err := database.GetProjectByID(lnk.ProjectID)
+			if err != nil {
+				return fmt.Errorf("failed to read project %d, linked by %s@%s: %w", lnk.ProjectID, pkg.Name, pkg.Version, err)
+			}
 			if proj == nil {
 				linksToRemove = append(linksToRemove, linkToRemove{
 					packageID: pkg.ID,

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -87,15 +87,28 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 			// statements about a project, and a read that failed establishes
 			// neither. This is the #292 half. Discarding the error left "the
 			// record would not parse" indistinguishable from "no record answers
-			// for this ID", and the link was filed as orphaned either way -
-			// which, with --fix-links, deletes it, and then leaves the version
-			// looking like one nothing consumes.
+			// for this ID", and the link was filed as orphaned either way.
 			//
-			// The lookup returning nil with its error is what makes this guard
-			// enough on its own; before #292 it returned a zero-valued project
-			// instead, so the nil check below let damage through to os.Stat("")
-			// and on to the wrong reason. Checking the error first does not
-			// depend on that, which is why it is checked first.
+			// That is destructive on a plain gc, with no flag involved, which is
+			// the part worth being exact about. The
+			//
+			//	validLinks := len(links) - countLinksForPackage(linksToRemove, pkg.ID)
+			//
+			// below subtracts unconditionally, so a misclassified link takes the
+			// version's last consumer with it and the version is collected -
+			// store entry and database row both. fixLinks gates only the block
+			// that reports and deletes the link rows themselves. So the flagless
+			// run is the quieter of the two, not the safer one: the same package
+			// is deleted and no line naming the link is ever printed.
+			//
+			// Checking the error before the nil result is what makes this guard
+			// hold whatever the lookup returns. Before #292 it returned a
+			// non-nil project alongside the error, and what that project held
+			// depended on how the record was damaged - a syntax error decoded
+			// nothing and reached os.Stat("") and the wrong reason, while a
+			// wrong-typed value left a real Path that stat'd fine and hid the
+			// damage entirely. GetProjectByID documents both. This check needs
+			// to know about neither.
 			proj, err := database.GetProjectByID(lnk.ProjectID)
 			if err != nil {
 				return fmt.Errorf("failed to read project %d, linked by %s@%s: %w", lnk.ProjectID, pkg.Name, pkg.Version, err)

--- a/internal/cli/gc_test.go
+++ b/internal/cli/gc_test.go
@@ -608,7 +608,8 @@ func damageDatabase(t *testing.T, bucket string, key []byte, value []byte) {
 	}
 }
 
-// linkKey encodes a link or package ID the way the link buckets key their rows.
+// linkKey encodes a record ID the way every bucket keyed by one keys its rows -
+// the link buckets it was written for, and the projects bucket alike.
 func linkKey(id int64) []byte {
 	key := make([]byte, 8)
 	binary.BigEndian.PutUint64(key, uint64(id))
@@ -713,8 +714,15 @@ func seededProjectID(t *testing.T, database *db.DB) int64 {
 	return links[0].ProjectID
 }
 
-// assertLinkSurvived fails unless the package still has the link the seed made.
-func assertLinkSurvived(t *testing.T, entry string) {
+// assertLinkSurvived fails unless the seeded package still has its live link.
+//
+// It is kept apart from assertGCDeletedNothing, which the tests below call
+// alongside it, because the two assert different rows: that one is about the
+// package's store entry and database row, this one about the link row, and
+// --fix-links deletes link rows on a pass of its own. Keeping them separate is
+// what lets the dangling-link test assert that gc removed one link and kept the
+// other, which a merged helper could not express.
+func assertLinkSurvived(t *testing.T) {
 	t.Helper()
 
 	database, err := db.GetDB()
@@ -730,33 +738,20 @@ func assertLinkSurvived(t *testing.T, entry string) {
 		t.Fatalf("read links back: %v", err)
 	}
 	if len(links) != 1 {
-		t.Errorf("gc removed the link of %s on a project read it could not complete, %d link(s) left", entry, len(links))
+		t.Errorf("gc removed the live link of linked-pkg@1.0.0, %d link(s) left", len(links))
 	}
 }
 
-// TestRunGCAbortsWhenAProjectRowCannotBeRead pins #292.
-//
-// The orphan scan discarded the error from the project lookup and classified on
-// a nil result, so a project record that would not parse was indistinguishable
-// from a project that had gone away. Two things followed, and the second is the
-// one that deletes: the link was reported under a reason gc had not established,
-// and it was then counted out of the package's live links, which left the
-// version looking like one nothing consumes.
-//
-// The run is given --fix-links deliberately: that is the flag that makes the
-// misclassification destructive, so the test drives the path a user's data
-// actually travels rather than the reporting half alone.
-func TestRunGCAbortsWhenAProjectRowCannotBeRead(t *testing.T) {
-	storeRoot, database := newGCStore(t)
-	entry, _ := seedCollectableLink(t, database, storeRoot)
-	projectID := seededProjectID(t, database)
-
-	damageDatabase(t, "projects", linkKey(projectID), []byte("{ not a project"))
+// assertAbortedOnProject runs gc over a store whose project record is damaged
+// and fails unless the run aborted naming projectID, reported nothing as
+// orphaned, and left the package and its link where they were.
+func assertAbortedOnProject(t *testing.T, entry string, projectID int64, fixLinks bool) {
+	t.Helper()
 
 	out := captureStdout(t, func() {
-		err := RunGC(false, "", true, true)
+		err := RunGC(false, "", fixLinks, true)
 		if err == nil {
-			t.Fatal("RunGC() returned no error for a project row it could not read")
+			t.Fatal("RunGC() returned no error for a project record it could not read")
 		}
 		if !strings.Contains(err.Error(), fmt.Sprintf("%d", projectID)) {
 			t.Errorf("RunGC() error = %v, want it to name project %d", err, projectID)
@@ -767,7 +762,64 @@ func TestRunGCAbortsWhenAProjectRowCannotBeRead(t *testing.T) {
 		t.Errorf("gc called something orphaned on a project it could not read, output was:\n%s", out)
 	}
 	assertGCDeletedNothing(t, entry)
-	assertLinkSurvived(t, entry)
+	assertLinkSurvived(t)
+}
+
+// TestRunGCAbortsWhenAProjectRowCannotBeRead pins #292 on a plain run, with no
+// flag set, because that is the run the misclassification hurt most.
+//
+// The orphan scan discarded the error from the project lookup and classified on
+// a nil result, so a record that would not parse was indistinguishable from a
+// project that had gone away. The link was filed as orphaned, and the validLinks
+// subtraction in the scan takes it off the version's consumer count
+// unconditionally - fixLinks gates only the block that reports and deletes the
+// link rows. So without the flag the version was still collected and its store
+// entry still removed, and because the reporting is behind the flag, no line
+// naming the link was printed: the same loss with nothing said about it.
+func TestRunGCAbortsWhenAProjectRowCannotBeRead(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	entry, _ := seedCollectableLink(t, database, storeRoot)
+	projectID := seededProjectID(t, database)
+
+	damageDatabase(t, "projects", linkKey(projectID), []byte("{ not a project"))
+
+	assertAbortedOnProject(t, entry, projectID, false)
+}
+
+// TestRunGCAbortsWhenAProjectRowCannotBeReadWithFixLinks is the same damage with
+// --fix-links, which adds the deletion of the link row to what the plain run
+// already destroyed.
+func TestRunGCAbortsWhenAProjectRowCannotBeReadWithFixLinks(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	entry, _ := seedCollectableLink(t, database, storeRoot)
+	projectID := seededProjectID(t, database)
+
+	damageDatabase(t, "projects", linkKey(projectID), []byte("{ not a project"))
+
+	assertAbortedOnProject(t, entry, projectID, true)
+}
+
+// TestRunGCAbortsWhenAProjectRowHoldsAWrongTypedValue drives the other damage
+// shape, which failed in the opposite direction and so is not covered by the
+// two above.
+//
+// json.Unmarshal validates a document before decoding any of it, so the syntax
+// error those tests use decodes nothing and leaves Path empty. A document that
+// parses but holds a value of the wrong type decodes up to the mismatch and
+// carries on, so Path survives - and pre-fix gc stat'd that real directory,
+// judged the link healthy and swept straight past the damage. Nothing was
+// deleted, which is why it is not the shape ADR-0001 calls a bug, but nothing
+// was reported either, and a record gc cannot read is not one it may vouch for.
+func TestRunGCAbortsWhenAProjectRowHoldsAWrongTypedValue(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	entry, _ := seedCollectableLink(t, database, storeRoot)
+	projectID := seededProjectID(t, database)
+
+	// A real directory in a record that will not decode: name takes a string.
+	damaged := fmt.Sprintf(`{"id":%d,"path":%q,"name":123}`, projectID, filepath.ToSlash(t.TempDir()))
+	damageDatabase(t, "projects", linkKey(projectID), []byte(damaged))
+
+	assertAbortedOnProject(t, entry, projectID, false)
 }
 
 // TestRunGCReportsALinkToAMissingProjectAsOrphaned is the other side of the same
@@ -808,5 +860,5 @@ func TestRunGCReportsALinkToAMissingProjectAsOrphaned(t *testing.T) {
 		t.Errorf("gc collected a package a live link still names, output was:\n%s", out)
 	}
 	assertGCDeletedNothing(t, entry)
-	assertLinkSurvived(t, entry)
+	assertLinkSurvived(t)
 }

--- a/internal/cli/gc_test.go
+++ b/internal/cli/gc_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/binary"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -692,4 +693,120 @@ func TestRunGCAbortsWhenALinkIndexEntryCannotBeRead(t *testing.T) {
 		t.Errorf("gc called a package orphaned on an index entry it could not read, output was:\n%s", out)
 	}
 	assertGCDeletedNothing(t, entry)
+}
+
+// --- Unreadable projects -----------------------------------------------------
+
+// seededProjectID returns the ID of the project seedCollectableLink linked the
+// package into, read back through the same lookups gc uses.
+func seededProjectID(t *testing.T, database *db.DB) int64 {
+	t.Helper()
+
+	packages, err := database.ListPackages()
+	if err != nil || len(packages) != 1 {
+		t.Fatalf("list packages: %v (%d found)", err, len(packages))
+	}
+	links, err := database.GetLinksForPackage(packages[0].ID)
+	if err != nil || len(links) != 1 {
+		t.Fatalf("read the seeded link: %v (%d found)", err, len(links))
+	}
+	return links[0].ProjectID
+}
+
+// assertLinkSurvived fails unless the package still has the link the seed made.
+func assertLinkSurvived(t *testing.T, entry string) {
+	t.Helper()
+
+	database, err := db.GetDB()
+	if err != nil {
+		t.Fatalf("reopen database: %v", err)
+	}
+	packages, err := database.ListPackages()
+	if err != nil || len(packages) != 1 {
+		t.Fatalf("list packages: %v (%d found)", err, len(packages))
+	}
+	links, err := database.GetLinksForPackage(packages[0].ID)
+	if err != nil {
+		t.Fatalf("read links back: %v", err)
+	}
+	if len(links) != 1 {
+		t.Errorf("gc removed the link of %s on a project read it could not complete, %d link(s) left", entry, len(links))
+	}
+}
+
+// TestRunGCAbortsWhenAProjectRowCannotBeRead pins #292.
+//
+// The orphan scan discarded the error from the project lookup and classified on
+// a nil result, so a project record that would not parse was indistinguishable
+// from a project that had gone away. Two things followed, and the second is the
+// one that deletes: the link was reported under a reason gc had not established,
+// and it was then counted out of the package's live links, which left the
+// version looking like one nothing consumes.
+//
+// The run is given --fix-links deliberately: that is the flag that makes the
+// misclassification destructive, so the test drives the path a user's data
+// actually travels rather than the reporting half alone.
+func TestRunGCAbortsWhenAProjectRowCannotBeRead(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	entry, _ := seedCollectableLink(t, database, storeRoot)
+	projectID := seededProjectID(t, database)
+
+	damageDatabase(t, "projects", linkKey(projectID), []byte("{ not a project"))
+
+	out := captureStdout(t, func() {
+		err := RunGC(false, "", true, true)
+		if err == nil {
+			t.Fatal("RunGC() returned no error for a project row it could not read")
+		}
+		if !strings.Contains(err.Error(), fmt.Sprintf("%d", projectID)) {
+			t.Errorf("RunGC() error = %v, want it to name project %d", err, projectID)
+		}
+	})
+
+	if strings.Contains(out, "orphaned") {
+		t.Errorf("gc called something orphaned on a project it could not read, output was:\n%s", out)
+	}
+	assertGCDeletedNothing(t, entry)
+	assertLinkSurvived(t, entry)
+}
+
+// TestRunGCReportsALinkToAMissingProjectAsOrphaned is the other side of the same
+// branch, and the reason the fix is an error check rather than a wider guard.
+//
+// A lookup that succeeds and finds no record has established what the reason
+// string says, so that link stays orphaned and stays removable. The package
+// keeps its other link and so is not collected, which is what separates this
+// from the abort above.
+func TestRunGCReportsALinkToAMissingProjectAsOrphaned(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	entry, _ := seedCollectableLink(t, database, storeRoot)
+
+	packages, err := database.ListPackages()
+	if err != nil || len(packages) != 1 {
+		t.Fatalf("list packages: %v (%d found)", err, len(packages))
+	}
+	// A link naming a project ID no record answers for. InsertLink keeps one row
+	// per project and package name, so this adds a row rather than replacing the
+	// live one.
+	if err := database.InsertLink(&db.Link{PackageID: packages[0].ID, ProjectID: 4242, LinkType: "hardlink"}); err != nil {
+		t.Fatalf("insert the dangling link: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := RunGC(false, "", true, true); err != nil {
+			t.Fatalf("RunGC() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "project not found in database") {
+		t.Errorf("gc did not report the dangling link under its own reason, output was:\n%s", out)
+	}
+	if !strings.Contains(out, "Found 1 orphaned link(s)") {
+		t.Errorf("gc did not report exactly one orphaned link, output was:\n%s", out)
+	}
+	if strings.Contains(out, "orphaned package") {
+		t.Errorf("gc collected a package a live link still names, output was:\n%s", out)
+	}
+	assertGCDeletedNothing(t, entry)
+	assertLinkSurvived(t, entry)
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1013,7 +1013,24 @@ func removeIDFromIndex(b *bolt.Bucket, key []byte, id int64) {
 	}
 }
 
-// GetProjectByID returns a project by its ID, or nil if not found.
+// GetProjectByID returns a project by its ID, or nil if not found. An ID no
+// record answers for is not an error: gc classifies a link naming one as
+// orphaned and removes it, which is the repair --fix-links exists for.
+//
+// A record that will not parse is an error, and nothing is returned with it.
+// That second half is #292. The lookup used to allocate the project before
+// unmarshalling into it, so damage came back as a non-nil project with every
+// field zero alongside the error - and its callers check the project, not the
+// error. gc's orphan scan then read Path "", found no directory there, and
+// filed the link under "project directory no longer exists": a reason it had not
+// established, with no path to print, on a project that may well still be there.
+// Counting that link out of the version's live links is what made it
+// destructive, since a version nothing links is one gc collects.
+//
+// Returning nil follows what #329 settled for GetLinksForPackage: a failed read
+// hands back nothing a caller can mistake for an answer. Per ADR-0001 the
+// direction decides, and both halves of that misclassification widen what a
+// destructive pass removes.
 func (db *DB) GetProjectByID(id int64) (*Project, error) {
 	db.mu.RLock()
 	defer db.mu.RUnlock()
@@ -1024,11 +1041,18 @@ func (db *DB) GetProjectByID(id int64) (*Project, error) {
 		if data == nil {
 			return nil
 		}
-		proj = &Project{}
-		return json.Unmarshal(data, proj)
+		var found Project
+		if err := json.Unmarshal(data, &found); err != nil {
+			return fmt.Errorf("the record of project %d will not parse: %w; run lnpm doctor to see what else the store disagrees about", id, err)
+		}
+		proj = &found
+		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
 
-	return proj, err
+	return proj, nil
 }
 
 // --- Project operations ---

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1019,18 +1019,42 @@ func removeIDFromIndex(b *bolt.Bucket, key []byte, id int64) {
 //
 // A record that will not parse is an error, and nothing is returned with it.
 // That second half is #292. The lookup used to allocate the project before
-// unmarshalling into it, so damage came back as a non-nil project with every
-// field zero alongside the error - and its callers check the project, not the
-// error. gc's orphan scan then read Path "", found no directory there, and
-// filed the link under "project directory no longer exists": a reason it had not
-// established, with no path to print, on a project that may well still be there.
-// Counting that link out of the version's live links is what made it
-// destructive, since a version nothing links is one gc collects.
+// unmarshalling into it, so damage came back as a non-nil project alongside the
+// error - and its callers check the project, not the error.
+//
+// What that project held depended on how the record was damaged, and the two
+// shapes failed in opposite directions. json.Unmarshal validates the whole
+// document before decoding any of it, so a syntax error - a truncated write, a
+// corrupted byte - decodes nothing and leaves every field zero; gc then read
+// Path "", found no directory at "", and filed the link under "project
+// directory no longer exists". A document that is valid JSON but holds a value
+// of the wrong type decodes normally up to the mismatch and carries on past it,
+// so any prefix of the fields can be populated - including a Path that is real
+// and still on disk. gc then stat'd a live directory, judged the link healthy,
+// and the damage was invisible rather than misclassified. Both were verified
+// against this struct rather than reasoned about.
 //
 // Returning nil follows what #329 settled for GetLinksForPackage: a failed read
-// hands back nothing a caller can mistake for an answer. Per ADR-0001 the
-// direction decides, and both halves of that misclassification widen what a
-// destructive pass removes.
+// hands back nothing a caller can mistake for an answer, and it covers both
+// shapes without the caller having to know which one it has. Per ADR-0001 the
+// direction decides, and the first shape widens what a destructive pass removes.
+//
+// This changes what a caller that discards the error sees, which is a real
+// behaviour change and not only a tightening. doctor.go's orphaned-link check is
+// the one such caller, and on the second shape above its count goes from 0 to 1:
+// it used to see a healthy project with a real path, and now sees no project at
+// all. Counting a damaged record as something to look at is the better answer,
+// but it is a change, and doctor's discarded error is tracked in #355.
+//
+// The error deliberately does not point at lnpm doctor, though the sibling
+// message in indexIDs does. There the pointer is honest; here doctor discards
+// this very error (#355), reports the link as orphaned and advises gc
+// --fix-links, which is the command that just aborted - so the pointer would
+// route the user in a circle. #355 can add it back once doctor can honour it.
+//
+// GetProjectByPath has the identical allocate-then-unmarshal shape and is left
+// alone here, to keep this change on the gc path; retreat.go discards its error
+// the same way. Both are #355.
 func (db *DB) GetProjectByID(id int64) (*Project, error) {
 	db.mu.RLock()
 	defer db.mu.RUnlock()
@@ -1043,7 +1067,7 @@ func (db *DB) GetProjectByID(id int64) (*Project, error) {
 		}
 		var found Project
 		if err := json.Unmarshal(data, &found); err != nil {
-			return fmt.Errorf("the record of project %d will not parse: %w; run lnpm doctor to see what else the store disagrees about", id, err)
+			return fmt.Errorf("the record of project %d will not parse: %w", id, err)
 		}
 		proj = &found
 		return nil

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -840,5 +841,66 @@ func TestGetLinksForPackage_ReturnsNothingForAPackageNothingLinks(t *testing.T) 
 	}
 	if len(links) != 0 {
 		t.Errorf("GetLinksForPackage() returned %d link(s) for a package nothing links", len(links))
+	}
+}
+
+// --- Unreadable project records ----------------------------------------------
+
+// seedProject records one project and returns it with its assigned ID.
+func seedProject(t *testing.T, d *DB) *Project {
+	t.Helper()
+
+	projectPath := filepath.FromSlash("/projects/consumer")
+	if err := d.InsertProject(&Project{Path: projectPath, Name: "consumer"}); err != nil {
+		t.Fatalf("Failed to insert the project: %v", err)
+	}
+	proj, err := d.GetProjectByPath(projectPath)
+	if err != nil || proj == nil {
+		t.Fatalf("Failed to read the project back: %v", err)
+	}
+	return proj
+}
+
+// TestGetProjectByID_ReturnsNoProjectWhenTheRecordWillNotUnmarshal pins the half
+// of #292 that lives in this method rather than in gc.
+//
+// The lookup used to allocate the project before unmarshalling into it, so a
+// record that would not parse came back as a non-nil project with every field
+// zero, alongside the error. A caller checking the project instead of the error
+// therefore got a project whose Path was empty and went on to use it, which is
+// the one shape a nil result would have stopped. Returning nil with the error
+// follows what #329 settled for GetLinksForPackage: a failed read hands back
+// nothing that can be mistaken for an answer.
+func TestGetProjectByID_ReturnsNoProjectWhenTheRecordWillNotUnmarshal(t *testing.T) {
+	database := openStore(t, t.TempDir())
+	proj := seedProject(t, database)
+
+	putRaw(t, database, bucketProjects, itob(proj.ID), []byte("{ not a project"))
+
+	got, err := database.GetProjectByID(proj.ID)
+	if err == nil {
+		t.Fatal("GetProjectByID() returned no error for a record it could not read")
+	}
+	if got != nil {
+		t.Errorf("GetProjectByID() returned a project with Path %q alongside its error; a caller reading the project instead of the error cannot tell that apart from a project that is there", got.Path)
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("%d", proj.ID)) {
+		t.Errorf("GetProjectByID() error = %v, want it to name project %d", err, proj.ID)
+	}
+}
+
+// TestGetProjectByID_ReturnsNothingForAnIDNoRecordAnswers pins the case the one
+// above has to stay distinguishable from: an ID with no record is not damage.
+// gc classifies a link naming one as orphaned and removes it, so turning this
+// into an error would refuse the repair the --fix-links flag exists for.
+func TestGetProjectByID_ReturnsNothingForAnIDNoRecordAnswers(t *testing.T) {
+	database := openStore(t, t.TempDir())
+
+	proj, err := database.GetProjectByID(4242)
+	if err != nil {
+		t.Fatalf("GetProjectByID() error = %v for an ID no record answers", err)
+	}
+	if proj != nil {
+		t.Errorf("GetProjectByID() returned a project for an ID no record answers: %+v", proj)
 	}
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -684,15 +684,7 @@ func seedLink(t *testing.T, d *DB) (*Package, *Link) {
 	t.Helper()
 
 	pkg := insertVersion(t, d, "linked-pkg", "h1")
-
-	projectPath := filepath.FromSlash("/projects/consumer")
-	if err := d.InsertProject(&Project{Path: projectPath, Name: "consumer"}); err != nil {
-		t.Fatalf("Failed to insert the project: %v", err)
-	}
-	proj, err := d.GetProjectByPath(projectPath)
-	if err != nil || proj == nil {
-		t.Fatalf("Failed to read the project back: %v", err)
-	}
+	proj := seedProject(t, d)
 
 	link := &Link{PackageID: pkg.ID, ProjectID: proj.ID, LinkType: "hardlink"}
 	if err := d.InsertLink(link); err != nil {
@@ -861,17 +853,19 @@ func seedProject(t *testing.T, d *DB) *Project {
 	return proj
 }
 
-// TestGetProjectByID_ReturnsNoProjectWhenTheRecordWillNotUnmarshal pins the half
-// of #292 that lives in this method rather than in gc.
+// TestGetProjectByID_ReturnsNoProjectWhenTheRecordWillNotParse pins the half of
+// #292 that lives in this method rather than in gc, on a record that is not
+// valid JSON at all.
 //
 // The lookup used to allocate the project before unmarshalling into it, so a
-// record that would not parse came back as a non-nil project with every field
-// zero, alongside the error. A caller checking the project instead of the error
-// therefore got a project whose Path was empty and went on to use it, which is
-// the one shape a nil result would have stopped. Returning nil with the error
-// follows what #329 settled for GetLinksForPackage: a failed read hands back
-// nothing that can be mistaken for an answer.
-func TestGetProjectByID_ReturnsNoProjectWhenTheRecordWillNotUnmarshal(t *testing.T) {
+// record it could not read came back as a non-nil project alongside the error,
+// and its callers check the project rather than the error. json.Unmarshal
+// validates a document before decoding any of it, so this shape decoded nothing
+// and handed back a project whose Path was empty - which gc went on to stat.
+// Returning nil with the error follows what #329 settled for
+// GetLinksForPackage: a failed read hands back nothing that can be mistaken for
+// an answer.
+func TestGetProjectByID_ReturnsNoProjectWhenTheRecordWillNotParse(t *testing.T) {
 	database := openStore(t, t.TempDir())
 	proj := seedProject(t, database)
 
@@ -886,6 +880,36 @@ func TestGetProjectByID_ReturnsNoProjectWhenTheRecordWillNotUnmarshal(t *testing
 	}
 	if !strings.Contains(err.Error(), fmt.Sprintf("%d", proj.ID)) {
 		t.Errorf("GetProjectByID() error = %v, want it to name project %d", err, proj.ID)
+	}
+}
+
+// TestGetProjectByID_ReturnsNoProjectWhenAValueHasTheWrongType pins the other
+// damage shape, which the test above does not reach and which failed in the
+// opposite direction.
+//
+// A document that is valid JSON but holds a value of the wrong type is decoded
+// normally up to the mismatch and decoding continues past it, so any prefix of
+// the fields can survive - here Path does. Pre-fix that came back as a non-nil
+// project carrying a real path, indistinguishable from a healthy record, and gc
+// stat'd the directory, found it and swept past. So this shape hid damage rather
+// than inventing an orphan, which is why the all-zero case is one shape and not
+// the shape. Both end at the same rule: a record that will not read is not a
+// project, whatever decoded before the failure.
+func TestGetProjectByID_ReturnsNoProjectWhenAValueHasTheWrongType(t *testing.T) {
+	database := openStore(t, t.TempDir())
+	proj := seedProject(t, database)
+
+	// name takes a string, so this parses as JSON and then fails to decode -
+	// after path has already been set.
+	putRaw(t, database, bucketProjects, itob(proj.ID),
+		fmt.Appendf(nil, `{"id":%d,"path":%q,"name":123}`, proj.ID, proj.Path))
+
+	got, err := database.GetProjectByID(proj.ID)
+	if err == nil {
+		t.Fatal("GetProjectByID() returned no error for a record whose value has the wrong type")
+	}
+	if got != nil {
+		t.Errorf("GetProjectByID() returned a project with Path %q alongside its error; that path is real, so a caller reading the project cannot tell the record is damaged at all", got.Path)
 	}
 }
 


### PR DESCRIPTION
Closes #292.

## The bug

`gc`'s orphan scan discarded the error from its project lookup and classified on the nil result:

```go
proj, _ := database.GetProjectByID(lnk.ProjectID)
if proj == nil { /* "project not found in database" */ }
```

A failure to *read* a project was therefore indistinguishable from the project genuinely not existing, and the link was filed as orphaned either way — a statement the code had not established. This is fail-open in the classification feeding a destructive command, which ADR-0001 puts on the bug side of its line.

Note the issue body is stale: it also quotes the link read, which #329 already fixed. The Agent Brief carries that correction.

## Two failure shapes, not one

`GetProjectByID` allocated the project *before* unmarshalling into it, so damage came back as a non-nil project alongside the error — and what that project held depended on how the record was damaged. The two fail in **opposite** directions:

- **Syntax damage** (truncated write, corrupted byte) — `json.Unmarshal` validates the whole document before decoding any of it, so nothing decodes and every field is zero. `gc` read `Path ""`, found no directory there, and filed the link under *"project directory no longer exists"* with a blank path.
- **A wrong-typed value** — valid JSON, decodes normally up to the mismatch, so any prefix of the fields can be populated, **including a real `Path` still on disk**. `gc` stat'd a live directory, judged the link healthy, and the damage was invisible rather than misclassified.

Both were verified against the struct, not reasoned about.

## The fix

`GetProjectByID` returns `(nil, err)` on a record that will not parse, following what #329 settled for the link read: a failed read hands back nothing a caller can mistake for an answer, and it covers both shapes without the caller having to know which one it has. An ID no record answers for stays `(nil, nil)` — that is a real orphan and the repair `--fix-links` exists for.

`gc` checks the error **before** the nil result, so the guard holds whatever the lookup returns.

## This is destructive without `--fix-links`

Worth being exact, because the first draft of this change got it wrong. `validLinks := len(links) - countLinksForPackage(...)` subtracts **unconditionally**; `fixLinks` gates only the block that reports and deletes the link rows themselves. So on a plain `gc` a misclassified link takes the version's last consumer with it and the version is collected — store entry and database row — with no line naming the link ever printed. The flagless run is the quieter of the two, not the safer one.

## Behaviour change worth knowing

`doctor` discards this same error (#355). On the wrong-typed shape its orphaned-link count goes **0 → 1**: it used to see a healthy project with a real path, and now sees no project at all. Counting a damaged record as something to look at is the better answer, but it is a change.

The error deliberately does **not** point at `lnpm doctor`, though the sibling message in `indexIDs` does — here doctor discards this very error, reports the link as orphaned and advises `gc --fix-links`, which is the command that just aborted. #355 can add the pointer back once doctor can honour it.

`GetProjectByPath` has the identical allocate-then-unmarshal shape and is left alone to keep this change on the gc path. Also #355.

## Tests

- `TestRunGCAbortsWhenAProjectRowCannotBeRead` — **flagless** `gc`, the path most users take
- `TestRunGCAbortsWhenAProjectRowCannotBeReadWithFixLinks`
- `TestRunGCAbortsWhenAProjectRowHoldsAWrongTypedValue` — a real path in a record that will not decode
- `TestRunGCReportsALinkToAMissingProjectAsOrphaned` — the legitimate repair still works, reason string unchanged
- `TestGetProjectByID_ReturnsNoProjectWhenTheRecordWillNotParse`, `…WhenAValueHasTheWrongType`, `…ForAnIDNoRecordAnswers`

Revert checks run in four directions: fix removed entirely; source fix only; call-site check only; abort moved after the deletion pass. Healthy-store `gc` behaviour and reported counts are unchanged — the existing gc suite passes untouched and the test diff is purely additive.