### PR TITLE
fix(gc): confirm before deleting orphaned links and report what was removed

### DIFF
--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -286,31 +286,43 @@ func pinnedByTag(tags map[string]string, hash string) bool {
 // removeOrphanedLinks deletes the database row of each orphaned link and reports
 // how many rows it actually removed.
 //
-// It counts successes rather than candidates, which is the rule #233 set for the
-// two blocks below: gc must not claim what it did not reclaim. The count printed
-// here used to be len(links), and the error was discarded on the way, so a run
-// where every delete failed printed a clean success and the rows it had left
-// behind were never named.
-//
-// The summary is skipped entirely when nothing was removed, which is where this
-// differs from removePackages and reapTempDirs - they print their line with a
-// count of zero. The difference is that a failure here leaves no other trace: no
-// bytes are freed and no directory disappears, so "Removed 0 orphaned link(s)"
-// under a success icon would be the only thing said about a run that achieved
-// nothing. The per-link failure lines above it are the report in that case.
+// It counts successes rather than candidates: gc must not claim what it did not
+// reclaim. That rule comes from #273, which stopped the package block discarding
+// the error from removing a store entry and made it count what it had actually
+// removed; #233 is a different rule, cited at the call site, and decoupled the
+// prompts rather than the counting. The count printed here used to be
+// len(links), and the error was discarded on the way, so a run where every
+// delete failed printed a clean success and the rows it had left behind were
+// never named.
 //
 // The failure is not fatal to the run for the reason ADR-0001 gives: skipping a
 // row narrows what this pass removes and leaves it for the next run, and the row
 // it could not delete is a stale record rather than anything a project depends
 // on.
 //
+// The failure line says "the link to X" where removePackages and reapTempDirs
+// say only "X". That is deliberate and not drift: the findings printed above
+// read "- Link to X", and a user matching a failure to a finding should see the
+// same words.
+//
+// The summary is skipped entirely when nothing was removed, and that is a
+// divergence from the two blocks below, which print theirs with a count of zero:
+// removePackages prints "Removed 0 package(s), freed 0 B" under a success icon
+// when every removal failed. This block is the one being fixed today, so it
+// diverges rather than repeating that - a clean success over nothing achieved is
+// the defect, not a house style. #358 tracks the same defects in the package
+// block. The per-link failure lines above are the report in this case.
+//
 // It is a function rather than an inline block for the reason removePackages is
-// one, and for a second: DeleteLink's only failure is the transaction, because
-// the function it hands to bolt.Update always returns nil. So the failure path
-// cannot be reached through RunGC at all - a damaged link row or index entry
-// does not reach it, they are skipped and return a nil error - and the only way
-// to drive it is to call this with a closed handle, as
-// TestReapTempDirsRequiresTheDatabaseLock calls the sweep.
+// one, and for a second: no damage to the link buckets can drive a failure here.
+// Every error DeleteLink meets inside its transaction is swallowed - a link row
+// that will not parse is skipped by the lookup, and a link ID that is not found
+// returns nil - which was confirmed by damaging both a row and an index entry
+// and getting a nil error back. What is left is transaction-level, from
+// bolt.Update's Begin or its Commit, and that is all-or-nothing across the pass.
+// So a total failure is drivable by calling this with a closed handle, as
+// TestReapTempDirsRequiresTheDatabaseLock calls the sweep, and a partial one
+// cannot be constructed at all without a fake database.
 func removeOrphanedLinks(database *db.DB, links []linkToRemove) {
 	removed := 0
 	for _, l := range links {

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -186,19 +186,21 @@ func RunGC(dryRun bool, olderThan string, fixLinks bool, yes bool) error {
 	if fixLinks && len(linksToRemove) > 0 {
 		fmt.Printf("Found %d orphaned link(s):\n", len(linksToRemove))
 		for _, l := range linksToRemove {
-			if l.projectPath != "" {
-				fmt.Printf("  - Link to %s (%s)\n", l.projectPath, l.reason)
-			} else {
-				fmt.Printf("  - Link to project ID %d (%s)\n", l.projectID, l.reason)
-			}
+			fmt.Printf("  - Link to %s (%s)\n", l.label(), l.reason)
 		}
 		fmt.Println()
 
 		if !dryRun {
-			for _, l := range linksToRemove {
-				_ = database.DeleteLink(l.packageID, l.projectID)
+			if confirm("Permanently delete these orphaned link(s)?", yes) {
+				removeOrphanedLinks(database, linksToRemove)
+			} else {
+				// A third question rather than one shared with the two below.
+				// The blocks act on different things — link rows, store
+				// entries, temp directories — and #233 already decoupled the
+				// other two for that reason. Declining here still leaves the
+				// rest of the run to ask about what it found.
+				fmt.Println("Skipped deleting orphaned links.")
 			}
-			fmt.Printf("%s Removed %d orphaned link(s)\n", iconOK(), len(linksToRemove))
 		}
 	}
 
@@ -279,6 +281,49 @@ func pinnedByTag(tags map[string]string, hash string) bool {
 		}
 	}
 	return false
+}
+
+// removeOrphanedLinks deletes the database row of each orphaned link and reports
+// how many rows it actually removed.
+//
+// It counts successes rather than candidates, which is the rule #233 set for the
+// two blocks below: gc must not claim what it did not reclaim. The count printed
+// here used to be len(links), and the error was discarded on the way, so a run
+// where every delete failed printed a clean success and the rows it had left
+// behind were never named.
+//
+// The summary is skipped entirely when nothing was removed, which is where this
+// differs from removePackages and reapTempDirs - they print their line with a
+// count of zero. The difference is that a failure here leaves no other trace: no
+// bytes are freed and no directory disappears, so "Removed 0 orphaned link(s)"
+// under a success icon would be the only thing said about a run that achieved
+// nothing. The per-link failure lines above it are the report in that case.
+//
+// The failure is not fatal to the run for the reason ADR-0001 gives: skipping a
+// row narrows what this pass removes and leaves it for the next run, and the row
+// it could not delete is a stale record rather than anything a project depends
+// on.
+//
+// It is a function rather than an inline block for the reason removePackages is
+// one, and for a second: DeleteLink's only failure is the transaction, because
+// the function it hands to bolt.Update always returns nil. So the failure path
+// cannot be reached through RunGC at all - a damaged link row or index entry
+// does not reach it, they are skipped and return a nil error - and the only way
+// to drive it is to call this with a closed handle, as
+// TestReapTempDirsRequiresTheDatabaseLock calls the sweep.
+func removeOrphanedLinks(database *db.DB, links []linkToRemove) {
+	removed := 0
+	for _, l := range links {
+		if err := database.DeleteLink(l.packageID, l.projectID); err != nil {
+			fmt.Printf("  %s Failed to remove the link to %s: %v\n", iconWarn(), l.label(), err)
+			continue
+		}
+		removed++
+	}
+	if removed == 0 {
+		return
+	}
+	fmt.Printf("%s Removed %d orphaned link(s)\n", iconOK(), removed)
 }
 
 // removePackages deletes each package's store entry and then its database row.
@@ -440,6 +485,21 @@ type linkToRemove struct {
 	projectID   int64
 	projectPath string
 	reason      string
+}
+
+// label names the project end of the link, which is what the findings report has
+// always printed. It falls back to the project ID because the two orphan reasons
+// differ in what they know - a project whose record is gone has no path to print.
+//
+// One helper rather than the branch written twice, because the findings report
+// and the failure report have to name the same link the same way. A user reading
+// "Failed to remove the link to project ID 7" needs to match it to a line above
+// it, and matching is what the report exists for.
+func (l linkToRemove) label() string {
+	if l.projectPath != "" {
+		return l.projectPath
+	}
+	return fmt.Sprintf("project ID %d", l.projectID)
 }
 
 func countLinksForPackage(links []linkToRemove, packageID int64) int {

--- a/internal/cli/gc_test.go
+++ b/internal/cli/gc_test.go
@@ -722,7 +722,15 @@ func seededProjectID(t *testing.T, database *db.DB) int64 {
 // --fix-links deletes link rows on a pass of its own. Keeping them separate is
 // what lets the dangling-link test assert that gc removed one link and kept the
 // other, which a merged helper could not express.
-func assertLinkSurvived(t *testing.T) {
+// remainingLinks counts the link rows the seeded package still has, read back
+// through a fresh handle so it sees what gc committed rather than what the
+// test's own handle remembers.
+//
+// assertLinkSurvived is the one-link case of it, kept as a named assertion
+// because that is the case most of these tests want and the message it prints
+// says what the count means. Tests that expect some other number call this
+// directly.
+func remainingLinks(t *testing.T) int {
 	t.Helper()
 
 	database, err := db.GetDB()
@@ -737,8 +745,14 @@ func assertLinkSurvived(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read links back: %v", err)
 	}
-	if len(links) != 1 {
-		t.Errorf("gc removed the live link of linked-pkg@1.0.0, %d link(s) left", len(links))
+	return len(links)
+}
+
+func assertLinkSurvived(t *testing.T) {
+	t.Helper()
+
+	if got := remainingLinks(t); got != 1 {
+		t.Errorf("gc removed the live link of linked-pkg@1.0.0, %d link(s) left", got)
 	}
 }
 
@@ -822,6 +836,47 @@ func TestRunGCAbortsWhenAProjectRowHoldsAWrongTypedValue(t *testing.T) {
 	assertAbortedOnProject(t, entry, projectID, false)
 }
 
+// TestRunGCReportsALinkToAMissingProjectAsOrphaned is the other side of the same
+// branch, and the reason the fix is an error check rather than a wider guard.
+//
+// A lookup that succeeds and finds no record has established what the reason
+// string says, so that link stays orphaned and stays removable. The package
+// keeps its other link and so is not collected, which is what separates this
+// from the abort above.
+func TestRunGCReportsALinkToAMissingProjectAsOrphaned(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	entry, _ := seedCollectableLink(t, database, storeRoot)
+
+	packages, err := database.ListPackages()
+	if err != nil || len(packages) != 1 {
+		t.Fatalf("list packages: %v (%d found)", err, len(packages))
+	}
+	// A link naming a project ID no record answers for. InsertLink keeps one row
+	// per project and package name, so this adds a row rather than replacing the
+	// live one.
+	if err := database.InsertLink(&db.Link{PackageID: packages[0].ID, ProjectID: 4242, LinkType: "hardlink"}); err != nil {
+		t.Fatalf("insert the dangling link: %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := RunGC(false, "", true, true); err != nil {
+			t.Fatalf("RunGC() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "project not found in database") {
+		t.Errorf("gc did not report the dangling link under its own reason, output was:\n%s", out)
+	}
+	if !strings.Contains(out, "Found 1 orphaned link(s)") {
+		t.Errorf("gc did not report exactly one orphaned link, output was:\n%s", out)
+	}
+	if strings.Contains(out, "orphaned package") {
+		t.Errorf("gc collected a package a live link still names, output was:\n%s", out)
+	}
+	assertGCDeletedNothing(t, entry)
+	assertLinkSurvived(t)
+}
+
 // --- Confirming and reporting orphaned-link deletion -------------------------
 
 // seedOrphanedLink adds a second link to the package seedCollectableLink
@@ -840,27 +895,6 @@ func seedOrphanedLink(t *testing.T, database *db.DB) {
 	if err := database.InsertLink(&db.Link{PackageID: packages[0].ID, ProjectID: 4242, LinkType: "hardlink"}); err != nil {
 		t.Fatalf("insert the dangling link: %v", err)
 	}
-}
-
-// remainingLinks counts the link rows the seeded package still has, read back
-// through a fresh handle so it sees what gc committed rather than what the
-// test's own handle remembers.
-func remainingLinks(t *testing.T) int {
-	t.Helper()
-
-	database, err := db.GetDB()
-	if err != nil {
-		t.Fatalf("reopen database: %v", err)
-	}
-	packages, err := database.ListPackages()
-	if err != nil || len(packages) != 1 {
-		t.Fatalf("list packages: %v (%d found)", err, len(packages))
-	}
-	links, err := database.GetLinksForPackage(packages[0].ID)
-	if err != nil {
-		t.Fatalf("read links back: %v", err)
-	}
-	return len(links)
 }
 
 // TestRunGCDeclinedKeepsOrphanedLinks pins that --fix-links asks before it
@@ -915,9 +949,8 @@ func TestRunGCConfirmedRemovesOrphanedLinks(t *testing.T) {
 	if strings.Contains(out, "Skipped deleting orphaned links") {
 		t.Errorf("--yes was treated as a refusal, output was:\n%s", out)
 	}
-	if got := remainingLinks(t); got != 1 {
-		t.Errorf("%d link(s) left after --fix-links --yes, want 1 (the live one)", got)
-	}
+	// One link left, and it is the live one: assertLinkSurvived is exactly that
+	// count, so asserting it again here would only say the same thing twice.
 	assertLinkSurvived(t)
 	assertGCDeletedNothing(t, entry)
 }
@@ -955,13 +988,18 @@ func TestRunGCDryRunKeepsOrphanedLinks(t *testing.T) {
 // success and the rows it had not touched were never mentioned again.
 //
 // The failure is driven by closing the database handle before the deletes, which
-// is the same device TestReapTempDirsRequiresTheDatabaseLock uses. It is the only
-// failure DeleteLink has: the function it hands to bolt.Update always returns
-// nil, so every error it can return comes from the transaction rather than from
-// one link. Damaging a link row or its index entry was tried and returns a nil
-// error - the damaged row is skipped by the ForEach that looks the ID up, and a
-// link ID that is not found is not an error - so there is no per-link failure to
-// drive, and a partial one cannot be produced without a fake database.
+// is the same device TestReapTempDirsRequiresTheDatabaseLock uses. It is not the
+// only failure DeleteLink has - bolt.Update also returns what its Commit returns
+// - but it is the only one a test can drive, and every one of them is
+// transaction-level and so all-or-nothing across the pass.
+//
+// No per-link failure exists to drive. Damaging a link row and damaging its
+// index entry were both tried and both return a nil error: the damaged row is
+// skipped by the ForEach that looks the ID up, and a link ID that is not found
+// is not an error. That is why this test covers a total failure and there is no
+// partial one beside it - a partial failure cannot be constructed without a fake
+// database, and a fake database here would be scaffolding that distorts the
+// code it is meant to test.
 func TestRemoveOrphanedLinksReportsEveryFailedDelete(t *testing.T) {
 	storeRoot, database := newGCStore(t)
 	seedCollectableLink(t, database, storeRoot)
@@ -1000,45 +1038,4 @@ func TestRemoveOrphanedLinksReportsEveryFailedDelete(t *testing.T) {
 	if strings.Contains(out, iconOK()) {
 		t.Errorf("gc reported success for a run where every delete failed, output was:\n%s", out)
 	}
-}
-
-// TestRunGCReportsALinkToAMissingProjectAsOrphaned is the other side of the same
-// branch, and the reason the fix is an error check rather than a wider guard.
-//
-// A lookup that succeeds and finds no record has established what the reason
-// string says, so that link stays orphaned and stays removable. The package
-// keeps its other link and so is not collected, which is what separates this
-// from the abort above.
-func TestRunGCReportsALinkToAMissingProjectAsOrphaned(t *testing.T) {
-	storeRoot, database := newGCStore(t)
-	entry, _ := seedCollectableLink(t, database, storeRoot)
-
-	packages, err := database.ListPackages()
-	if err != nil || len(packages) != 1 {
-		t.Fatalf("list packages: %v (%d found)", err, len(packages))
-	}
-	// A link naming a project ID no record answers for. InsertLink keeps one row
-	// per project and package name, so this adds a row rather than replacing the
-	// live one.
-	if err := database.InsertLink(&db.Link{PackageID: packages[0].ID, ProjectID: 4242, LinkType: "hardlink"}); err != nil {
-		t.Fatalf("insert the dangling link: %v", err)
-	}
-
-	out := captureStdout(t, func() {
-		if err := RunGC(false, "", true, true); err != nil {
-			t.Fatalf("RunGC() error = %v", err)
-		}
-	})
-
-	if !strings.Contains(out, "project not found in database") {
-		t.Errorf("gc did not report the dangling link under its own reason, output was:\n%s", out)
-	}
-	if !strings.Contains(out, "Found 1 orphaned link(s)") {
-		t.Errorf("gc did not report exactly one orphaned link, output was:\n%s", out)
-	}
-	if strings.Contains(out, "orphaned package") {
-		t.Errorf("gc collected a package a live link still names, output was:\n%s", out)
-	}
-	assertGCDeletedNothing(t, entry)
-	assertLinkSurvived(t)
 }

--- a/internal/cli/gc_test.go
+++ b/internal/cli/gc_test.go
@@ -822,6 +822,186 @@ func TestRunGCAbortsWhenAProjectRowHoldsAWrongTypedValue(t *testing.T) {
 	assertAbortedOnProject(t, entry, projectID, false)
 }
 
+// --- Confirming and reporting orphaned-link deletion -------------------------
+
+// seedOrphanedLink adds a second link to the package seedCollectableLink
+// recorded, naming a project ID no record answers for, so the orphan scan files
+// exactly one link as orphaned and leaves the package's live link alone.
+//
+// InsertLink keeps one row per project and package name, so this adds a row
+// rather than replacing the live one.
+func seedOrphanedLink(t *testing.T, database *db.DB) {
+	t.Helper()
+
+	packages, err := database.ListPackages()
+	if err != nil || len(packages) != 1 {
+		t.Fatalf("list packages: %v (%d found)", err, len(packages))
+	}
+	if err := database.InsertLink(&db.Link{PackageID: packages[0].ID, ProjectID: 4242, LinkType: "hardlink"}); err != nil {
+		t.Fatalf("insert the dangling link: %v", err)
+	}
+}
+
+// remainingLinks counts the link rows the seeded package still has, read back
+// through a fresh handle so it sees what gc committed rather than what the
+// test's own handle remembers.
+func remainingLinks(t *testing.T) int {
+	t.Helper()
+
+	database, err := db.GetDB()
+	if err != nil {
+		t.Fatalf("reopen database: %v", err)
+	}
+	packages, err := database.ListPackages()
+	if err != nil || len(packages) != 1 {
+		t.Fatalf("list packages: %v (%d found)", err, len(packages))
+	}
+	links, err := database.GetLinksForPackage(packages[0].ID)
+	if err != nil {
+		t.Fatalf("read links back: %v", err)
+	}
+	return len(links)
+}
+
+// TestRunGCDeclinedKeepsOrphanedLinks pins that --fix-links asks before it
+// deletes, like every other destructive step in gc.
+//
+// The block deleted link rows the moment the flag was set. It honoured
+// --dry-run, but --yes was meaningless because nothing ever asked, so there was
+// no answer a user could give that stopped it.
+func TestRunGCDeclinedKeepsOrphanedLinks(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	entry, _ := seedCollectableLink(t, database, storeRoot)
+	seedOrphanedLink(t, database)
+
+	// yes=false with a non-interactive stdin is how confirm reports a refusal,
+	// so this is the "the user did not agree" case.
+	out := captureStdout(t, func() {
+		if err := RunGC(false, "", true, false); err != nil {
+			t.Fatalf("RunGC() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Found 1 orphaned link(s)") {
+		t.Errorf("gc did not report the orphaned link before asking, output was:\n%s", out)
+	}
+	if strings.Contains(out, "Removed") {
+		t.Errorf("gc claimed it removed a link the user did not agree to, output was:\n%s", out)
+	}
+	if got := remainingLinks(t); got != 2 {
+		t.Errorf("gc deleted a link without confirmation, %d link(s) left, want 2", got)
+	}
+	assertGCDeletedNothing(t, entry)
+}
+
+// TestRunGCConfirmedRemovesOrphanedLinks is the other side of the gate: --yes
+// satisfies the confirmation, so the orphaned row goes and the live one stays.
+//
+// Without this the gate could be satisfied by never deleting anything at all.
+func TestRunGCConfirmedRemovesOrphanedLinks(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	entry, _ := seedCollectableLink(t, database, storeRoot)
+	seedOrphanedLink(t, database)
+
+	out := captureStdout(t, func() {
+		if err := RunGC(false, "", true, true); err != nil {
+			t.Fatalf("RunGC() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Removed 1 orphaned link(s)") {
+		t.Errorf("gc did not report removing the orphaned link, output was:\n%s", out)
+	}
+	if strings.Contains(out, "Skipped deleting orphaned links") {
+		t.Errorf("--yes was treated as a refusal, output was:\n%s", out)
+	}
+	if got := remainingLinks(t); got != 1 {
+		t.Errorf("%d link(s) left after --fix-links --yes, want 1 (the live one)", got)
+	}
+	assertLinkSurvived(t)
+	assertGCDeletedNothing(t, entry)
+}
+
+// TestRunGCDryRunKeepsOrphanedLinks pins that adding the gate did not change
+// what a dry run prints or leaves behind. A dry run reports its findings and
+// stops before the question, so it must not print the prompt's refusal line
+// either — a dry run has nothing to refuse.
+func TestRunGCDryRunKeepsOrphanedLinks(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	entry, _ := seedCollectableLink(t, database, storeRoot)
+	seedOrphanedLink(t, database)
+
+	out := captureStdout(t, func() {
+		if err := RunGC(true, "", true, true); err != nil {
+			t.Fatalf("RunGC() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Found 1 orphaned link(s)") {
+		t.Errorf("a dry run did not report the orphaned link, output was:\n%s", out)
+	}
+	if strings.Contains(out, "Removed") || strings.Contains(out, "Skipped deleting orphaned links") {
+		t.Errorf("a dry run reached the deletion step, output was:\n%s", out)
+	}
+	if got := remainingLinks(t); got != 2 {
+		t.Errorf("a dry run deleted a link, %d link(s) left, want 2", got)
+	}
+	assertGCDeletedNothing(t, entry)
+}
+
+// TestRemoveOrphanedLinksReportsEveryFailedDelete pins the other half of #291:
+// the delete's error was discarded, and the summary counted the candidates
+// rather than the successes, so a run where every delete failed printed a clean
+// success and the rows it had not touched were never mentioned again.
+//
+// The failure is driven by closing the database handle before the deletes, which
+// is the same device TestReapTempDirsRequiresTheDatabaseLock uses. It is the only
+// failure DeleteLink has: the function it hands to bolt.Update always returns
+// nil, so every error it can return comes from the transaction rather than from
+// one link. Damaging a link row or its index entry was tried and returns a nil
+// error - the damaged row is skipped by the ForEach that looks the ID up, and a
+// link ID that is not found is not an error - so there is no per-link failure to
+// drive, and a partial one cannot be produced without a fake database.
+func TestRemoveOrphanedLinksReportsEveryFailedDelete(t *testing.T) {
+	storeRoot, database := newGCStore(t)
+	seedCollectableLink(t, database, storeRoot)
+
+	packages, err := database.ListPackages()
+	if err != nil || len(packages) != 1 {
+		t.Fatalf("list packages: %v (%d found)", err, len(packages))
+	}
+	if err := database.Close(); err != nil {
+		t.Fatalf("close database: %v", err)
+	}
+
+	links := []linkToRemove{
+		{packageID: packages[0].ID, projectID: 4242, reason: "project not found in database"},
+		{packageID: packages[0].ID, projectID: 77, projectPath: filepath.Join("gone", "project"), reason: "project directory no longer exists"},
+	}
+	out := captureStdout(t, func() {
+		removeOrphanedLinks(database, links)
+	})
+
+	// Both failures named, so a user knows which rows are still there.
+	if !strings.Contains(out, "4242") {
+		t.Errorf("the failed delete of the link to project 4242 was not reported, output was:\n%s", out)
+	}
+	if !strings.Contains(out, filepath.Join("gone", "project")) {
+		t.Errorf("the failed delete of the link to %s was not reported, output was:\n%s", filepath.Join("gone", "project"), out)
+	}
+	// The reason each one failed, not just that it did.
+	if !strings.Contains(out, "database not open") {
+		t.Errorf("gc swallowed the error DeleteLink returned, output was:\n%s", out)
+	}
+	// And no claim about what was removed: nothing was.
+	if strings.Contains(out, "Removed") {
+		t.Errorf("gc claimed it removed links it did not remove, output was:\n%s", out)
+	}
+	if strings.Contains(out, iconOK()) {
+		t.Errorf("gc reported success for a run where every delete failed, output was:\n%s", out)
+	}
+}
+
 // TestRunGCReportsALinkToAMissingProjectAsOrphaned is the other side of the same
 // branch, and the reason the fix is an error check rather than a wider guard.
 //


### PR DESCRIPTION
Closes #291.

## The bug

The orphaned-links block in `gc` had three defects in fifteen lines:

1. **No confirmation.** It deleted immediately. `--dry-run` was honoured, but `--yes` was meaningless because nothing ever asked. The two sibling blocks in the same function — package deletion and the temp-directory sweep — are both gated on `confirm(...)`. This block sat above both, gated on nothing.
2. **The delete error was discarded** (`_ = database.DeleteLink(...)`), so a failed delete was indistinguishable from a successful one.
3. **Success was reported unconditionally** — `Removed %d orphaned link(s)` printed the *candidate* count under a success icon, so a run where every delete failed still reported a clean success.

On its own the blast radius was bounded — `--fix-links` is opt-in and a genuinely orphaned link is stale by definition. It stopped being bounded in combination with #292, whose misclassification could mark a **live** link as orphaned. That pair was the silent-data-loss path; #292 landed first, and this closes it.

## The fix

The block now prints its findings, gates deletion on `confirm("Permanently delete these orphaned link(s)?", yes)`, and delegates to `removeOrphanedLinks`, which checks each delete's error, reports every failure by name, and counts only successes.

**Three separate prompts are kept deliberately**, per #233's reasoning: the blocks act on different things — link rows, store entries, temp directories — and declining one still leaves the rest of the run to ask about what it found.

The findings output is byte-identical to before. A new `label()` method exists so the findings line and the failure line name the same link the same way.

## Two deliberate divergences, both documented

**The summary is suppressed when nothing was removed**, where `removePackages` and `reapTempDirs` print theirs with a count of zero. A failure here frees no bytes and removes no directory, so `Removed 0 orphaned link(s)` under a success icon would be the only thing said about a run that achieved nothing. The per-link failure lines are the report in that case. The siblings have the same defect and are tracked in **#358**.

**The failure line reads `Failed to remove the link to X`** where the siblings say `Failed to remove X` — so it matches the findings line (`- Link to X`) a user is matching it against.

## On test coverage — one criterion is deliberately unmet

The brief asked for decline, accept, **partial failure**, and total failure. Partial failure is **not drivable**, and this was established by probing rather than assumed: `DeleteLink`'s closure swallows every error it meets inside the transaction — a link row that will not parse is skipped by the lookup, and a link ID that is not found returns nil, both confirmed by damaging a row and an index entry and getting `nil` back. What remains is transaction-level, from `bolt.Update`'s `Begin` or `Commit`, which is all-or-nothing across the pass.

So a total failure is drivable with a closed handle — the way `TestReapTempDirsRequiresTheDatabaseLock` already drives the sweep — and a partial one cannot be constructed without a fake database. Three real tests plus a real total-failure test, rather than four with one built on a seam that would distort the code. The reviewer confirmed this independently.

## Tests

- `TestRunGCDeclinedKeepsOrphanedLinks`
- `TestRunGCConfirmedRemovesOrphanedLinks`
- `TestRunGCDryRunKeepsOrphanedLinks`
- `TestRemoveOrphanedLinksReportsEveryFailedDelete`

Revert checks run in three directions: fix removed entirely; counting candidates instead of successes; and the gate ignoring `--yes` — the last proving the accept path is not vacuous. All three go red.