### PR TITLE
fix(lockfile): bound lock-file and workspace-config size before parsing

### DIFF
--- a/internal/fsutil/read.go
+++ b/internal/fsutil/read.go
@@ -41,6 +41,14 @@ var ErrFileTooLarge = errors.New("file is over the size limit")
 // lets a test build the oversized case with os.Truncate instead of writing
 // megabytes.
 //
+// What it is not is a hard bound. Stat and the read are two calls, so a writer
+// growing the file in between hands back more than max, and lnpm parses it. That
+// window is accepted rather than closed: reading through an io.LimitReader would
+// make the bound absolute and would cost a full read of every legitimate file to
+// do it, losing the free refusal above. The threat #323 describes is a repo that
+// ships an oversized file, not a writer racing the read, and this closes that
+// one.
+//
 // A missing file is reported as the *fs.PathError os.Stat produced, so
 // os.IsNotExist and errors.Is(err, fs.ErrNotExist) still recognise it -
 // pkg/lockfile turns that case into "no lock file here" and has to keep being

--- a/internal/fsutil/read.go
+++ b/internal/fsutil/read.go
@@ -101,6 +101,13 @@ var ErrFileTooLarge = errors.New("file is over the size limit")
 // able to. The refusal names the file, its size and the limit, because a user
 // who hits it has to decide whether the file is corrupt or the limit is wrong,
 // and cannot do either without all three.
+//
+// max is a parameter although both call sites pass MaxYAMLBytes, and no test
+// passes anything else. It stays one because this function knows nothing about
+// YAML: the limit is a property of the format the caller is about to parse, and
+// baking a YAML-derived number into a filesystem helper would put the reason for
+// the number somewhere it cannot be read. Do not read the parameter as an
+// invitation to make the limit configurable - nothing asked for that.
 func ReadFileCapped(path string, max int64) ([]byte, error) {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/internal/fsutil/read.go
+++ b/internal/fsutil/read.go
@@ -70,13 +70,21 @@ const MaxYAMLBytes = 4 << 20
 // the message instead would pin the wording rather than the behaviour.
 var ErrFileTooLarge = errors.New("file is over the size limit")
 
-// ReadFileCapped reads path, refusing files larger than max bytes.
+// ReadFileCapped reads path, refusing anything that is not a regular file and
+// any regular file larger than max bytes.
 //
 // The size is taken from os.Stat before any read, which is what makes the
 // refusal free: an oversized file is never read into memory and never reaches a
 // parser, so the cost the cap exists to bound is never paid. It is also what
 // lets a test build the oversized case with os.Truncate instead of writing
 // megabytes.
+//
+// The regular-file check is what makes the size check mean anything. os.Stat
+// reports Size() == 0 for a FIFO, a device node and their like, so without the
+// check such a path sails past the comparison and reaches os.ReadFile
+// unbounded - and a FIFO with no writer blocks there rather than yielding a
+// small file, which is the opposite of what a size of 0 suggested. A zero size
+// from a non-regular file is not the same fact as a zero size from a small one.
 //
 // What it is not is a hard bound. Stat and the read are two calls, so a writer
 // growing the file in between hands back more than max, and lnpm parses it. That
@@ -97,6 +105,9 @@ func ReadFileCapped(path string, max int64) ([]byte, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
 	}
 	if info.Size() > max {
 		return nil, fmt.Errorf("%s is %d bytes, over the %d-byte limit: %w", path, info.Size(), max, ErrFileTooLarge)

--- a/internal/fsutil/read.go
+++ b/internal/fsutil/read.go
@@ -1,0 +1,59 @@
+package fsutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// MaxYAMLBytes is the largest YAML document lnpm will read before parsing it.
+//
+// It exists to bound parse cost, not memory. gopkg.in/yaml.v3's cost is
+// superlinear in the input, and the sweep on #323 measured it going up faster
+// than the file does: 5,000 lock entries (1.1MB) took 165ms, 20,000 (4.5MB) took
+// 2.69s, 40,000 (9.0MB) took 25.1s - 4.6x the work for 2x the input - and
+// 100,000 (21MB) took 3m35s allocating 259MiB. That cost is inside the YAML
+// library rather than in lnpm's own structs, and go-yaml has been archived
+// upstream since 2025, so a cap at read time is the mitigation available.
+//
+// The 4 MiB figure comes from those rows rather than from roundness. They put a
+// lock entry at about 225 bytes (4.5MB/20,000, and 9.0MB/40,000), so 4 MiB is
+// roughly 18,600 entries - between the 10,000-entry row at 806ms and the
+// 20,000-entry row at 2.69s, which bounds a worst-case parse to a few seconds.
+// Nothing legitimate comes near it: lnpm.lock records the packages a project has
+// *linked*, not a resolved dependency graph, so real files run to tens of
+// entries.
+//
+// One constant covers the lock file and pnpm-workspace.yaml both. A workspace
+// config is far smaller than a lock file, but a second number would need its own
+// justification and would bound nothing the first does not.
+const MaxYAMLBytes = 4 << 20
+
+// ErrFileTooLarge is returned by ReadFileCapped when a file is over the limit.
+// Callers match on it to tell a refusal apart from a file that would not read.
+var ErrFileTooLarge = errors.New("file is over the size limit")
+
+// ReadFileCapped reads path, refusing files larger than max bytes.
+//
+// The size is taken from os.Stat before any read, which is what makes the
+// refusal free: an oversized file is never read into memory and never reaches a
+// parser, so the cost the cap exists to bound is never paid. It is also what
+// lets a test build the oversized case with os.Truncate instead of writing
+// megabytes.
+//
+// A missing file is reported as the *fs.PathError os.Stat produced, so
+// os.IsNotExist and errors.Is(err, fs.ErrNotExist) still recognise it -
+// pkg/lockfile turns that case into "no lock file here" and has to keep being
+// able to. The refusal names the file, its size and the limit, because a user
+// who hits it has to decide whether the file is corrupt or the limit is wrong,
+// and cannot do either without all three.
+func ReadFileCapped(path string, max int64) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > max {
+		return nil, fmt.Errorf("%s is %d bytes, over the %d-byte limit: %w", path, info.Size(), max, ErrFileTooLarge)
+	}
+	return os.ReadFile(path)
+}

--- a/internal/fsutil/read.go
+++ b/internal/fsutil/read.go
@@ -10,27 +10,64 @@ import (
 //
 // It exists to bound parse cost, not memory. gopkg.in/yaml.v3's cost is
 // superlinear in the input, and the sweep on #323 measured it going up faster
-// than the file does: 5,000 lock entries (1.1MB) took 165ms, 20,000 (4.5MB) took
-// 2.69s, 40,000 (9.0MB) took 25.1s - 4.6x the work for 2x the input - and
-// 100,000 (21MB) took 3m35s allocating 259MiB. That cost is inside the YAML
-// library rather than in lnpm's own structs, and go-yaml has been archived
-// upstream since 2025, so a cap at read time is the mitigation available.
+// than the file does:
+//
+//	entries     size    elapsed
+//	  5,000    1.1MB      165ms
+//	 10,000    2.2MB      806ms
+//	 20,000    4.5MB      2.69s
+//	 40,000    9.0MB      25.1s
+//	100,000     21MB    3m35.5s, 259MiB allocated
+//
+// Doubling 20,000 entries to 40,000 costs 9.3x the time (25.1/2.69). Per byte
+// that is 0.598 s/MB against 2.79 s/MB, so the rate itself rises 4.6x across
+// those two rows. That cost is inside the YAML library rather than in lnpm's own
+// structs, and go-yaml has been archived upstream since 2025, so a cap at read
+// time is the mitigation available.
 //
 // The 4 MiB figure comes from those rows rather than from roundness. They put a
-// lock entry at about 225 bytes (4.5MB/20,000, and 9.0MB/40,000), so 4 MiB is
-// roughly 18,600 entries - between the 10,000-entry row at 806ms and the
-// 20,000-entry row at 2.69s, which bounds a worst-case parse to a few seconds.
+// lock entry at about 225 bytes (4.5MB/20,000, and 9.0MB/40,000), so 4 MiB of
+// lock-shaped content is roughly 18,600 entries - between the 10,000-entry row
+// at 806ms and the 20,000-entry row at 2.69s.
+//
+// That is a typical-case bound and not a worst case, which matters to anyone who
+// later leans on it. The cap counts bytes; yaml.v3's cost tracks node count, and
+// 225 bytes per entry is what *lock-shaped* content costs. Measured while
+// writing this, best of five on one machine: 4 MiB of lock-shaped YAML is
+// 254,000 nodes and unmarshals in 251ms, while 4 MiB written for node count
+// instead - a flow sequence of one-byte scalars - is 2.1 million nodes and
+// unmarshals in 1.14s. Same byte budget, 8x the nodes, 4.6x the time. No search
+// was made for the worst shape, so read this cap as bounding the documents lnpm
+// actually reads rather than every 4 MiB document.
+//
 // Nothing legitimate comes near it: lnpm.lock records the packages a project has
 // *linked*, not a resolved dependency graph, so real files run to tens of
 // entries.
 //
 // One constant covers the lock file and pnpm-workspace.yaml both. A workspace
-// config is far smaller than a lock file, but a second number would need its own
-// justification and would bound nothing the first does not.
+// config is far smaller than a lock file, so a tighter second cap would refuse
+// things this one accepts - 64 KiB on the config would turn away a 3 MiB
+// pnpm-workspace.yaml that 4 MiB lets through. That is a real difference; it is
+// just not worth a second number. Neither figure is a size a legitimate
+// workspace config reaches, and a second constant would need its own
+// measurements to defend and its own reason when someone later asks why the two
+// disagree.
+//
+// It lives in fsutil rather than beside a caller because pkg/lockfile and
+// internal/workspace both need it and neither should depend on the other. It is
+// a property of yaml.v3's cost curve, not of the filesystem, which is why the
+// measurements are written down here instead of being left for a reader to
+// reconstruct.
 const MaxYAMLBytes = 4 << 20
 
 // ErrFileTooLarge is returned by ReadFileCapped when a file is over the limit.
-// Callers match on it to tell a refusal apart from a file that would not read.
+//
+// Nothing in production branches on it - the callers pass the refusal straight
+// up. The tests do, and that is what it is for. #323 asks that moving the size
+// check to after the unmarshal turn the refusal tests red, and the fixtures are
+// oversized *and* invalid YAML, so the only thing that tells the two placements
+// apart is whether what comes back is this error or a parse error. Matching on
+// the message instead would pin the wording rather than the behaviour.
 var ErrFileTooLarge = errors.New("file is over the size limit")
 
 // ReadFileCapped reads path, refusing files larger than max bytes.
@@ -44,10 +81,11 @@ var ErrFileTooLarge = errors.New("file is over the size limit")
 // What it is not is a hard bound. Stat and the read are two calls, so a writer
 // growing the file in between hands back more than max, and lnpm parses it. That
 // window is accepted rather than closed: reading through an io.LimitReader would
-// make the bound absolute and would cost a full read of every legitimate file to
-// do it, losing the free refusal above. The threat #323 describes is a repo that
-// ships an oversized file, not a writer racing the read, and this closes that
-// one.
+// make the bound absolute, but it would give up the free refusal above, opening
+// and reading an oversized file up to the limit instead of turning it away on
+// its stat. It would cost no more on legitimate files, which are already read in
+// full here. The threat #323 describes is a repo that ships an oversized file,
+// not a writer racing the read, and this closes that one.
 //
 // A missing file is reported as the *fs.PathError os.Stat produced, so
 // os.IsNotExist and errors.Is(err, fs.ErrNotExist) still recognise it -

--- a/internal/fsutil/read_test.go
+++ b/internal/fsutil/read_test.go
@@ -1,0 +1,112 @@
+package fsutil
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// writeSparseFile creates a file at path whose first bytes are head and whose
+// length is size, by writing head and extending the file with os.Truncate
+// instead of writing size bytes out.
+//
+// It reads back what it built rather than assuming: a test that wants an
+// oversized file needs both properties - the length, so the cap sees it, and the
+// leading bytes, so a check placed after the unmarshal fails on the contents
+// instead. Whether the extension is stored sparsely is a filesystem question and
+// is deliberately not asserted; only the size and the contents are.
+func writeSparseFile(t *testing.T, path, head string, size int64) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(head), 0644); err != nil {
+		t.Fatalf("WriteFile(%s) error: %v", path, err)
+	}
+	if err := os.Truncate(path, size); err != nil {
+		t.Fatalf("Truncate(%s, %d) error: %v", path, size, err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%s) error: %v", path, err)
+	}
+	if info.Size() != size {
+		t.Fatalf("built %s at %d bytes, want %d", path, info.Size(), size)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open(%s) error: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	got := make([]byte, len(head))
+	if _, err := io.ReadFull(f, got); err != nil {
+		t.Fatalf("reading back the head of %s: %v", path, err)
+	}
+	if string(got) != head {
+		t.Fatalf("head of %s = %q, want %q", path, got, head)
+	}
+}
+
+func TestReadFileCappedReadsAFileUnderTheLimit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "small.yaml")
+	if err := os.WriteFile(path, []byte("packages:\n  - a\n"), 0644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	data, err := ReadFileCapped(path, MaxYAMLBytes)
+	if err != nil {
+		t.Fatalf("ReadFileCapped() error: %v", err)
+	}
+	if string(data) != "packages:\n  - a\n" {
+		t.Errorf("ReadFileCapped() = %q, want the file's contents", data)
+	}
+}
+
+// TestReadFileCappedRefusesAFileOverTheLimit checks the refusal names all three
+// things a user needs to act on it: which file, how big it is, and what the
+// limit was.
+func TestReadFileCappedRefusesAFileOverTheLimit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "big.yaml")
+	writeSparseFile(t, path, "packages: {not valid yaml", MaxYAMLBytes+1)
+
+	data, err := ReadFileCapped(path, MaxYAMLBytes)
+	if err == nil {
+		t.Fatalf("ReadFileCapped() error = nil, want a refusal; read %d bytes", len(data))
+	}
+	if data != nil {
+		t.Errorf("ReadFileCapped() = %d bytes, want nil alongside the refusal", len(data))
+	}
+	if !errors.Is(err, ErrFileTooLarge) {
+		t.Errorf("ReadFileCapped() error = %v, want it to wrap ErrFileTooLarge", err)
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		path,
+		strconv.FormatInt(MaxYAMLBytes+1, 10),
+		strconv.FormatInt(MaxYAMLBytes, 10),
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("ReadFileCapped() error = %q, want it to name %q", msg, want)
+		}
+	}
+}
+
+// TestReadFileCappedReportsAMissingFileAsNotExist pins the contract
+// pkg/lockfile's read depends on: it turns a missing file into (nil, nil), and
+// it can only keep doing that if os.IsNotExist still recognises what comes back
+// from here.
+func TestReadFileCappedReportsAMissingFileAsNotExist(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "absent.yaml")
+
+	_, err := ReadFileCapped(path, MaxYAMLBytes)
+	if err == nil {
+		t.Fatal("ReadFileCapped() error = nil, want a not-exist error")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("os.IsNotExist(%v) = false, want true", err)
+	}
+}

--- a/internal/fsutil/read_unix_test.go
+++ b/internal/fsutil/read_unix_test.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestReadFileCappedRefusesANonRegularFile covers the case that makes the size
+// check mean anything. os.Stat reports Size() == 0 for a FIFO, so the size
+// comparison lets one through - the test asserts that, so the reason the guard
+// is needed is visible rather than asserted in a comment.
+//
+// Its revert behaviour is unusual and worth knowing before running it. Remove
+// the regular-file guard and this test does not go red, it hangs: os.ReadFile
+// opens the FIFO O_RDONLY and blocks until a writer appears, which with no
+// writer is forever, so the package dies on go test's timeout instead. That
+// hang is the bypass.
+func TestReadFileCappedRefusesANonRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fifo.yaml")
+	if err := syscall.Mkfifo(path, 0644); err != nil {
+		t.Skipf("mkfifo(%s): %v", path, err)
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat(%s) error: %v", path, err)
+	}
+	if info.Mode()&os.ModeNamedPipe == 0 {
+		t.Fatalf("built %s with mode %v, want a named pipe", path, info.Mode())
+	}
+	if info.Size() > MaxYAMLBytes {
+		t.Fatalf("the fifo stats at %d bytes, over the %d-byte cap; this case only tests the guard if the size check would pass it", info.Size(), int64(MaxYAMLBytes))
+	}
+
+	_, err = ReadFileCapped(path, MaxYAMLBytes)
+	if err == nil {
+		t.Fatal("ReadFileCapped() error = nil, want a refusal for a named pipe")
+	}
+	for _, want := range []string{path, "not a regular file"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("ReadFileCapped() error = %q, want it to name %q", err, want)
+		}
+	}
+}

--- a/internal/fsutil/read_windows_test.go
+++ b/internal/fsutil/read_windows_test.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package fsutil
+
+import "testing"
+
+// TestReadFileCappedRefusesANonRegularFile is built on Unix only. This file
+// exists so the case shows up as skipped on Windows rather than silently
+// absent from the package.
+//
+// The skip is a build constraint and not a statement about the guard: the Unix
+// file makes its FIFO with syscall.Mkfifo, and syscall.Mkfifo is not declared
+// on Windows, so that file cannot compile here. Whether the guard behaves the
+// same way on Windows is untested either way.
+func TestReadFileCappedRefusesANonRegularFile(t *testing.T) {
+	t.Skip("syscall.Mkfifo is not declared on Windows, so the named-pipe fixture cannot be built here")
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	"gopkg.in/yaml.v3"
+
+	"github.com/pedrosousa13/lnpm/internal/fsutil"
 )
 
 // Workspace represents a monorepo workspace
@@ -97,10 +99,14 @@ func detectWorkspaceAt(dir string) (*Workspace, error) {
 //
 // The parse error is wrapped with the path because yaml.Unmarshal describes
 // only the syntax problem and never says which file it was reading. The read
-// error is not: os.ReadFile returns a *fs.PathError, which already names the
-// file, and wrapping would give one file two spellings in one message.
+// error is not: it is a *fs.PathError, or a refusal that names the file itself,
+// and wrapping would give one file two spellings in one message.
+//
+// The read is capped before the unmarshal, because yaml.v3's parse cost is
+// superlinear and this file comes from the repository being worked in - see
+// fsutil.MaxYAMLBytes, whose comment carries the measurements.
 func parsePnpmWorkspace(root, path string) (*Workspace, error) {
-	data, err := os.ReadFile(path)
+	data, err := fsutil.ReadFileCapped(path, fsutil.MaxYAMLBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -3,12 +3,16 @@ package workspace
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/pedrosousa13/lnpm/internal/fsutil"
 )
 
 // writePackage creates a directory under root containing a minimal package.json
@@ -543,5 +547,81 @@ func TestListPackagesNamelessMemberFails(t *testing.T) {
 				t.Errorf("Expected no packages alongside the error, got %v", packages)
 			}
 		})
+	}
+}
+
+// TestDetectRefusesAnOversizedPnpmWorkspace covers the cap on the workspace
+// config, which shares its reason and its constant with the lock file's:
+// yaml.v3's parse cost is superlinear, so an oversized document has to be
+// refused rather than parsed.
+//
+// The fixture is invalid YAML as well as oversized, and that is the point. With
+// the cap before the unmarshal the caller gets the size refusal; with it after,
+// yaml.Unmarshal reports the syntax error first and the size is never
+// mentioned. Asserting which error comes back distinguishes the two placements
+// without measuring how long anything takes.
+//
+// os.Truncate extends the file instead of writing four megabytes out, so the
+// oversized case costs nothing to build. Both properties are read back rather
+// than assumed - the length, which is what the cap sees, and the leading bytes,
+// which are what a misplaced cap would trip over.
+func TestDetectRefusesAnOversizedPnpmWorkspace(t *testing.T) {
+	root := t.TempDir()
+	writePackage(t, root, "packages/package-a")
+
+	config := filepath.Join(root, "pnpm-workspace.yaml")
+	const head = "packages: [packages/*\n"
+	size := int64(fsutil.MaxYAMLBytes) + 1
+
+	if err := os.WriteFile(config, []byte(head), 0644); err != nil {
+		t.Fatalf("Failed to write pnpm-workspace.yaml: %v", err)
+	}
+	if err := os.Truncate(config, size); err != nil {
+		t.Fatalf("Truncate(%s, %d) error: %v", config, size, err)
+	}
+	info, err := os.Stat(config)
+	if err != nil {
+		t.Fatalf("Stat(%s) error: %v", config, err)
+	}
+	if info.Size() != size {
+		t.Fatalf("built %s at %d bytes, want %d", config, info.Size(), size)
+	}
+	built, err := os.Open(config)
+	if err != nil {
+		t.Fatalf("Open(%s) error: %v", config, err)
+	}
+	gotHead := make([]byte, len(head))
+	if _, err := io.ReadFull(built, gotHead); err != nil {
+		_ = built.Close()
+		t.Fatalf("reading back the head of %s: %v", config, err)
+	}
+	_ = built.Close()
+	if string(gotHead) != head {
+		t.Fatalf("head of %s = %q, want the invalid YAML %q", config, gotHead, head)
+	}
+
+	ws, err := Detect(root)
+	if err == nil {
+		t.Fatalf("Expected a refusal for the oversized pnpm-workspace.yaml, got nil and workspace %+v", ws)
+	}
+	if ws != nil {
+		t.Errorf("Expected no workspace alongside the error, got %+v", ws)
+	}
+	if !errors.Is(err, fsutil.ErrFileTooLarge) {
+		t.Errorf("Detect() error = %v, want it to wrap fsutil.ErrFileTooLarge", err)
+	}
+
+	msg := err.Error()
+	for _, want := range []string{
+		config,
+		strconv.FormatInt(size, 10),
+		strconv.FormatInt(fsutil.MaxYAMLBytes, 10),
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("Detect() error = %q, want it to name %q", msg, want)
+		}
+	}
+	if strings.Contains(msg, "failed to parse") {
+		t.Errorf("Detect() error = %q, want a size refusal; a parse error means the file was unmarshalled before the cap was checked", msg)
 	}
 }

--- a/pkg/lockfile/lockfile.go
+++ b/pkg/lockfile/lockfile.go
@@ -1,12 +1,15 @@
 package lockfile
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/pedrosousa13/lnpm/internal/fsutil"
 )
 
 // LockFile represents the lnpm.lock file format
@@ -75,11 +78,20 @@ func LoadRetreat(projectPath string) (*LockFile, error) {
 // file": the snapshot shares this reader, and a message that named the format
 // instead of the file would send a user whose snapshot is corrupt to inspect a
 // lock file that is perfectly fine.
+//
+// The read is capped before the unmarshal, because yaml.v3's parse cost is
+// superlinear and a project can ship whatever lock file it likes - see
+// fsutil.MaxYAMLBytes. The refusal is passed through unwrapped: it already names
+// the file, and "failed to read X: X is N bytes" would give one file two
+// spellings in one message.
 func read(path string) (*LockFile, error) {
-	data, err := os.ReadFile(path)
+	data, err := fsutil.ReadFileCapped(path, fsutil.MaxYAMLBytes)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
+		}
+		if errors.Is(err, fsutil.ErrFileTooLarge) {
+			return nil, err
 		}
 		return nil, fmt.Errorf("failed to read %s: %w", path, err)
 	}

--- a/pkg/lockfile/lockfile_test.go
+++ b/pkg/lockfile/lockfile_test.go
@@ -544,6 +544,17 @@ func TestLoadRetreatRefusesAnOversizedSnapshot(t *testing.T) {
 // resolved dependency graph, so a few thousand entries is already far past any
 // project; the file it produces has to stay comfortably under the cap and parse
 // as it always did.
+//
+// What it does not do is cover the refusal, and it should not be counted as if
+// it did. It is not revert-sensitive in either direction: delete the cap and it
+// stays green, move the check after the unmarshal and it stays green, because
+// every file it builds is one the cap accepts. It is a floor under
+// MaxYAMLBytes - it goes red if that constant is ever lowered past what a
+// realistic lock file needs - and nothing more. The refusal is
+// TestLoadRefusesAnOversizedLockFile's job.
+//
+// Measured on this branch, 3,000 entries writes about 675KB, roughly a sixth of
+// the 4 MiB cap, so the headroom it proves is real but not large.
 func TestLoadParsesARealisticLockFile(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/pkg/lockfile/lockfile_test.go
+++ b/pkg/lockfile/lockfile_test.go
@@ -1,10 +1,17 @@
 package lockfile
 
 import (
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/pedrosousa13/lnpm/internal/fsutil"
 )
 
 func TestLoadNonExistent(t *testing.T) {
@@ -434,5 +441,140 @@ func TestSaveRefusesAReadOnlyLockFile(t *testing.T) {
 	}
 	if got.Has("second-package") {
 		t.Errorf("the refused Save() landed anyway; lock file holds %v", got.List())
+	}
+}
+
+// writeOversizedLockFile creates a file at path whose first bytes are invalid
+// YAML and whose length is one byte over the cap, by writing the bad bytes and
+// extending the file with os.Truncate rather than writing megabytes out.
+//
+// Both properties matter, so both are read back rather than assumed. The length
+// is what the cap sees. The invalid YAML is the discriminator for where the cap
+// sits: checked before the unmarshal, the caller gets the size refusal; checked
+// after it, yaml.Unmarshal reports a syntax error first and the size is never
+// mentioned. Asserting which error comes back pins the placement without
+// measuring how long anything takes.
+func writeOversizedLockFile(t *testing.T, path string) int64 {
+	t.Helper()
+
+	const head = "packages: {not valid yaml"
+	size := int64(fsutil.MaxYAMLBytes) + 1
+
+	if err := os.WriteFile(path, []byte(head), 0644); err != nil {
+		t.Fatalf("WriteFile(%s) error: %v", path, err)
+	}
+	if err := os.Truncate(path, size); err != nil {
+		t.Fatalf("Truncate(%s, %d) error: %v", path, size, err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(%s) error: %v", path, err)
+	}
+	if info.Size() != size {
+		t.Fatalf("built %s at %d bytes, want %d", path, info.Size(), size)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open(%s) error: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	got := make([]byte, len(head))
+	if _, err := io.ReadFull(f, got); err != nil {
+		t.Fatalf("reading back the head of %s: %v", path, err)
+	}
+	if string(got) != head {
+		t.Fatalf("head of %s = %q, want the invalid YAML %q", path, got, head)
+	}
+
+	return size
+}
+
+// TestLoadRefusesAnOversizedLockFile covers the cap on the lock file. The error
+// has to name the file, its size and the limit: a user who hits this decides
+// whether the file is corrupt or the limit is wrong, and cannot do either
+// without all three.
+//
+// The assertion that the message is not a parse error is what pins the cap
+// *before* the unmarshal - see writeOversizedLockFile for why the fixture is
+// invalid YAML as well as oversized.
+func TestLoadRefusesAnOversizedLockFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	size := writeOversizedLockFile(t, Path(tmpDir))
+
+	lock, err := Load(tmpDir)
+	if err == nil {
+		t.Fatalf("Load() error = nil, want a refusal; got %+v", lock)
+	}
+	if !errors.Is(err, fsutil.ErrFileTooLarge) {
+		t.Errorf("Load() error = %v, want it to wrap fsutil.ErrFileTooLarge", err)
+	}
+
+	msg := err.Error()
+	for _, want := range []string{
+		Path(tmpDir),
+		strconv.FormatInt(size, 10),
+		strconv.FormatInt(fsutil.MaxYAMLBytes, 10),
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("Load() error = %q, want it to name %q", msg, want)
+		}
+	}
+	if strings.Contains(msg, "failed to parse") {
+		t.Errorf("Load() error = %q, want a size refusal; a parse error means the file was unmarshalled before the cap was checked", msg)
+	}
+}
+
+// TestLoadRetreatRefusesAnOversizedSnapshot covers the other file that shares
+// the reader. The snapshot is written by lnpm itself, so it is bounded for the
+// same reason the lock file is: it is a file in the project that anything could
+// have replaced.
+func TestLoadRetreatRefusesAnOversizedSnapshot(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeOversizedLockFile(t, RetreatPath(tmpDir))
+
+	if _, err := LoadRetreat(tmpDir); !errors.Is(err, fsutil.ErrFileTooLarge) {
+		t.Errorf("LoadRetreat() error = %v, want it to wrap fsutil.ErrFileTooLarge", err)
+	}
+}
+
+// TestLoadParsesARealisticLockFile checks the cap is not in the way of anything
+// real. lnpm.lock records the packages a project has linked rather than a
+// resolved dependency graph, so a few thousand entries is already far past any
+// project; the file it produces has to stay comfortably under the cap and parse
+// as it always did.
+func TestLoadParsesARealisticLockFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	const entries = 3000
+	lock := &LockFile{Version: currentVersion, Packages: make(map[string]Package)}
+	for i := 0; i < entries; i++ {
+		lock.Add(fmt.Sprintf("@scope/package-%05d", i), Package{
+			Version:         "1.2.3",
+			Hash:            "0123456789abcdef0123456789abcdef01234567",
+			Source:          fmt.Sprintf("/home/user/src/package-%05d", i),
+			Linked:          time.Now().Truncate(time.Second),
+			OriginalVersion: "^1.2.0",
+		})
+	}
+	if err := lock.Save(tmpDir); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	info, err := os.Stat(Path(tmpDir))
+	if err != nil {
+		t.Fatalf("Stat() error: %v", err)
+	}
+	if info.Size() >= fsutil.MaxYAMLBytes {
+		t.Fatalf("%d entries wrote %d bytes, at or over the %d-byte cap; the cap is too small for a realistic lock file", entries, info.Size(), int64(fsutil.MaxYAMLBytes))
+	}
+
+	got, err := Load(tmpDir)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if len(got.Packages) != entries {
+		t.Errorf("len(Packages) = %d, want %d", len(got.Packages), entries)
 	}
 }


### PR DESCRIPTION
Closes #323.

`pkg/lockfile`'s `read` and the workspace's `pnpm-workspace.yaml` parse both did `os.ReadFile` then `yaml.Unmarshal` with no size bound. `gopkg.in/yaml.v3`'s cost is superlinear and the dependency has been archived upstream since 2025, so a byte cap at read time is the mitigation available.

## The change

`internal/fsutil.ReadFileCapped` stats before reading, refuses over the limit, and is used by both load paths. `MaxYAMLBytes` is 4 MiB, derived in its comment from the issue's own measured table rather than picked for roundness — those rows put a lock entry at ~225 bytes, so 4 MiB is ~18,600 entries, between the 10,000-entry row at 806ms and the 20,000-entry row at 2.69s. Nothing legitimate comes near it: `lnpm.lock` records the packages a project has *linked*, not a resolved dependency graph.

Stat-first is what makes the refusal free — an oversized file is never read and never reaches a parser — and it is what lets the tests build the oversized case with `os.Truncate` instead of writing megabytes.

## A bypass found during review, worse than the bug being fixed

`os.Stat` reports `Size() == 0` for a FIFO or device, so a non-regular file sailed past the size check. Removing the guard and pointing the test at a named pipe does not produce an unbounded read — it **hangs forever in `openat`**, and the test package dies on its timeout:

```
panic: test timed out after 20s
	running tests:
		TestReadFileCappedRefusesANonRegularFile (20s)
goroutine 5 [syscall]:
syscall.Syscall6(0x101, ...)   // openat
```

So a lock file replaced by a named pipe wedges every lnpm command that reads it, silently and indefinitely. `ReadFileCapped` now refuses anything that is not a regular file, before the size comparison. The guard also catches a directory at the lock-file path, which previously surfaced as a wrapped `EISDIR` — a behaviour change worth noting, though nothing tested it.

## Verification

Both revert directions run, not argued:

- **Neutralise the cap** → the three refusal tests go red.
- **Move the check to after the unmarshal** → they go red too, because the oversized fixtures are also *invalid YAML*: cap-first yields the size error, cap-after yields `yaml: control characters are not allowed`. That is a deterministic discriminator with no reliance on timing.

Gates green: `go test ./...` (17 packages), `go vet`, `golangci-lint` (0 issues), `gofmt`, Windows build, cross-vet for windows/amd64 + darwin/arm64 + linux/arm64, Windows test-compile.

## Claims that were corrected before landing

Review caught three statements in the comments that did not survive checking, and they are worth listing because the code now says something weaker and truer:

- **"Bounds a worst-case parse to a few seconds"** — false. The cap bounds *bytes*; yaml.v3's cost tracks *node count*. Measured at 4 MiB, best-of-five: lock-shaped YAML is 254,214 nodes and 251ms, while a flow sequence of one-byte scalars is 2,097,154 nodes and 1.14s. The node density differs by 8.25x and the cost by 4.6x. It is a typical-case bound, and the comment now says so and states that no search was made for the worst shape.
- **"4.6x the work for 2x the input"** — does not compute as written; 25.1/2.69 is 9.3x. The 4.6 is the *per-byte* rate ratio. Both numbers are now shown.
- **"An `io.LimitReader` would cost a full read of every legitimate file"** — false, since `ReadFileCapped` already reads every legitimate file in full. What a LimitReader actually costs is the free stat-time refusal.

The stat/read TOCTOU window is documented rather than closed: the threat #323 describes is a repo that *ships* an oversized file, not a writer racing the read.

## Out of scope, as the issue specifies

No change to the YAML dependency, the lock-file format, or manifest/`package.json` reads. `internal/config/config.go`'s own config read remains uncapped — the issue named only the lock file and the workspace config.
