### PR TITLE
feat(publish): add --dry-run and print the packed file list

### DIFF
--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -50,7 +50,7 @@ my-monorepo/                    external-app/
 ├── packages/                   └── node_modules/
 │   └── ui/                         └── @my/ui ← linked from monorepo
 │       ├── package.json
-│       └── src/
+│       └── src/index.js
 └── apps/
     └── web/
         └── package.json
@@ -555,22 +555,20 @@ The root `package.json` of a monorepo is itself a package as far as lnpm is conc
 $ cd ~/my-monorepo
 $ lnpm push
 Package my-monorepo not published yet, publishing...
-Publishing my-monorepo@0.0.0 (6 files)...
+Publishing my-monorepo@0.0.0 (4 files)...
 ✓ Published my-monorepo@0.0.0
-  Hash: 6d4af6eb
-  Files: 6
-  Size: 247 B
-  Store: /home/you/.lnpm/store/my-monorepo/6d4af6eb7a14a98a
+  Hash: 10618390
+  Files: 4
+  Size: 334 B
+  Store: /home/you/.lnpm/store/my-monorepo/10618390ed098b47
   Packed:
-    README.md
-    index.js
+    apps/web/package.json
     package.json
-    packages/ui/index.js
     packages/ui/package.json
-    tsconfig.json
+    packages/ui/src/index.js
 ```
 
-That exits 0 and nothing warns you. The `Packed:` list is the tell: it holds the root's own files, and your library's sources only appear under `packages/`, as data carried along rather than as the package being shipped. `cd` into the package you actually changed and push from there:
+That exits 0 and nothing warns you. The `Packed:` list is the tell — it is the whole workspace laid out above, not your library. `@my/ui`'s sources are in there under `packages/ui/`, but as data inside `my-monorepo`, and an app that ran `lnpm add @my/ui` resolves that name and never sees them. `cd` into the package you actually changed and push from there:
 
 ```bash
 $ cd packages/ui

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -555,15 +555,22 @@ The root `package.json` of a monorepo is itself a package as far as lnpm is conc
 $ cd ~/my-monorepo
 $ lnpm push
 Package my-monorepo not published yet, publishing...
-Publishing my-monorepo@0.0.0 (5 files)...
+Publishing my-monorepo@0.0.0 (6 files)...
 ✓ Published my-monorepo@0.0.0
-  Hash: a8cfcfa7
-  Files: 5
-  Size: 441 B
-  Store: /home/you/.lnpm/store/my-monorepo/a8cfcfa78070eb53
+  Hash: 6d4af6eb
+  Files: 6
+  Size: 247 B
+  Store: /home/you/.lnpm/store/my-monorepo/6d4af6eb7a14a98a
+  Packed:
+    README.md
+    index.js
+    package.json
+    packages/ui/index.js
+    packages/ui/package.json
+    tsconfig.json
 ```
 
-That exits 0 and nothing warns you. `cd` into the package you actually changed and push from there:
+That exits 0 and nothing warns you. The `Packed:` list is the tell: it holds the root's own files, and your library's sources only appear under `packages/`, as data carried along rather than as the package being shipped. `cd` into the package you actually changed and push from there:
 
 ```bash
 $ cd packages/ui

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ lnpm push
 
 | Command | Description |
 |---------|-------------|
-| `lnpm publish` | Publish package to local store |
+| `lnpm publish` | Publish package to local store (`--dry-run` lists what would be packed and writes nothing) |
 | `lnpm add <pkg...>` | Add package(s) from store to project |
 | `lnpm remove <pkg>` | Remove linked package |
 | `lnpm pull [pkg...]` | Sync linked packages with the store (all of them when no name is given) |

--- a/examples/nx-example.md
+++ b/examples/nx-example.md
@@ -304,13 +304,26 @@ Check your project.json outputs configuration:
 $ cd ~/projects/my-nx-workspace
 $ lnpm push
 Package my-nx-workspace not published yet, publishing...
-Publishing my-nx-workspace@1.0.0 (6 files)...
+Publishing my-nx-workspace@1.0.0 (10 files)...
 ✓ Published my-nx-workspace@1.0.0
-  Hash: 0322bedf
-  Files: 6
-  Size: 480 B
-  Store: /home/you/.lnpm/store/my-nx-workspace/0322bedfad632406
+  Hash: b0901fd9
+  Files: 10
+  Size: 1.54 KB
+  Store: /home/you/.lnpm/store/my-nx-workspace/b0901fd9859c76c9
+  Packed:
+    apps/web/project.json
+    libs/feature-auth/dist/index.js
+    libs/feature-auth/package.json
+    libs/feature-auth/project.json
+    libs/feature-auth/src/auth.service.ts
+    libs/feature-auth/src/index.ts
+    libs/ui/project.json
+    libs/ui/src/index.ts
+    nx.json
+    package.json
 ```
+
+Read the `Packed:` list when you are not sure which project you just shipped. Every lib in the workspace is in there, `libs/feature-auth/dist/index.js` included, but as data inside `my-nx-workspace` — an app that ran `lnpm add @my-org/feature-auth` resolves that name and never sees them.
 
 Run it from the library instead:
 ```bash

--- a/examples/nx-example.md
+++ b/examples/nx-example.md
@@ -6,20 +6,29 @@ Quick example showing lnpm with Nx monorepo.
 
 ```
 my-nx-workspace/
-├── package.json         # Root workspace config (lnpm is a system binary, not a dependency)
-├── nx.json             # Nx config
+├── package.json                  # Root workspace config (lnpm is a system binary, not a dependency)
+├── nx.json                       # Nx config
 ├── libs/
 │   ├── feature-auth/
+│   │   ├── package.json          # What lnpm publishes: @my-org/feature-auth
 │   │   ├── project.json
+│   │   ├── tsconfig.lib.json     # The build target's tsConfig
 │   │   ├── src/
+│   │   │   ├── index.ts
+│   │   │   └── auth.service.ts
 │   │   └── dist/
+│   │       └── index.js          # Built output, and the package's main
 │   └── ui/
+│       ├── package.json          # @my-org/ui, no build step
 │       ├── project.json
 │       └── src/
+│           └── index.ts
 └── apps/
     └── web/
         └── project.json
 ```
+
+Twelve files, and the count matters later: `lnpm push` from the root packs all of them.
 
 ## Setup
 
@@ -304,12 +313,12 @@ Check your project.json outputs configuration:
 $ cd ~/projects/my-nx-workspace
 $ lnpm push
 Package my-nx-workspace not published yet, publishing...
-Publishing my-nx-workspace@1.0.0 (10 files)...
+Publishing my-nx-workspace@1.0.0 (12 files)...
 ✓ Published my-nx-workspace@1.0.0
-  Hash: b0901fd9
-  Files: 10
-  Size: 1.54 KB
-  Store: /home/you/.lnpm/store/my-nx-workspace/b0901fd9859c76c9
+  Hash: beb035af
+  Files: 12
+  Size: 1.74 KB
+  Store: /home/you/.lnpm/store/my-nx-workspace/beb035af7d44461d
   Packed:
     apps/web/project.json
     libs/feature-auth/dist/index.js
@@ -317,13 +326,15 @@ Publishing my-nx-workspace@1.0.0 (10 files)...
     libs/feature-auth/project.json
     libs/feature-auth/src/auth.service.ts
     libs/feature-auth/src/index.ts
+    libs/feature-auth/tsconfig.lib.json
+    libs/ui/package.json
     libs/ui/project.json
     libs/ui/src/index.ts
     nx.json
     package.json
 ```
 
-Read the `Packed:` list when you are not sure which project you just shipped. Every lib in the workspace is in there, `libs/feature-auth/dist/index.js` included, but as data inside `my-nx-workspace` — an app that ran `lnpm add @my-org/feature-auth` resolves that name and never sees them.
+That is every file in the Structure section at the top of this page — the whole workspace, swept up as one package. Read the `Packed:` list when you are not sure which project you just shipped: `libs/feature-auth/dist/index.js` is in there, but as data inside `my-nx-workspace`, and an app that ran `lnpm add @my-org/feature-auth` resolves that name and never sees it.
 
 Run it from the library instead:
 ```bash

--- a/examples/turborepo-example.md
+++ b/examples/turborepo-example.md
@@ -6,17 +6,21 @@ Quick example showing lnpm with Turborepo.
 
 ```
 my-turborepo/
-├── package.json         # Root workspace config (lnpm is a system binary, not a dependency)
-├── turbo.json          # Turborepo config
+├── package.json              # Root workspace config (lnpm is a system binary, not a dependency)
+├── turbo.json                # Turborepo config
 ├── packages/
 │   └── ui/
 │       ├── package.json
 │       ├── src/
-│       └── dist/       # Built output
+│       │   └── index.ts
+│       └── dist/
+│           └── index.js      # Built output, and the package's main
 └── apps/
     └── web/
         └── package.json
 ```
+
+Six files, and the count matters later: `lnpm push` from the root packs all of them.
 
 ## Setup
 
@@ -232,7 +236,7 @@ Publishing my-turborepo@0.0.0 (6 files)...
     turbo.json
 ```
 
-Read the `Packed:` list when you are not sure which package you just shipped. `@my/ui`'s files are in there, but under `packages/ui/`, as data inside `my-turborepo` — an app that ran `lnpm add @my/ui` resolves `@my/ui` and never sees them.
+That is every file in the Structure section at the top of this page — the whole workspace, swept up as one package. Read the `Packed:` list when you are not sure which package you just shipped: `@my/ui`'s files are in there, but under `packages/ui/`, as data inside `my-turborepo`, and an app that ran `lnpm add @my/ui` resolves `@my/ui` and never sees them.
 
 Run it from the package instead:
 ```bash

--- a/examples/turborepo-example.md
+++ b/examples/turborepo-example.md
@@ -219,11 +219,20 @@ $ lnpm push
 Package my-turborepo not published yet, publishing...
 Publishing my-turborepo@0.0.0 (6 files)...
 ✓ Published my-turborepo@0.0.0
-  Hash: 37e17a1b
+  Hash: d49407af
   Files: 6
-  Size: 590 B
-  Store: /home/you/.lnpm/store/my-turborepo/37e17a1bf0121ca4
+  Size: 929 B
+  Store: /home/you/.lnpm/store/my-turborepo/d49407af3568da7d
+  Packed:
+    apps/web/package.json
+    package.json
+    packages/ui/dist/index.js
+    packages/ui/package.json
+    packages/ui/src/index.ts
+    turbo.json
 ```
+
+Read the `Packed:` list when you are not sure which package you just shipped. `@my/ui`'s files are in there, but under `packages/ui/`, as data inside `my-turborepo` — an app that ran `lnpm add @my/ui` resolves `@my/ui` and never sees them.
 
 Run it from the package instead:
 ```bash

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -28,14 +28,23 @@ Examples:
   lnpm publish            # Publish current package
   lnpm publish --push     # Publish and update all linked projects
   lnpm publish --all      # Publish all packages in monorepo
-  lnpm publish --tag beta # Publish to the beta channel, leaving latest alone`,
+  lnpm publish --tag beta # Publish to the beta channel, leaving latest alone
+  lnpm publish --dry-run  # List exactly what would be packed, write nothing`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		push, _ := cmd.Flags().GetBool("push")
 		all, _ := cmd.Flags().GetBool("all")
 		skipHooks, _ := cmd.Flags().GetBool("skip-hooks")
 		skipValidation, _ := cmd.Flags().GetBool("skip-validation")
 		tag, _ := cmd.Flags().GetString("tag")
-		return RunPublishTagged(push, all, skipHooks, skipValidation, tag)
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		return RunPublishWith(PublishOptions{
+			Push:           push,
+			All:            all,
+			SkipHooks:      skipHooks,
+			SkipValidation: skipValidation,
+			DryRun:         dryRun,
+			Tag:            tag,
+		})
 	},
 }
 
@@ -407,6 +416,7 @@ func init() {
 	publishCmd.Flags().Bool("skip-hooks", false, "Skip prepare scripts (prepare, prepublishOnly, prepack)")
 	publishCmd.Flags().Bool("skip-validation", false, "Skip package validation before publish")
 	publishCmd.Flags().String("tag", db.DefaultTag, "Channel to publish to; anything but "+db.DefaultTag+" leaves "+db.DefaultTag+" where it is")
+	publishCmd.Flags().Bool("dry-run", false, "Show what would be packed and write nothing (pre_publish and prepare scripts still run, since they are usually what builds those files)")
 
 	// retreat flags
 	retreatCmd.Flags().Bool("force", false, "Actually remove everything (required)")

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -18,11 +18,9 @@ import (
 	"github.com/pedrosousa13/lnpm/internal/workspace"
 )
 
-// PublishOptions carries everything the publish command was asked for. It
-// exists so a new flag does not change a signature: RunPublish and
-// RunPublishTagged are called from about forty-five places across the test
-// suite, and every one of them would have had to be edited to add --dry-run as
-// a parameter.
+// PublishOptions is the full request a publish run is given: every flag the
+// command accepts, in one value. It is what RunPublishWith takes, so a new flag
+// is a new field rather than a new parameter on every caller.
 type PublishOptions struct {
 	Push           bool
 	All            bool
@@ -40,8 +38,11 @@ func RunPublish(push bool, all bool, skipHooks bool, skipValidation bool) error 
 }
 
 // RunPublishTagged is RunPublish, moving tag onto what it writes instead of the
-// default one. An empty tag means the default one, which is what the flag's own
-// default value carries.
+// default one. An empty tag means the default one.
+//
+// The command no longer reaches it - cobra builds a PublishOptions and calls
+// RunPublishWith - so its only callers are tests that want a tag without
+// naming the other fields.
 func RunPublishTagged(push bool, all bool, skipHooks bool, skipValidation bool, tag string) error {
 	return RunPublishWith(PublishOptions{
 		Push:           push,
@@ -92,7 +93,14 @@ func publishAll(cwd string, opts PublishOptions) error {
 		return fmt.Errorf("no packages found in workspace")
 	}
 
-	fmt.Printf("Publishing %d packages from %s workspace...\n\n", len(packages), ws.Type)
+	// A dry run writes nothing, so this function's own three lines - the header
+	// here, and the count and failure message at the end - must not say the
+	// workspace was published. Only the wording differs; the run is the same.
+	if opts.DryRun {
+		fmt.Printf("Dry run over %d packages from %s workspace; nothing will be written...\n\n", len(packages), ws.Type)
+	} else {
+		fmt.Printf("Publishing %d packages from %s workspace...\n\n", len(packages), ws.Type)
+	}
 
 	// Publish packages in parallel with worker pool
 	numWorkers := min(runtime.NumCPU(), len(packages))
@@ -155,8 +163,17 @@ func publishAll(cwd string, opts PublishOptions) error {
 		}
 	}
 
-	fmt.Printf("Published %d/%d packages\n", successCount, len(packages))
+	if opts.DryRun {
+		fmt.Printf("Dry run: %d/%d packages packed; nothing was written\n", successCount, len(packages))
+	} else {
+		fmt.Printf("Published %d/%d packages\n", successCount, len(packages))
+	}
 	if successCount < len(packages) {
+		if opts.DryRun {
+			// Not "failed to pack": validation and the pre-pack hooks run
+			// before pack does, and a failure in either lands here too.
+			return fmt.Errorf("the dry run failed for %d of %d package(s)", len(packages)-successCount, len(packages))
+		}
 		return fmt.Errorf("%d of %d package(s) failed to publish", len(packages)-successCount, len(packages))
 	}
 	return nil
@@ -173,17 +190,14 @@ func publishSingle(pkgPath string, opts PublishOptions) error {
 
 	// Run custom pre_publish hook before packing.
 	//
-	// A dry run runs it too, deliberately. Those hooks are frequently what
-	// builds the files being packed, so skipping them would make the dry run
-	// report a set that differs from the real publish - the dry run would lie,
-	// which defeats the whole point of having one. --skip-hooks is already
-	// there for anyone who does not want them.
+	// A dry run runs it too, deliberately: these hooks are often what builds
+	// the files being packed, so skipping them would make the dry run report a
+	// set the real publish would not. --skip-hooks covers anyone who objects.
 	//
-	// npm does the same, which was run rather than assumed: with npm 11.16.0,
-	// `npm publish --dry-run` over a package carrying prepack and
-	// prepublishOnly ran both, and the file each wrote showed up in the tarball
-	// listing the dry run printed. (The same run also showed npm executing
-	// postpublish on a dry run. lnpm deliberately does not - see below.)
+	// npm agrees, run rather than assumed: with npm 11.16.0, `npm publish
+	// --dry-run` over a package carrying prepack and prepublishOnly ran both,
+	// and the file each wrote appeared in the tarball listing. That same run
+	// also executed postpublish; lnpm does not - see the dry-run return below.
 	cfg := config.Get()
 	if !opts.SkipHooks {
 		if err := hooks.RunCustom(pkgPath, cfg.Hooks.PrePublish, "pre_publish"); err != nil {
@@ -216,22 +230,22 @@ func publishSingle(pkgPath string, opts PublishOptions) error {
 		return err
 	}
 
-	// A dry run stops here: everything that decides the packed set has run, and
-	// nothing that writes has. The rewritten manifest is already materialised,
-	// so the reported set is the one a real publish would store, and the defer
-	// above removes the temporary file it lives in on the way out.
+	// A dry run stops here: everything that decides the packed set has run,
+	// nothing that writes has, and the rewritten manifest is already
+	// materialised, so the reported set is the one a real publish would store.
+	// The defer above removes the temporary file it lives in on the way out.
 	//
-	// It stops here rather than immediately before finishPublish because the
-	// "already published with same content" short-circuit sits in between, and
-	// it returns. A dry run that fell into it would answer "already published"
-	// to the question "what would you ship?" - which is the question a user
-	// asks most often about a package they have already published.
+	// Here rather than immediately before finishPublish because the "already
+	// published with same content" short-circuit sits in between and returns -
+	// a dry run that fell into it would answer "already published" to the
+	// question "what would you ship?".
 	//
-	// Returning above db.GetDB is also what keeps the guarantee cheap to state:
+	// Stopping above db.GetDB is also what keeps the guarantee cheap to state:
 	// the database is never opened, the store is never constructed (store.New
 	// creates its directory tree as a side effect of being called), and
-	// post_publish never runs. npm runs postpublish on a dry run; lnpm does
-	// not, because post_publish is for reacting to a release that happened.
+	// post_publish never runs. npm does run postpublish on a dry run (the same
+	// 11.16.0 run cited above); lnpm does not, because post_publish is for
+	// reacting to a release that happened.
 	if opts.DryRun {
 		reportDryRun(pkgJSON, files)
 		return nil
@@ -280,33 +294,46 @@ func publishSingle(pkgPath string, opts PublishOptions) error {
 	return nil
 }
 
-// reportDryRun prints the packed set, one relative path per line.
+// writePackedPaths renders the packed set into b, one relative path per line,
+// each prefixed with indent. Shared by the dry run and by finishPublish so the
+// two print the same set the same way and one of them cannot drift.
 //
 // Sorted by RelPath, and not because the walk leaves them unsorted by accident:
 // filepath.Walk visits each directory's entries in lexical order, which puts
 // "a/inner.js" before "a.js" because it descends into "a" on reaching it, while
-// a sort by path puts "a.js" first ('.' is 0x2E, '/' is 0x2F). Diffing two dry
-// runs is the main reason to have one, so the order is pinned rather than
+// a sort by path puts "a.js" first ('.' is 0x2E, '/' is 0x2F). Diffing two
+// listings is a main reason to have one, so the order is pinned rather than
 // inherited.
 //
-// The whole report is built and printed with one call: --all publishes in
-// parallel and only brackets its per-package header with a mutex, so a report
-// emitted line by line would interleave with another package's.
-func reportDryRun(pkgJSON *pack.PackageJSON, files []*pack.FileInfo) {
+// It writes into a builder so the caller can emit the whole block with one
+// Print. That is not an atomicity guarantee - a pipe only writes atomically up
+// to PIPE_BUF, 4096 bytes on Linux, and a tty promises nothing at all, and a
+// few hundred paths pass 4096 easily. It is one write syscall instead of one
+// per path, which makes interleaving under --all's parallel workers far less
+// likely, and that is the whole claim.
+func writePackedPaths(b *strings.Builder, files []*pack.FileInfo, indent string) {
 	paths := make([]string, len(files))
-	var totalSize int64
 	for i, f := range files {
 		paths[i] = f.RelPath
-		totalSize += f.Size
 	}
 	sort.Strings(paths)
+
+	for _, p := range paths {
+		fmt.Fprintf(b, "%s%s\n", indent, p)
+	}
+}
+
+// reportDryRun prints what a real publish would have packed.
+func reportDryRun(pkgJSON *pack.PackageJSON, files []*pack.FileInfo) {
+	var totalSize int64
+	for _, f := range files {
+		totalSize += f.Size
+	}
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "Dry run: %s@%s would pack %d files (%s); nothing was written\n",
 		pkgJSON.Name, pkgJSON.Version, len(files), formatSize(totalSize))
-	for _, p := range paths {
-		fmt.Fprintf(&b, "  %s\n", p)
-	}
+	writePackedPaths(&b, files, "  ")
 	fmt.Print(b.String())
 }
 
@@ -368,13 +395,16 @@ func finishPublish(pkgPath string, pkgJSON *pack.PackageJSON, files []*pack.File
 	fmt.Printf("  Files: %d\n", len(files))
 	fmt.Printf("  Size: %s\n", formatSize(totalSize))
 	fmt.Printf("  Store: %s\n", storePath)
-	// The count above is the only thing an ordinary publish says about the
-	// packed set, and a count cannot show that a secret was packed. The list
-	// itself is not printed here on purpose: publish is an inner-loop command
-	// run many times a day, and output that appears on every run is output
-	// users learn to skip, which serves detection worse than a pointer to the
-	// command that prints it on demand.
-	fmt.Printf("  %s Run 'lnpm publish --dry-run' to see the packed files\n", iconTip())
+
+	// The packed set itself, not only the count above. A count cannot show that
+	// a secret was packed, and this is the one place that can say what was
+	// actually stored: `publish --dry-run` re-packs the working tree, so it
+	// answers "what would ship now", never "what did ship". push reaches this
+	// same summary and gets the same list, which is what it needs too.
+	var listing strings.Builder
+	listing.WriteString("  Packed:\n")
+	writePackedPaths(&listing, files, "    ")
+	fmt.Print(listing.String())
 
 	// If push requested, push to all linked projects
 	if push {

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -33,16 +33,18 @@ type PublishOptions struct {
 
 // RunPublish executes the publish command, moving the default tag onto what it
 // writes.
+//
+// It and RunPublishTagged below are both test-only now: cobra builds a
+// PublishOptions and calls RunPublishWith directly, so nothing in the command
+// path reaches either. They stay because the tests that call them name only
+// the fields they care about, which reads better than a struct literal
+// repeated across every call site.
 func RunPublish(push bool, all bool, skipHooks bool, skipValidation bool) error {
 	return RunPublishTagged(push, all, skipHooks, skipValidation, db.DefaultTag)
 }
 
 // RunPublishTagged is RunPublish, moving tag onto what it writes instead of the
 // default one. An empty tag means the default one.
-//
-// The command no longer reaches it - cobra builds a PublishOptions and calls
-// RunPublishWith - so its only callers are tests that want a tag without
-// naming the other fields.
 func RunPublishTagged(push bool, all bool, skipHooks bool, skipValidation bool, tag string) error {
 	return RunPublishWith(PublishOptions{
 		Push:           push,
@@ -399,8 +401,18 @@ func finishPublish(pkgPath string, pkgJSON *pack.PackageJSON, files []*pack.File
 	// The packed set itself, not only the count above. A count cannot show that
 	// a secret was packed, and this is the one place that can say what was
 	// actually stored: `publish --dry-run` re-packs the working tree, so it
-	// answers "what would ship now", never "what did ship". push reaches this
-	// same summary and gets the same list, which is what it needs too.
+	// answers "what would ship now", never "what did ship".
+	//
+	// Uncapped, deliberately. A dist-heavy package puts thousands of lines on
+	// every publish, which is real, but a list truncated at N is worthless for
+	// the thing the list is for - the packed secret is as likely to be at
+	// position 900 as position 9, and a reader who cannot trust the list to be
+	// complete has to go and check by hand anyway.
+	//
+	// push reaches this only through RunPushTagged's "not published yet"
+	// branch, which delegates the first publish here. A steady-state push does
+	// its own packing and storing and prints no list; #322 is about publish, so
+	// that half is left as it is.
 	var listing strings.Builder
 	listing.WriteString("  Packed:\n")
 	writePackedPaths(&listing, files, "    ")

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/pedrosousa13/lnpm/internal/config"
@@ -16,6 +18,21 @@ import (
 	"github.com/pedrosousa13/lnpm/internal/workspace"
 )
 
+// PublishOptions carries everything the publish command was asked for. It
+// exists so a new flag does not change a signature: RunPublish and
+// RunPublishTagged are called from about forty-five places across the test
+// suite, and every one of them would have had to be edited to add --dry-run as
+// a parameter.
+type PublishOptions struct {
+	Push           bool
+	All            bool
+	SkipHooks      bool
+	SkipValidation bool
+	// DryRun reports what would be packed and returns without writing.
+	DryRun bool
+	Tag    string
+}
+
 // RunPublish executes the publish command, moving the default tag onto what it
 // writes.
 func RunPublish(push bool, all bool, skipHooks bool, skipValidation bool) error {
@@ -26,8 +43,20 @@ func RunPublish(push bool, all bool, skipHooks bool, skipValidation bool) error 
 // default one. An empty tag means the default one, which is what the flag's own
 // default value carries.
 func RunPublishTagged(push bool, all bool, skipHooks bool, skipValidation bool, tag string) error {
-	if tag == "" {
-		tag = db.DefaultTag
+	return RunPublishWith(PublishOptions{
+		Push:           push,
+		All:            all,
+		SkipHooks:      skipHooks,
+		SkipValidation: skipValidation,
+		Tag:            tag,
+	})
+}
+
+// RunPublishWith is the publish entry point. RunPublish and RunPublishTagged
+// are convenience wrappers over it.
+func RunPublishWith(opts PublishOptions) error {
+	if opts.Tag == "" {
+		opts.Tag = db.DefaultTag
 	}
 
 	cwd, err := os.Getwd()
@@ -36,15 +65,15 @@ func RunPublishTagged(push bool, all bool, skipHooks bool, skipValidation bool, 
 	}
 
 	// Handle --all for monorepo publishing
-	if all {
-		return publishAll(cwd, push, skipHooks, skipValidation, tag)
+	if opts.All {
+		return publishAll(cwd, opts)
 	}
 
-	return publishSingle(cwd, push, skipHooks, skipValidation, tag)
+	return publishSingle(cwd, opts)
 }
 
 // publishAll publishes all packages in a monorepo workspace
-func publishAll(cwd string, push bool, skipHooks bool, skipValidation bool, tag string) error {
+func publishAll(cwd string, opts PublishOptions) error {
 	ws, err := workspace.Detect(cwd)
 	if err != nil {
 		return fmt.Errorf("failed to detect workspace: %w", err)
@@ -93,7 +122,7 @@ func publishAll(cwd string, push bool, skipHooks bool, skipValidation bool, tag 
 				fmt.Printf("%s %s@%s %s\n", sep, pkg.Name, pkg.Version, sep)
 				outputMu.Unlock()
 
-				err := publishSingle(pkg.Path, push, skipHooks, skipValidation, tag)
+				err := publishSingle(pkg.Path, opts)
 
 				outputMu.Lock()
 				if err != nil {
@@ -134,24 +163,36 @@ func publishAll(cwd string, push bool, skipHooks bool, skipValidation bool, tag 
 }
 
 // publishSingle publishes a single package
-func publishSingle(pkgPath string, push bool, skipHooks bool, skipValidation bool, tag string) error {
+func publishSingle(pkgPath string, opts PublishOptions) error {
 	// Validate package before proceeding
-	if !skipValidation {
+	if !opts.SkipValidation {
 		if err := validation.ValidatePackage(pkgPath); err != nil {
 			return fmt.Errorf("validation failed: %w", err)
 		}
 	}
 
-	// Run custom pre_publish hook before packing
+	// Run custom pre_publish hook before packing.
+	//
+	// A dry run runs it too, deliberately. Those hooks are frequently what
+	// builds the files being packed, so skipping them would make the dry run
+	// report a set that differs from the real publish - the dry run would lie,
+	// which defeats the whole point of having one. --skip-hooks is already
+	// there for anyone who does not want them.
+	//
+	// npm does the same, which was run rather than assumed: with npm 11.16.0,
+	// `npm publish --dry-run` over a package carrying prepack and
+	// prepublishOnly ran both, and the file each wrote showed up in the tarball
+	// listing the dry run printed. (The same run also showed npm executing
+	// postpublish on a dry run. lnpm deliberately does not - see below.)
 	cfg := config.Get()
-	if !skipHooks {
+	if !opts.SkipHooks {
 		if err := hooks.RunCustom(pkgPath, cfg.Hooks.PrePublish, "pre_publish"); err != nil {
 			return fmt.Errorf("pre_publish hook failed: %w", err)
 		}
 	}
 
 	// Run prepare scripts before packing
-	if err := hooks.RunPrepare(pkgPath, skipHooks); err != nil {
+	if err := hooks.RunPrepare(pkgPath, opts.SkipHooks); err != nil {
 		return fmt.Errorf("prepare hook failed: %w", err)
 	}
 
@@ -175,6 +216,27 @@ func publishSingle(pkgPath string, push bool, skipHooks bool, skipValidation boo
 		return err
 	}
 
+	// A dry run stops here: everything that decides the packed set has run, and
+	// nothing that writes has. The rewritten manifest is already materialised,
+	// so the reported set is the one a real publish would store, and the defer
+	// above removes the temporary file it lives in on the way out.
+	//
+	// It stops here rather than immediately before finishPublish because the
+	// "already published with same content" short-circuit sits in between, and
+	// it returns. A dry run that fell into it would answer "already published"
+	// to the question "what would you ship?" - which is the question a user
+	// asks most often about a package they have already published.
+	//
+	// Returning above db.GetDB is also what keeps the guarantee cheap to state:
+	// the database is never opened, the store is never constructed (store.New
+	// creates its directory tree as a side effect of being called), and
+	// post_publish never runs. npm runs postpublish on a dry run; lnpm does
+	// not, because post_publish is for reacting to a release that happened.
+	if opts.DryRun {
+		reportDryRun(pkgJSON, files)
+		return nil
+	}
+
 	// Check if already published with same hash
 	database, err := db.GetDB()
 	if err != nil {
@@ -192,30 +254,60 @@ func publishSingle(pkgPath string, push bool, skipHooks bool, skipValidation boo
 	// skips finishPublish, which is the only place a tag is ever moved, so
 	// without it `publish --tag beta` over an unchanged working tree would print
 	// a reassuring line and leave beta pointing wherever it was - or nowhere.
-	tagged, err := database.ResolveTag(pkgJSON.Name, tag)
+	tagged, err := database.ResolveTag(pkgJSON.Name, opts.Tag)
 	if err != nil {
-		return fmt.Errorf("failed to read the %s tag of %s: %w", tag, pkgJSON.Name, err)
+		return fmt.Errorf("failed to read the %s tag of %s: %w", opts.Tag, pkgJSON.Name, err)
 	}
 
-	if existing != nil && !push && tagged != nil && tagged.ContentHash == contentHash {
+	if existing != nil && !opts.Push && tagged != nil && tagged.ContentHash == contentHash {
 		fmt.Printf("%s Package %s@%s already published with same content (hash: %s)\n",
 			iconWarn(), pkgJSON.Name, pkgJSON.Version, shortHash(contentHash))
 		fmt.Println("Use --push to update linked projects anyway")
 		return nil
 	}
 
-	if err := finishPublish(pkgPath, pkgJSON, files, database, push, tag); err != nil {
+	if err := finishPublish(pkgPath, pkgJSON, files, database, opts.Push, opts.Tag); err != nil {
 		return err
 	}
 
 	// Run custom post_publish hook after a successful publish
-	if !skipHooks {
+	if !opts.SkipHooks {
 		if err := hooks.RunCustom(pkgPath, cfg.Hooks.PostPublish, "post_publish"); err != nil {
 			return fmt.Errorf("post_publish hook failed: %w", err)
 		}
 	}
 
 	return nil
+}
+
+// reportDryRun prints the packed set, one relative path per line.
+//
+// Sorted by RelPath, and not because the walk leaves them unsorted by accident:
+// filepath.Walk visits each directory's entries in lexical order, which puts
+// "a/inner.js" before "a.js" because it descends into "a" on reaching it, while
+// a sort by path puts "a.js" first ('.' is 0x2E, '/' is 0x2F). Diffing two dry
+// runs is the main reason to have one, so the order is pinned rather than
+// inherited.
+//
+// The whole report is built and printed with one call: --all publishes in
+// parallel and only brackets its per-package header with a mutex, so a report
+// emitted line by line would interleave with another package's.
+func reportDryRun(pkgJSON *pack.PackageJSON, files []*pack.FileInfo) {
+	paths := make([]string, len(files))
+	var totalSize int64
+	for i, f := range files {
+		paths[i] = f.RelPath
+		totalSize += f.Size
+	}
+	sort.Strings(paths)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Dry run: %s@%s would pack %d files (%s); nothing was written\n",
+		pkgJSON.Name, pkgJSON.Version, len(files), formatSize(totalSize))
+	for _, p := range paths {
+		fmt.Fprintf(&b, "  %s\n", p)
+	}
+	fmt.Print(b.String())
 }
 
 // finishPublish completes publishing with pre-packed data (used by push too),
@@ -276,6 +368,13 @@ func finishPublish(pkgPath string, pkgJSON *pack.PackageJSON, files []*pack.File
 	fmt.Printf("  Files: %d\n", len(files))
 	fmt.Printf("  Size: %s\n", formatSize(totalSize))
 	fmt.Printf("  Store: %s\n", storePath)
+	// The count above is the only thing an ordinary publish says about the
+	// packed set, and a count cannot show that a secret was packed. The list
+	// itself is not printed here on purpose: publish is an inner-loop command
+	// run many times a day, and output that appears on every run is output
+	// users learn to skip, which serves detection worse than a pointer to the
+	// command that prints it on demand.
+	fmt.Printf("  %s Run 'lnpm publish --dry-run' to see the packed files\n", iconTip())
 
 	// If push requested, push to all linked projects
 	if push {

--- a/tests/publish_dry_run_test.go
+++ b/tests/publish_dry_run_test.go
@@ -20,6 +20,14 @@ import (
 // dryRunHeading is the prefix of the line a dry run prints above its file list.
 const dryRunHeading = "Dry run:"
 
+// The two indents the packed list is printed at: a dry run lists at the top
+// level of its own report, while a publish nests the list inside the indented
+// summary block under "Packed:".
+const (
+	dryRunIndent  = "  "
+	publishIndent = "    "
+)
+
 // dryRunFiles is the fixture the dry-run output tests share. It is chosen for
 // one property: filepath.Walk does not visit these paths in the order a sort by
 // RelPath puts them in. Walk descends into "a" before it reaches "a.js",
@@ -55,17 +63,19 @@ func packedPaths(t *testing.T, pkgDir string) []string {
 }
 
 // assertListsInOrder checks that every path in want appears in out as a line of
-// its own, and that the lines appear in the order want gives them.
+// its own at the given indent, and that the lines appear in the order want
+// gives them.
 //
-// It matches "\n  <path>\n" rather than the bare path: "a.js" is a substring of
-// "lib/a.js", so a Contains check on the bare path would be satisfied by the
-// wrong line.
-func assertListsInOrder(t *testing.T, out string, want []string) {
+// It matches "\n<indent><path>\n" rather than the bare path: "a.js" is a
+// substring of "lib/a.js", so a Contains check on the bare path would be
+// satisfied by the wrong line. The indent is a parameter because the dry run
+// lists at two spaces and the publish summary nests its list at four.
+func assertListsInOrder(t *testing.T, out string, want []string, indent string) {
 	t.Helper()
 
 	prev := -1
 	for _, p := range want {
-		line := "\n  " + p + "\n"
+		line := "\n" + indent + p + "\n"
 		at := strings.Index(out, line)
 		if at < 0 {
 			t.Errorf("Expected the output to list %q on a line of its own; it does not.\nOutput:\n%s", p, out)
@@ -160,7 +170,7 @@ func TestPublishDryRunPrintsEveryPackedPath(t *testing.T) {
 		t.Fatalf("Expected the dry run to succeed, got: %v", err)
 	}
 
-	assertListsInOrder(t, out, want)
+	assertListsInOrder(t, out, want, dryRunIndent)
 }
 
 // The listed order is a sort by RelPath, which is not the order the walk
@@ -198,7 +208,7 @@ func TestPublishDryRunOutputOrderIsDeterministic(t *testing.T) {
 		}
 	})
 
-	assertListsInOrder(t, first, want)
+	assertListsInOrder(t, first, want, dryRunIndent)
 	if first != second {
 		t.Errorf("Expected two dry runs to print identical output.\nFirst:\n%s\nSecond:\n%s", first, second)
 	}
@@ -323,7 +333,7 @@ func TestPublishDryRunExitStatusDistinguishesSuccessFromPackFailure(t *testing.T
 	if goodErr != nil {
 		t.Errorf("Expected a successful dry run to return nil, got: %v", goodErr)
 	}
-	assertListsInOrder(t, out, want)
+	assertListsInOrder(t, out, want, dryRunIndent)
 
 	// A manifest pack cannot parse. Validation and the prepare hooks are
 	// skipped so that pack is the step that fails, rather than one of the
@@ -364,7 +374,7 @@ func TestPublishDryRunListsFilesForAnAlreadyPublishedPackage(t *testing.T) {
 		}
 	})
 
-	assertListsInOrder(t, out, want)
+	assertListsInOrder(t, out, want, dryRunIndent)
 }
 
 // --dry-run --push pushes nothing: linked projects keep the content they had.
@@ -442,22 +452,90 @@ func TestPublishDryRunAllReportsEachPackage(t *testing.T) {
 			t.Errorf("Expected the dry run to report %s.\nOutput:\n%s", name, out)
 		}
 	}
-	assertListsInOrder(t, out, wantA)
-	assertListsInOrder(t, out, wantB)
+	assertListsInOrder(t, out, wantA, dryRunIndent)
+	assertListsInOrder(t, out, wantB, dryRunIndent)
 
 	assertSnapshotsEqual(t, before, storeSnapshot(t, env.StoreDir), "dry run --all changed the store")
 	env.AssertPackageInDatabase("@npm-test/package-a", false)
 	env.AssertPackageInDatabase("@npm-test/package-b", false)
 }
 
-// An ordinary publish reports a count, so it has to tell the user where the
-// list itself is. Without this the packed set is only visible to someone who
-// knows about the debug logger.
-func TestPublishPointsAtDryRunForTheFullFileList(t *testing.T) {
+// --dry-run --all writes nothing, so the three lines publishAll prints around
+// the per-package reports must not say it published anything.
+func TestPublishDryRunAllDoesNotClaimItPublished(t *testing.T) {
 	env := setupTest(t)
 
-	pkgDir := env.CreateTestPackage("publish-pointer-pkg", "1.0.0", dryRunFiles)
+	wsDir := env.CopyFixture("npm-workspace")
+	env.chdir(wsDir)
+
+	var err error
+	out := captureStdout(t, func() {
+		err = cli.RunPublishWith(cli.PublishOptions{DryRun: true, All: true, SkipValidation: true})
+	})
+	if err != nil {
+		t.Fatalf("Expected the dry run to succeed, got: %v", err)
+	}
+
+	// The negative is the point: "Publishing 2 packages from npm workspace..."
+	// and "Published 2/2 packages" are what this printed before, both of them
+	// untrue of a run that wrote nothing.
+	for _, claim := range []string{"Publishing ", "Published "} {
+		if strings.Contains(out, claim) {
+			t.Errorf("Expected a dry run over a workspace not to say %q anywhere.\nOutput:\n%s", claim, out)
+		}
+	}
+	for _, want := range []string{
+		"Dry run over 2 packages from npm workspace",
+		"Dry run: 2/2 packages packed; nothing was written",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Expected the output to contain %q.\nOutput:\n%s", want, out)
+		}
+	}
+}
+
+// The error publishAll returns is worded for a dry run too, for the same reason
+// as its printed lines: nothing was being published, so nothing failed to
+// publish.
+//
+// package-b is made to fail validation rather than pack, because a package.json
+// broken enough to fail pack also fails workspace.ListPackages, which aborts
+// publishAll before any package is attempted. That is also why the message says
+// "the dry run failed" rather than naming pack: the step that failed here is
+// the one before it.
+func TestPublishDryRunAllDoesNotClaimAFailedPublish(t *testing.T) {
+	env := setupTest(t)
+
+	wsDir := env.CopyFixture("npm-workspace")
+	env.writeFile(filepath.Join(wsDir, "packages", "package-b", "package.json"),
+		`{"name":"@npm-test/package-b","version":"1.0.0","main":"missing.js"}`)
+	env.chdir(wsDir)
+
+	var err error
+	out := captureStdout(t, func() {
+		err = cli.RunPublishWith(cli.PublishOptions{DryRun: true, All: true})
+	})
+	if err == nil {
+		t.Fatal("Expected the dry run to fail for package-b, got nil")
+	}
+	if want := "the dry run failed for 1 of 2 package(s)"; err.Error() != want {
+		t.Errorf("Expected %q, got: %v", want, err)
+	}
+	if strings.Contains(out, "Published ") {
+		t.Errorf("Expected a failed dry run not to say anything was published.\nOutput:\n%s", out)
+	}
+}
+
+// An ordinary publish prints the packed set, not only how many files it holds.
+// A count cannot show that a secret was packed, and --dry-run cannot answer it
+// after the fact: it re-packs the working tree, so it says what would ship now,
+// never what did.
+func TestPublishPrintsThePackedFileList(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.CreateTestPackage("publish-list-pkg", "1.0.0", dryRunFiles)
 	env.chdir(pkgDir)
+	want := packedPaths(t, pkgDir)
 
 	var err error
 	out := captureStdout(t, func() {
@@ -467,31 +545,32 @@ func TestPublishPointsAtDryRunForTheFullFileList(t *testing.T) {
 		t.Fatalf("Failed to publish: %v", err)
 	}
 
-	if !strings.Contains(out, "--dry-run") {
-		t.Errorf("Expected an ordinary publish to point at 'lnpm publish --dry-run'.\nOutput:\n%s", out)
-	}
+	assertListsInOrder(t, out, want, publishIndent)
 }
 
-// The pointer belongs to the ordinary publish only: a dry run has just printed
-// the list, so telling it to run a dry run would be noise. This one is a guard
-// on where the pointer is printed rather than a test of the dry run; it was
-// green before the pointer existed, and only starts asserting anything once it
-// does.
-func TestPublishDryRunDoesNotPointAtItself(t *testing.T) {
+// push reaches the same summary as publish when the package is not in the store
+// yet, and it gets the same list. This is the half a command-specific pointer
+// could not serve: telling a `lnpm push` user to run `lnpm publish --dry-run`
+// is advice about a command they did not run.
+func TestPushPrintsThePackedFileList(t *testing.T) {
 	env := setupTest(t)
 
-	pkgDir := env.CreateTestPackage("dryrun-no-pointer-pkg", "1.0.0", dryRunFiles)
+	pkgDir := env.CreateTestPackage("push-list-pkg", "1.0.0", dryRunFiles)
 	env.chdir(pkgDir)
+	want := packedPaths(t, pkgDir)
 
+	var err error
 	out := captureStdout(t, func() {
-		if err := cli.RunPublishWith(cli.PublishOptions{DryRun: true}); err != nil {
-			t.Errorf("Expected the dry run to succeed, got: %v", err)
-		}
+		err = cli.RunPush(false)
 	})
-
-	if strings.Contains(out, "Run 'lnpm publish --dry-run'") {
-		t.Errorf("Expected a dry run not to advertise itself.\nOutput:\n%s", out)
+	if err != nil {
+		t.Fatalf("Failed to push: %v", err)
 	}
+	if !strings.Contains(out, "not published yet, publishing...") {
+		t.Fatalf("Expected push to fall through to the publish summary.\nOutput:\n%s", out)
+	}
+
+	assertListsInOrder(t, out, want, publishIndent)
 }
 
 // yamlQuote renders s as a YAML double-quoted scalar, so a hook command holding

--- a/tests/publish_dry_run_test.go
+++ b/tests/publish_dry_run_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pedrosousa13/lnpm/internal/cli"
 	"github.com/pedrosousa13/lnpm/internal/config"
 	"github.com/pedrosousa13/lnpm/internal/pack"
-	"github.com/pedrosousa13/lnpm/internal/shellcmd"
 )
 
 // dryRunHeading is the prefix of the line a dry run prints above its file list.
@@ -408,10 +407,36 @@ func TestPublishDryRunRunsPrePublishButNotPostPublish(t *testing.T) {
 	pre := filepath.Join(markers, "pre.txt")
 	post := filepath.Join(markers, "post.txt")
 
+	// The marker paths go into the hook command unquoted, which is why an
+	// unquotable one has to skip rather than run.
+	//
+	// shellcmd.QuoteArg was the obvious spelling and it fails on Windows: the
+	// hook runs through shellcmd.Command as `cmd /C <string>`, and os/exec
+	// escapes that string with syscall.EscapeArg, which wraps an argument
+	// containing spaces in quotes and rewrites an inner `"` as `\"`. cmd.exe
+	// does not read `\"` as an escaped quote - it takes the backslash
+	// literally - so the redirection target arrives mangled and the hook exits
+	// 1. Observed on CI, run 32634796756: `pre_publish hook failed: command
+	// failed: exit status 1`, Windows only, with Linux and macOS green on the
+	// same commit.
+	//
+	// Unquoted, the whole command still contains spaces, so EscapeArg wraps it
+	// once and cmd.exe strips that outer pair - which is the shape cmd expects.
+	// That only holds while the paths themselves have no spaces, hence the
+	// skip. Go's t.TempDir sits under TMPDIR, so this is a property of the
+	// machine, not of the test.
+	//
+	// The underlying quoting defect belongs to internal/shellcmd, not to this
+	// test, and no test covered a custom hook before this one - which is why it
+	// surfaced here. Filed separately rather than fixed under #322.
+	if strings.ContainsAny(pre+post, " \t") {
+		t.Skipf("temp path contains a space, which the hook command cannot quote on Windows: %s", markers)
+	}
+
 	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
 	env.writeFile(cfgPath, "hooks:\n"+
-		"  pre_publish: "+yamlQuote("echo ran > "+shellcmd.QuoteArg(pre))+"\n"+
-		"  post_publish: "+yamlQuote("echo ran > "+shellcmd.QuoteArg(post))+"\n")
+		"  pre_publish: "+yamlQuote("echo ran > "+pre)+"\n"+
+		"  post_publish: "+yamlQuote("echo ran > "+post)+"\n")
 	t.Setenv("LNPM_CONFIG", cfgPath)
 	config.ResetForTesting()
 	t.Cleanup(config.ResetForTesting)

--- a/tests/publish_dry_run_test.go
+++ b/tests/publish_dry_run_test.go
@@ -1,0 +1,514 @@
+package tests
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/cli"
+	"github.com/pedrosousa13/lnpm/internal/config"
+	"github.com/pedrosousa13/lnpm/internal/pack"
+	"github.com/pedrosousa13/lnpm/internal/shellcmd"
+)
+
+// dryRunHeading is the prefix of the line a dry run prints above its file list.
+const dryRunHeading = "Dry run:"
+
+// dryRunFiles is the fixture the dry-run output tests share. It is chosen for
+// one property: filepath.Walk does not visit these paths in the order a sort by
+// RelPath puts them in. Walk descends into "a" before it reaches "a.js",
+// because it sorts directory entries by name and "a" < "a.js", so the packed
+// slice arrives as [a/inner.js, a.js, index.js, package.json]. Sorted by
+// RelPath it is [a.js, a/inner.js, index.js, package.json], because '.' (0x2E)
+// sorts before '/' (0x2F). A dry run that printed the packed slice as it came
+// would therefore pass an "every path is listed" check and fail the ordering
+// one, which is what makes the explicit sort load-bearing rather than
+// decorative.
+var dryRunFiles = map[string]string{
+	"a.js":       "module.exports = 'a';",
+	"a/inner.js": "module.exports = 'inner';",
+	"index.js":   "module.exports = 'index';",
+}
+
+// packedPaths returns the RelPaths pack would select for pkgDir, sorted. The
+// tests derive their expectations from pack rather than restating the fixture,
+// so a change in the selection rules cannot leave them asserting a stale set.
+func packedPaths(t *testing.T, pkgDir string) []string {
+	t.Helper()
+
+	_, files, err := pack.Pack(pkgDir)
+	if err != nil {
+		t.Fatalf("Failed to pack %s: %v", pkgDir, err)
+	}
+	paths := make([]string, len(files))
+	for i, f := range files {
+		paths[i] = f.RelPath
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// assertListsInOrder checks that every path in want appears in out as a line of
+// its own, and that the lines appear in the order want gives them.
+//
+// It matches "\n  <path>\n" rather than the bare path: "a.js" is a substring of
+// "lib/a.js", so a Contains check on the bare path would be satisfied by the
+// wrong line.
+func assertListsInOrder(t *testing.T, out string, want []string) {
+	t.Helper()
+
+	prev := -1
+	for _, p := range want {
+		line := "\n  " + p + "\n"
+		at := strings.Index(out, line)
+		if at < 0 {
+			t.Errorf("Expected the output to list %q on a line of its own; it does not.\nOutput:\n%s", p, out)
+			continue
+		}
+		if at < prev {
+			t.Errorf("Expected %q to be listed after the previous path, but it comes before it.\nOutput:\n%s", p, out)
+		}
+		prev = at
+	}
+}
+
+// storeSnapshot fingerprints every entry under root: the relative path of each
+// directory, and for each file its size, permission bits and the SHA-256 of its
+// bytes. The store root holds both the content-addressed store tree and
+// lnpm.db, so one snapshot covers "the store" and "the database" together, and
+// covers them by content rather than by absence - a write that replaced a file
+// with one of the same length would still change the digest.
+//
+// Directories are recorded too, so a run that only created an empty tree (which
+// store.New does before it stores anything) is still a difference.
+func storeSnapshot(t *testing.T, root string) map[string]string {
+	t.Helper()
+
+	snap := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if d.IsDir() {
+			snap[rel] = "dir"
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		sum := sha256.Sum256(data)
+		snap[rel] = fmt.Sprintf("file size=%d mode=%v sha256=%s", info.Size(), info.Mode().Perm(), hex.EncodeToString(sum[:]))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to snapshot %s: %v", root, err)
+	}
+	return snap
+}
+
+// assertSnapshotsEqual reports every entry that was added, removed or changed
+// between two storeSnapshot results.
+func assertSnapshotsEqual(t *testing.T, before, after map[string]string, what string) {
+	t.Helper()
+
+	for rel, b := range before {
+		a, ok := after[rel]
+		if !ok {
+			t.Errorf("%s: %s disappeared", what, rel)
+			continue
+		}
+		if a != b {
+			t.Errorf("%s: %s changed\n  before: %s\n  after:  %s", what, rel, b, a)
+		}
+	}
+	for rel := range after {
+		if _, ok := before[rel]; !ok {
+			t.Errorf("%s: %s was created (%s)", what, rel, after[rel])
+		}
+	}
+}
+
+// A dry run prints every path it would pack, not just how many there are.
+func TestPublishDryRunPrintsEveryPackedPath(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.CreateTestPackage("dryrun-list-pkg", "1.0.0", dryRunFiles)
+	env.chdir(pkgDir)
+	want := packedPaths(t, pkgDir)
+
+	var err error
+	out := captureStdout(t, func() {
+		err = cli.RunPublishWith(cli.PublishOptions{DryRun: true})
+	})
+	if err != nil {
+		t.Fatalf("Expected the dry run to succeed, got: %v", err)
+	}
+
+	assertListsInOrder(t, out, want)
+}
+
+// The listed order is a sort by RelPath, which is not the order the walk
+// produces, and it is the same on every run.
+func TestPublishDryRunOutputOrderIsDeterministic(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.CreateTestPackage("dryrun-order-pkg", "1.0.0", dryRunFiles)
+	env.chdir(pkgDir)
+	want := packedPaths(t, pkgDir)
+
+	// The fixture only proves anything if the sorted order really does differ
+	// from the order pack returns; if a future change to pack made them the
+	// same, this test would silently stop testing the sort.
+	_, packed, err := pack.Pack(pkgDir)
+	if err != nil {
+		t.Fatalf("Failed to pack: %v", err)
+	}
+	asPacked := make([]string, len(packed))
+	for i, f := range packed {
+		asPacked[i] = f.RelPath
+	}
+	if strings.Join(asPacked, "\n") == strings.Join(want, "\n") {
+		t.Fatalf("Fixture no longer distinguishes packed order from sorted order (%v); the ordering assertion below would pass without any sort", want)
+	}
+
+	first := captureStdout(t, func() {
+		if err := cli.RunPublishWith(cli.PublishOptions{DryRun: true}); err != nil {
+			t.Errorf("First dry run failed: %v", err)
+		}
+	})
+	second := captureStdout(t, func() {
+		if err := cli.RunPublishWith(cli.PublishOptions{DryRun: true}); err != nil {
+			t.Errorf("Second dry run failed: %v", err)
+		}
+	})
+
+	assertListsInOrder(t, first, want)
+	if first != second {
+		t.Errorf("Expected two dry runs to print identical output.\nFirst:\n%s\nSecond:\n%s", first, second)
+	}
+}
+
+// The load-bearing one: a dry run leaves the store tree and the database
+// byte-identical, compared by digest rather than by "no error was returned".
+func TestPublishDryRunLeavesStoreAndDatabaseByteIdentical(t *testing.T) {
+	env := setupTest(t)
+
+	// Publish something real first, so the store and the database both hold
+	// content. A comparison over two empty directories would be satisfied by a
+	// dry run that wrote nothing only because there was nothing to write.
+	env.publishPkg("dryrun-neighbour", "1.0.0", map[string]string{"index.js": "module.exports = 1;"})
+
+	pkgDir := env.CreateTestPackage("dryrun-untouched-pkg", "2.0.0", dryRunFiles)
+	env.chdir(pkgDir)
+
+	before := storeSnapshot(t, env.StoreDir)
+	if len(before) < 3 {
+		t.Fatalf("Expected the store to hold real content before the dry run, snapshot has %d entries: %v", len(before), before)
+	}
+
+	if err := cli.RunPublishWith(cli.PublishOptions{DryRun: true}); err != nil {
+		t.Fatalf("Expected the dry run to succeed, got: %v", err)
+	}
+
+	after := storeSnapshot(t, env.StoreDir)
+	assertSnapshotsEqual(t, before, after, "dry run changed the store")
+
+	env.AssertPackageInDatabase("dryrun-untouched-pkg", false)
+	env.AssertPackageInDatabase("dryrun-neighbour", true)
+}
+
+// On a store that has never been published to, a dry run must not even bring
+// the store tree into existence, and must leave no lock file behind.
+func TestPublishDryRunOnEmptyStoreCreatesNothing(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.CreateTestPackage("dryrun-empty-store-pkg", "1.0.0", dryRunFiles)
+	env.chdir(pkgDir)
+
+	before := storeSnapshot(t, env.StoreDir)
+	if err := cli.RunPublishWith(cli.PublishOptions{DryRun: true}); err != nil {
+		t.Fatalf("Expected the dry run to succeed, got: %v", err)
+	}
+	after := storeSnapshot(t, env.StoreDir)
+
+	assertSnapshotsEqual(t, before, after, "dry run changed an untouched store")
+	env.AssertDirectoryExists(filepath.Join(env.StoreDir, "store"), false)
+	env.AssertFileExists(filepath.Join(pkgDir, "lnpm.lock"), false)
+}
+
+// A dry run leaves no temporary files behind, including the one the workspace:
+// specifier rewrite has to materialise to hash the rewritten manifest.
+//
+// TMPDIR is redirected at a directory this test owns so the assertion can be
+// "the directory is empty" rather than a diff of the shared system temp
+// directory, which other packages in this suite are writing to concurrently.
+//
+// It is not the guarantee the other tests in this file are, and it was green
+// before --dry-run did anything: publishSingle defers the rewrite's cleanup
+// unconditionally, so the temp file goes away on every path out of the
+// function, dry run or not. It pins the acceptance criterion and it would catch
+// a dry-run return placed above that defer, but it does not test the return
+// itself.
+func TestPublishDryRunLeavesNoTempFiles(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp) // unix
+	t.Setenv("TMP", tmp)    // windows
+	t.Setenv("TEMP", tmp)   // windows
+	if got := os.TempDir(); got != strings.TrimRight(tmp, string(os.PathSeparator)) {
+		t.Skipf("os.TempDir() is %s, not the redirected %s; cannot isolate temp files on this platform", got, tmp)
+	}
+
+	env := setupTest(t)
+
+	// The workspace-deps fixture's lib depends on its sibling with
+	// "workspace:*", which is the only path in publish that writes a temp file
+	// before anything is stored.
+	wsDir := env.CopyFixture("workspace-deps")
+	libDir := filepath.Join(wsDir, "packages", "lib")
+	env.chdir(libDir)
+
+	// Skip validation: the fixture has no built files.
+	if err := cli.RunPublishWith(cli.PublishOptions{DryRun: true, SkipValidation: true}); err != nil {
+		t.Fatalf("Expected the dry run to succeed, got: %v", err)
+	}
+
+	entries, err := os.ReadDir(tmp)
+	if err != nil {
+		t.Fatalf("Failed to read %s: %v", tmp, err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("Expected the dry run to leave no temporary files, found: %v", names)
+	}
+}
+
+// A successful dry run exits zero; a pack failure comes back as an error, so
+// the two are distinguishable by exit code and not only by reading the output.
+//
+// Each half also checks the output, because the return values alone are what an
+// ordinary publish already produces: nil on success, a wrapped pack error on a
+// broken manifest. Asserting only on the error would leave the test green with
+// --dry-run doing nothing at all, which is what it did on the first run of this
+// file.
+func TestPublishDryRunExitStatusDistinguishesSuccessFromPackFailure(t *testing.T) {
+	env := setupTest(t)
+
+	good := env.CreateTestPackage("dryrun-exit-pkg", "1.0.0", dryRunFiles)
+	env.chdir(good)
+	want := packedPaths(t, good)
+
+	var goodErr error
+	out := captureStdout(t, func() {
+		goodErr = cli.RunPublishWith(cli.PublishOptions{DryRun: true})
+	})
+	if goodErr != nil {
+		t.Errorf("Expected a successful dry run to return nil, got: %v", goodErr)
+	}
+	assertListsInOrder(t, out, want)
+
+	// A manifest pack cannot parse. Validation and the prepare hooks are
+	// skipped so that pack is the step that fails, rather than one of the
+	// steps before it.
+	bad := env.CreateTestPackage("dryrun-broken-pkg", "1.0.0", nil)
+	env.writeFile(filepath.Join(bad, "package.json"), `{"name": "dryrun-broken-pkg",`)
+	env.chdir(bad)
+
+	var badErr error
+	badOut := captureStdout(t, func() {
+		badErr = cli.RunPublishWith(cli.PublishOptions{DryRun: true, SkipHooks: true, SkipValidation: true})
+	})
+	if badErr == nil {
+		t.Fatal("Expected a dry run over an unpackable package to return an error, got nil")
+	}
+	if !strings.Contains(badErr.Error(), "failed to pack") {
+		t.Errorf("Expected a pack failure, got: %v", badErr)
+	}
+	if strings.Contains(badOut, dryRunHeading) {
+		t.Errorf("Expected a failed pack to report no file list.\nOutput:\n%s", badOut)
+	}
+}
+
+// A dry run of a package that is already in the store still prints its file
+// list. The publish path short-circuits on unchanged content well before it
+// writes anything, so a dry run that returned from there would answer "already
+// published" to the question "what would you ship?".
+func TestPublishDryRunListsFilesForAnAlreadyPublishedPackage(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.publishPkg("dryrun-republish-pkg", "1.0.0", dryRunFiles)
+	env.chdir(pkgDir)
+	want := packedPaths(t, pkgDir)
+
+	out := captureStdout(t, func() {
+		if err := cli.RunPublishWith(cli.PublishOptions{DryRun: true}); err != nil {
+			t.Errorf("Expected the dry run to succeed, got: %v", err)
+		}
+	})
+
+	assertListsInOrder(t, out, want)
+}
+
+// --dry-run --push pushes nothing: linked projects keep the content they had.
+func TestPublishDryRunWithPushUpdatesNoProject(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir, projectDir := env.publishAndAdd("dryrun-push-pkg")
+	env.AssertLinkedFileContent(projectDir, "dryrun-push-pkg", "index.js", "module.exports = 'dryrun-push-pkg';")
+
+	// Change the source so a real --push would have something to propagate.
+	env.chdir(pkgDir)
+	env.writeFile(filepath.Join(pkgDir, "index.js"), "module.exports = 'CHANGED';")
+
+	before := storeSnapshot(t, env.StoreDir)
+	if err := cli.RunPublishWith(cli.PublishOptions{DryRun: true, Push: true}); err != nil {
+		t.Fatalf("Expected the dry run to succeed, got: %v", err)
+	}
+	assertSnapshotsEqual(t, before, storeSnapshot(t, env.StoreDir), "dry run --push changed the store")
+
+	env.AssertLinkedFileContent(projectDir, "dryrun-push-pkg", "index.js", "module.exports = 'dryrun-push-pkg';")
+}
+
+// A dry run runs pre_publish, because that hook is often what builds the files
+// being packed and a dry run that skipped it would report a different set than
+// the real publish. It does not run post_publish, because nothing was
+// published.
+func TestPublishDryRunRunsPrePublishButNotPostPublish(t *testing.T) {
+	env := setupTest(t)
+
+	markers := t.TempDir()
+	pre := filepath.Join(markers, "pre.txt")
+	post := filepath.Join(markers, "post.txt")
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	env.writeFile(cfgPath, "hooks:\n"+
+		"  pre_publish: "+yamlQuote("echo ran > "+shellcmd.QuoteArg(pre))+"\n"+
+		"  post_publish: "+yamlQuote("echo ran > "+shellcmd.QuoteArg(post))+"\n")
+	t.Setenv("LNPM_CONFIG", cfgPath)
+	config.ResetForTesting()
+	t.Cleanup(config.ResetForTesting)
+
+	pkgDir := env.CreateTestPackage("dryrun-hooks-pkg", "1.0.0", dryRunFiles)
+	env.chdir(pkgDir)
+
+	if err := cli.RunPublishWith(cli.PublishOptions{DryRun: true}); err != nil {
+		t.Fatalf("Expected the dry run to succeed, got: %v", err)
+	}
+
+	env.AssertFileExists(pre, true)
+	env.AssertFileExists(post, false)
+}
+
+// --dry-run --all reports every package in the workspace and publishes none of
+// them.
+func TestPublishDryRunAllReportsEachPackage(t *testing.T) {
+	env := setupTest(t)
+
+	wsDir := env.CopyFixture("npm-workspace")
+	env.chdir(wsDir)
+
+	wantA := packedPaths(t, filepath.Join(wsDir, "packages", "package-a"))
+	wantB := packedPaths(t, filepath.Join(wsDir, "packages", "package-b"))
+
+	before := storeSnapshot(t, env.StoreDir)
+	var err error
+	out := captureStdout(t, func() {
+		err = cli.RunPublishWith(cli.PublishOptions{DryRun: true, All: true, SkipValidation: true})
+	})
+	if err != nil {
+		t.Fatalf("Expected the dry run to succeed, got: %v", err)
+	}
+
+	for _, name := range []string{"@npm-test/package-a", "@npm-test/package-b"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("Expected the dry run to report %s.\nOutput:\n%s", name, out)
+		}
+	}
+	assertListsInOrder(t, out, wantA)
+	assertListsInOrder(t, out, wantB)
+
+	assertSnapshotsEqual(t, before, storeSnapshot(t, env.StoreDir), "dry run --all changed the store")
+	env.AssertPackageInDatabase("@npm-test/package-a", false)
+	env.AssertPackageInDatabase("@npm-test/package-b", false)
+}
+
+// An ordinary publish reports a count, so it has to tell the user where the
+// list itself is. Without this the packed set is only visible to someone who
+// knows about the debug logger.
+func TestPublishPointsAtDryRunForTheFullFileList(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.CreateTestPackage("publish-pointer-pkg", "1.0.0", dryRunFiles)
+	env.chdir(pkgDir)
+
+	var err error
+	out := captureStdout(t, func() {
+		err = cli.RunPublishWith(cli.PublishOptions{})
+	})
+	if err != nil {
+		t.Fatalf("Failed to publish: %v", err)
+	}
+
+	if !strings.Contains(out, "--dry-run") {
+		t.Errorf("Expected an ordinary publish to point at 'lnpm publish --dry-run'.\nOutput:\n%s", out)
+	}
+}
+
+// The pointer belongs to the ordinary publish only: a dry run has just printed
+// the list, so telling it to run a dry run would be noise. This one is a guard
+// on where the pointer is printed rather than a test of the dry run; it was
+// green before the pointer existed, and only starts asserting anything once it
+// does.
+func TestPublishDryRunDoesNotPointAtItself(t *testing.T) {
+	env := setupTest(t)
+
+	pkgDir := env.CreateTestPackage("dryrun-no-pointer-pkg", "1.0.0", dryRunFiles)
+	env.chdir(pkgDir)
+
+	out := captureStdout(t, func() {
+		if err := cli.RunPublishWith(cli.PublishOptions{DryRun: true}); err != nil {
+			t.Errorf("Expected the dry run to succeed, got: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "Run 'lnpm publish --dry-run'") {
+		t.Errorf("Expected a dry run not to advertise itself.\nOutput:\n%s", out)
+	}
+}
+
+// yamlQuote renders s as a YAML double-quoted scalar, so a hook command holding
+// shell quoting or Windows backslashes survives the config file intact.
+func yamlQuote(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/tests/publish_dry_run_test.go
+++ b/tests/publish_dry_run_test.go
@@ -552,6 +552,10 @@ func TestPublishPrintsThePackedFileList(t *testing.T) {
 // yet, and it gets the same list. This is the half a command-specific pointer
 // could not serve: telling a `lnpm push` user to run `lnpm publish --dry-run`
 // is advice about a command they did not run.
+//
+// Only that branch. A steady-state push - package already in the store - packs
+// and stores on its own and never calls finishPublish, so it prints no list.
+// The fixture publishes nothing first for exactly that reason.
 func TestPushPrintsThePackedFileList(t *testing.T) {
 	env := setupTest(t)
 


### PR DESCRIPTION
Closes #322.

`lnpm publish` reported only `(%d files)`. The actual list lived solely behind `debug.Logf`, so there was no user-facing way to notice a secret had been packed — the OWASP **A09** finding this issue was filed for.

## The change

**`lnpm publish --dry-run`** prints exactly what would be packed, sorted, and writes nothing:

```
$ lnpm publish --dry-run
Dry run: my-pkg@2.0.0 would pack 4 files (129 B); nothing was written
  a.js
  a/inner.js
  index.js
  package.json
```

**An ordinary publish now prints the packed set too**, under the existing summary:

```
✓ Published my-monorepo@0.0.0
  Hash: 10618390
  Files: 4
  Size: 334 B
  Store: …/store/my-monorepo/10618390ed098b47
  Packed:
    apps/web/package.json
    package.json
    packages/ui/package.json
    packages/ui/src/index.js
```

The first round of this PR used a one-line pointer at `--dry-run` instead. Review was right that it under-delivered: the issue says a leak should be noticeable "before **or** after" publishing, and `--dry-run` re-packs the *working tree*, so it answers "what would ship now", never "what did ship". The list is uncapped on purpose — a list truncated at N is worthless for finding a packed secret, which is as likely to sit at position 900 as position 9.

## What a dry run does and does not do

- Runs validation and the `pre_publish`/prepare hooks. Deliberate: those hooks are frequently what *builds* the files being packed, so skipping them would make the dry run report a set the real publish would not produce. `--skip-hooks` is the escape. Verified against npm 11.16.0, which does the same on `npm publish --dry-run`.
- Does **not** run `post_publish` — that is for reacting to a release that happened. (npm does run it; this is a deliberate divergence, not parity.)
- Writes nothing: no store, no database, no lock file, no surviving temp file. It returns above `db.GetDB()`, which is also above `store.New()` — that call creates its directory tree as a side effect of being called.
- Returns *before* the "already published with same content" short-circuit, so a dry run over an already-published package answers "here is what you would ship" rather than "already published".
- `--all` works, and no longer claims it published: the header, summary and failure lines are worded honestly under a dry run.

## Verification

Both revert directions run, not argued:

- **Remove the early return** → `TestPublishDryRunLeavesStoreAndDatabaseByteIdentical` goes red on the real store diff (`lnpm.db` digest changed; 8 store entries created; the package appears in the database).
- **Move the early return to after `finishPublish`** → the same test goes red the same way. Worth noting the dry-run *report* still prints there, so an output-only test would stay green — the byte-identical snapshot is what actually catches it.

That assertion compares a digest-based snapshot of `LNPM_STORE` (which holds both the content-addressed tree and `lnpm.db`): per entry, the relative path, `dir` marker, size, permission bits and SHA-256 of full contents. It runs over a **populated** store — the fixture publishes a real package first — so a dry run writing nothing because there was nothing to write cannot satisfy it.

Gates green: `go test ./...` (17 packages), `go vet`, `golangci-lint` (0 issues), `gofmt`, Windows build, cross-vet for windows/amd64 + darwin/arm64 + linux/arm64, Windows test-compile.

## Docs

The publish-summary transcripts in `MONOREPO.md`, `examples/nx-example.md` and `examples/turborepo-example.md` all predated the `Packed:` block. Regenerated from real runs against a throwaway store — and in doing so, all three turned out to have counts that could not be derived from their own Structure sections. Each Structure block now enumerates every file, so the count in the transcript is one a reader can reach by counting.

## Filed, not fixed — kept out of scope deliberately

- **#372** — the steady-state `lnpm push` path packs and stores on its own and still shows no file list. Same A09 gap on the other command; #322 is publish-scoped.
- **#373** — the `Pushed to N/M projects` transcripts in those same three docs omit the relink counts the code prints. Same class, different root cause.
- **#371** — `tests/helpers_test.go` sets `LNPM_STORE` but not `LNPM_CONFIG`, so the suite reads the developer's real `~/.lnpm/config.yaml` and would run any configured `pre_publish` hook.
